### PR TITLE
changed RawTransactionInput prevIndex to big-endian

### DIFF
--- a/crypto/src/main/java/io/neow3j/crypto/transaction/RawTransactionInput.java
+++ b/crypto/src/main/java/io/neow3j/crypto/transaction/RawTransactionInput.java
@@ -58,12 +58,14 @@ public class RawTransactionInput extends NeoSerializable {
     @Override
     public void deserialize(BinaryReader reader) throws IOException {
         this.prevHash = Numeric.toHexStringNoPrefix(ArrayUtils.reverseArray(reader.readBytes(32)));
-        this.prevIndex = Numeric.toBigInt(reader.readBytes(2)).intValue();
+        byte[] readBytes = reader.readBytes(2);
+        this.prevIndex = Numeric.toBigInt(ArrayUtils.reverseArray(readBytes)).intValue();
     }
 
     @Override
     public void serialize(BinaryWriter writer) throws IOException {
         writer.write(ArrayUtils.reverseArray(Numeric.hexStringToByteArray(this.prevHash)));
-        writer.write(BigIntegers.asUnsignedByteArray(2, BigInteger.valueOf(this.prevIndex)));
+        byte[] prevIndex = BigIntegers.asUnsignedByteArray(2, BigInteger.valueOf(this.prevIndex));
+        writer.write(ArrayUtils.reverseArray(prevIndex));
     }
 }


### PR DESCRIPTION
A serialized transaction must serialize utxo's prevIndex in big-endian,or The transaction will failed unless it's input index was zero.Please confirm this commit.