### PR TITLE
Allow asset transfers from contracts.

### DIFF
--- a/crypto/src/main/java/io/neow3j/crypto/transaction/RawTransactionOutput.java
+++ b/crypto/src/main/java/io/neow3j/crypto/transaction/RawTransactionOutput.java
@@ -6,7 +6,6 @@ import io.neow3j.io.BinaryWriter;
 import io.neow3j.io.NeoSerializable;
 import io.neow3j.model.types.NEOAsset;
 import io.neow3j.utils.ArrayUtils;
-import io.neow3j.utils.Keys;
 import io.neow3j.utils.Numeric;
 
 import java.io.IOException;

--- a/wallet/src/main/java/io/neow3j/wallet/Account.java
+++ b/wallet/src/main/java/io/neow3j/wallet/Account.java
@@ -132,6 +132,21 @@ public class Account {
         balances.updateTokenBalances(response.getBalances());
     }
 
+    /**
+     * <p>Fetches a set of UTXOs from this account that fulfill the required asset amount.</p>
+     * <br>
+     * <p>Usually the UTXOs will not cover the amount exactly but cover a larger amount. Therefore
+     * it is important to calculate the necessary change before using the UTXOs in a transaction.</p>
+     *
+     * @param assetId  The asset needed.
+     * @param amount   The amount needed.
+     * @param strategy The strategy with which to choose the UTXOs available on this account.
+     * @return the list of UTXOs covering the required amount.
+     * @throws IllegalStateException      if this account does not have any balances, e.g. because they
+     *                                    have not been updated before.
+     * @throws InsufficientFundsException if this account does does not possess enough UTXOs to
+     *                                    fulfill the required amount.
+     */
     public List<Utxo> getUtxosForAssetAmount(String assetId, BigDecimal amount,
                                              InputCalculationStrategy strategy) {
 

--- a/wallet/src/main/java/io/neow3j/wallet/AssetTransfer.java
+++ b/wallet/src/main/java/io/neow3j/wallet/AssetTransfer.java
@@ -313,16 +313,16 @@ public class AssetTransfer {
         }
 
         private void calculateInputsAndChange(Map<String, BigDecimal> requiredAssets, Account acct) {
-            requiredAssets.forEach((assetId, value) -> {
-                List<Utxo> utxos = acct.getUtxosForAssetAmount(assetId, value, inputCalculationStrategy);
+            requiredAssets.forEach((assetId, requiredValue) -> {
+                List<Utxo> utxos = acct.getUtxosForAssetAmount(assetId, requiredValue, inputCalculationStrategy);
                 inputs.addAll(utxos.stream().map(Utxo::toTransactionInput).collect(Collectors.toList()));
-                outputs.add(getChangeTransactionOutput(utxos, value, assetId, acct.getAddress()));
+                outputs.add(getChangeTransactionOutput(assetId, requiredValue, utxos, acct.getAddress()));
             });
         }
 
-        private RawTransactionOutput getChangeTransactionOutput(List<Utxo> utxos,
+        private RawTransactionOutput getChangeTransactionOutput(String assetId,
                                                                 BigDecimal requiredValue,
-                                                                String assetId,
+                                                                List<Utxo> utxos,
                                                                 String changeAddress) {
 
             BigDecimal inputAmount = utxos.stream().map(Utxo::getValue).reduce(BigDecimal::add).get();

--- a/wallet/src/main/java/io/neow3j/wallet/AssetTransfer.java
+++ b/wallet/src/main/java/io/neow3j/wallet/AssetTransfer.java
@@ -292,7 +292,7 @@ public class AssetTransfer {
                 contractAcct.updateAssetBalances(neow3j);
             } catch (Exception e) {
                 throw new RuntimeException("Failed to fetch UTXOs for the contract with " +
-                        "script hash " + fromContractScriptHash.toString());
+                        "script hash " + fromContractScriptHash.toString(), e);
             }
             calculateInputsAndChange(requiredAssets, contractAcct);
             // Because in a transaction that withdraws from a contract address the transaction
@@ -304,8 +304,10 @@ public class AssetTransfer {
             NeoGetContractState contractState;
             try {
                 contractState = neow3j.getContractState(fromContractScriptHash.toString()).send();
-            } catch (IOException e) {
-                throw new RuntimeException(e);
+                contractState.throwOnError();
+            } catch (Exception e) {
+                throw new RuntimeException("Failed to fetch contract information for the " +
+                        "contract with script hash " + fromContractScriptHash.toString(), e);
             }
             int nrOfParams = contractState.getContractState().getContractParameters().size();
             byte[] invocationScript = Numeric.hexStringToByteArray(Strings.zeros(nrOfParams * 2));

--- a/wallet/src/main/java/io/neow3j/wallet/AssetTransfer.java
+++ b/wallet/src/main/java/io/neow3j/wallet/AssetTransfer.java
@@ -5,7 +5,6 @@ import io.neow3j.crypto.transaction.RawScript;
 import io.neow3j.crypto.transaction.RawTransactionAttribute;
 import io.neow3j.crypto.transaction.RawTransactionInput;
 import io.neow3j.crypto.transaction.RawTransactionOutput;
-import io.neow3j.io.NeoSerializableInterface;
 import io.neow3j.model.types.GASAsset;
 import io.neow3j.model.types.TransactionAttributeUsageType;
 import io.neow3j.protocol.Neow3j;
@@ -238,10 +237,15 @@ public class AssetTransfer {
                         new RawTransactionOutput(reqAssetId, changeAmount.toPlainString(), fromContractScriptHash.toAddress()));
             });
 
-            attributes.add(new RawTransactionAttribute(TransactionAttributeUsageType.SCRIPT, fromContractScriptHash.toArray()));
+            // Because in a transaction that withdraws from a contract address the transaction
+            // inputs are coming from the contract, there are now inputs from the account that
+            // initiates the transfer. Therefore it needs to be mentioned in an script attribute.
+            attributes.add(new RawTransactionAttribute(
+                    TransactionAttributeUsageType.SCRIPT, account.getScriptHash().toArray()));
+
             NeoGetContractState contractState;
             try {
-                 contractState = neow3j.getContractState(fromContractScriptHash.toString()).send();
+                contractState = neow3j.getContractState(fromContractScriptHash.toString()).send();
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/wallet/src/test/java/io/neow3j/wallet/AssetTransferTest.java
+++ b/wallet/src/test/java/io/neow3j/wallet/AssetTransferTest.java
@@ -54,7 +54,7 @@ public class AssetTransferTest {
     private Account acct;
 
     @Before
-    public void setup() {
+    public void setUp() {
         acct = Account.fromWIF("KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr").build();
     }
 
@@ -112,7 +112,6 @@ public class AssetTransferTest {
         Neow3j neow3j = ResponseInterceptor.createNeow3jWithInceptor(address);
         acct.updateAssetBalances(neow3j);
         RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", ALT_ADDR);
-        BigDecimal fee = BigDecimal.ONE;
         AssetTransfer at = new AssetTransfer.Builder(neow3j).account(acct).output(output).networkFee(1).build().sign();
         RawTransaction tx = at.getTransaction();
 
@@ -335,7 +334,7 @@ public class AssetTransferTest {
      * only need the number of input parameters.
      */
     @Test
-    public void transfer_from_contract() throws IOException {
+    public void transferFromContract() throws IOException {
         ScriptHash contractScriptHash = new ScriptHash("d994605e4f3960ba8d7422c4c8b1e94d48960a8d");
         Account contractAccount = Account.fromAddress(contractScriptHash.toAddress()).build();
 

--- a/wallet/src/test/java/io/neow3j/wallet/AssetTransferTest.java
+++ b/wallet/src/test/java/io/neow3j/wallet/AssetTransferTest.java
@@ -32,10 +32,8 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import static junit.framework.TestCase.assertEquals;
-import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.Mockito.doReturn;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
 public class AssetTransferTest {

--- a/wallet/src/test/java/io/neow3j/wallet/AssetTransferTest.java
+++ b/wallet/src/test/java/io/neow3j/wallet/AssetTransferTest.java
@@ -1,18 +1,29 @@
 package io.neow3j.wallet;
 
 import io.neow3j.constants.OpCode;
+import io.neow3j.contract.ScriptHash;
 import io.neow3j.crypto.Sign;
 import io.neow3j.crypto.Sign.SignatureData;
 import io.neow3j.crypto.transaction.RawScript;
 import io.neow3j.crypto.transaction.RawTransaction;
 import io.neow3j.crypto.transaction.RawTransactionInput;
 import io.neow3j.crypto.transaction.RawTransactionOutput;
+import io.neow3j.model.types.ContractParameterType;
 import io.neow3j.model.types.GASAsset;
 import io.neow3j.model.types.NEOAsset;
 import io.neow3j.protocol.Neow3j;
+import io.neow3j.protocol.core.Request;
+import io.neow3j.protocol.core.methods.response.NeoGetContractState;
+import io.neow3j.protocol.core.methods.response.NeoGetContractState.ContractState;
+import io.neow3j.protocol.core.methods.response.NeoGetUnspents;
+import io.neow3j.protocol.core.methods.response.NeoGetUnspents.Balance;
+import io.neow3j.protocol.core.methods.response.NeoGetUnspents.UnspentTransaction;
+import io.neow3j.protocol.core.methods.response.NeoGetUnspents.Unspents;
 import io.neow3j.protocol.exceptions.ErrorResponseException;
 import io.neow3j.transaction.ContractTransaction;
 import io.neow3j.utils.ArrayUtils;
+import io.neow3j.utils.Numeric;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -21,28 +32,50 @@ import java.nio.ByteBuffer;
 import java.util.Arrays;
 
 import static junit.framework.TestCase.assertEquals;
+import static junit.framework.TestCase.fail;
 import static org.junit.Assert.assertArrayEquals;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 
 public class AssetTransferTest {
 
+    /**
+     * Alternative address.
+     */
+    private static final String ALT_ADDR = "AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3";
+
+    /**
+     * An empty Neow3j instance which doesn't actually have connection to a RPC node.
+     */
+    private static final Neow3j EMPTY_NEOW3J = Neow3j.build(null);
+
+    /**
+     * Account with address AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y
+     */
+    private Account acct;
+
+    @Before
+    public void setup() {
+        acct = Account.fromWIF("KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr").build();
+    }
+
     @Test
     public void test_transfer_with_normal_account_without_fee() throws IOException, ErrorResponseException {
-        String address = "AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y";
-        Neow3j neow3j = ResponseInterceptor.createNeow3jWithInceptor(address);
-        Account a = Account.fromWIF("KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr").build();
-        a.updateAssetBalances(neow3j);
-        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", "AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3");
-        AssetTransfer at = new AssetTransfer.Builder(neow3j).account(a).output(output).build().sign();
+        Neow3j neow3j = ResponseInterceptor.createNeow3jWithInceptor(acct.getAddress());
+        acct.updateAssetBalances(neow3j);
+        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", ALT_ADDR);
+        AssetTransfer at = new AssetTransfer.Builder(neow3j).account(acct).output(output).build().sign();
         RawTransaction tx = at.getTransaction();
 
-        RawTransactionOutput expectedChange = new RawTransactionOutput(NEOAsset.HASH_ID, "99999999", a.getAddress());
+        RawTransactionOutput expectedChange = new RawTransactionOutput(NEOAsset.HASH_ID, "99999999", acct.getAddress());
         RawTransactionInput expectedInput = new RawTransactionInput("4ba4d1f1acf7c6648ced8824aa2cd3e8f836f59e7071340e0c440d099a508cff", 0);
         // The ordering of the inputs and outputs is important
         ContractTransaction expectedTx = new ContractTransaction.Builder()
                 .outputs(Arrays.asList(output, expectedChange))
                 .inputs(Arrays.asList(expectedInput))
                 .build();
-        SignatureData expectedSig = Sign.signMessage(expectedTx.toArrayWithoutScripts(), a.getECKeyPair());
+        SignatureData expectedSig = Sign.signMessage(expectedTx.toArrayWithoutScripts(), acct.getECKeyPair());
 
         // Test Witness
         assertEquals(1, tx.getScripts().size());
@@ -53,7 +86,7 @@ public class AssetTransferTest {
         );
         assertArrayEquals(ByteBuffer.allocate(1 + 33 + 1)
                 .put(OpCode.PUSHBYTES33.getValue())
-                .put(a.getPublicKey().toByteArray())
+                .put(acct.getPublicKey().toByteArray())
                 .put(OpCode.CHECKSIG.getValue()).array(), script.getVerificationScript().getScript()
         );
 
@@ -67,7 +100,7 @@ public class AssetTransferTest {
         // Intended output
         assertEquals(NEOAsset.HASH_ID, tx.getOutputs().get(0).getAssetId());
         assertEquals("1", tx.getOutputs().get(0).getValue());
-        assertEquals("AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3", tx.getOutputs().get(0).getAddress());
+        assertEquals(ALT_ADDR, tx.getOutputs().get(0).getAddress());
         // Change
         assertEquals(NEOAsset.HASH_ID, tx.getOutputs().get(1).getAssetId());
         assertEquals("99999999", tx.getOutputs().get(1).getValue());
@@ -79,15 +112,14 @@ public class AssetTransferTest {
         // setup
         String address = "AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y";
         Neow3j neow3j = ResponseInterceptor.createNeow3jWithInceptor(address);
-        Account a = Account.fromWIF("KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr").build();
-        a.updateAssetBalances(neow3j);
-        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", "AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3");
+        acct.updateAssetBalances(neow3j);
+        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", ALT_ADDR);
         BigDecimal fee = BigDecimal.ONE;
-        AssetTransfer at = new AssetTransfer.Builder(neow3j).account(a).output(output).networkFee(fee).build().sign();
+        AssetTransfer at = new AssetTransfer.Builder(neow3j).account(acct).output(output).networkFee(fee).build().sign();
         RawTransaction tx = at.getTransaction();
 
-        RawTransactionOutput expectedChangeNeo = new RawTransactionOutput(NEOAsset.HASH_ID, "99999999", a.getAddress());
-        RawTransactionOutput expectedChangeGas = new RawTransactionOutput(GASAsset.HASH_ID, "15983", a.getAddress());
+        RawTransactionOutput expectedChangeNeo = new RawTransactionOutput(NEOAsset.HASH_ID, "99999999", acct.getAddress());
+        RawTransactionOutput expectedChangeGas = new RawTransactionOutput(GASAsset.HASH_ID, "15983", acct.getAddress());
         RawTransactionInput expectedInput = new RawTransactionInput("4ba4d1f1acf7c6648ced8824aa2cd3e8f836f59e7071340e0c440d099a508cff", 0);
         RawTransactionInput expectedInputFee = new RawTransactionInput("c2f7fac79531d94d406367c7feafe425f893a580fa703c7b4df9572f5944df5a", 0);
         // The ordering of the inputs and outputs is important
@@ -95,7 +127,7 @@ public class AssetTransferTest {
                 .outputs(Arrays.asList(output, expectedChangeGas, expectedChangeNeo))
                 .inputs(Arrays.asList(expectedInputFee, expectedInput))
                 .build();
-        SignatureData expectedSig = Sign.signMessage(expectedTx.toArrayWithoutScripts(), a.getECKeyPair());
+        SignatureData expectedSig = Sign.signMessage(expectedTx.toArrayWithoutScripts(), acct.getECKeyPair());
 
         // Test Witness
         assertEquals(1, tx.getScripts().size());
@@ -106,7 +138,7 @@ public class AssetTransferTest {
         );
         assertArrayEquals(ByteBuffer.allocate(1 + 33 + 1)
                         .put(OpCode.PUSHBYTES33.getValue())
-                        .put(a.getPublicKey().toByteArray())
+                        .put(acct.getPublicKey().toByteArray())
                         .put(OpCode.CHECKSIG.getValue()).array(),
                 script.getVerificationScript().getScript()
         );
@@ -140,26 +172,25 @@ public class AssetTransferTest {
     public void test_transfer_with_single_output() throws IOException, ErrorResponseException {
         String address = "AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y";
         Neow3j neow3j = ResponseInterceptor.createNeow3jWithInceptor(address);
-        Account a = Account.fromWIF("KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr").build();
-        a.updateAssetBalances(neow3j);
+        acct.updateAssetBalances(neow3j);
         AssetTransfer at = new AssetTransfer.Builder(neow3j)
-                .account(a)
+                .account(acct)
                 .asset(NEOAsset.HASH_ID)
                 .amount(BigDecimal.ONE)
-                .toAddress("AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3")
+                .toAddress(ALT_ADDR)
                 .build()
                 .sign();
         RawTransaction tx = at.getTransaction();
 
-        RawTransactionOutput expectedChange = new RawTransactionOutput(NEOAsset.HASH_ID, "99999999", a.getAddress());
+        RawTransactionOutput expectedChange = new RawTransactionOutput(NEOAsset.HASH_ID, "99999999", acct.getAddress());
         RawTransactionInput expectedInput = new RawTransactionInput("4ba4d1f1acf7c6648ced8824aa2cd3e8f836f59e7071340e0c440d099a508cff", 0);
         // The ordering of the inputs and outputs is important
-        RawTransactionOutput expectedOutput = new RawTransactionOutput(NEOAsset.HASH_ID, "1", "AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3");
+        RawTransactionOutput expectedOutput = new RawTransactionOutput(NEOAsset.HASH_ID, "1", ALT_ADDR);
         ContractTransaction expectedTx = new ContractTransaction.Builder()
                 .outputs(Arrays.asList(expectedOutput, expectedChange))
                 .inputs(Arrays.asList(expectedInput))
                 .build();
-        SignatureData expectedSig = Sign.signMessage(expectedTx.toArrayWithoutScripts(), a.getECKeyPair());
+        SignatureData expectedSig = Sign.signMessage(expectedTx.toArrayWithoutScripts(), acct.getECKeyPair());
 
         // Test Witness
         assertEquals(1, tx.getScripts().size());
@@ -170,7 +201,7 @@ public class AssetTransferTest {
         );
         assertArrayEquals(ByteBuffer.allocate(1 + 33 + 1)
                 .put(OpCode.PUSHBYTES33.getValue())
-                .put(a.getPublicKey().toByteArray())
+                .put(acct.getPublicKey().toByteArray())
                 .put(OpCode.CHECKSIG.getValue()).array(), script.getVerificationScript().getScript()
         );
 
@@ -184,7 +215,7 @@ public class AssetTransferTest {
         // Intended output
         assertEquals(NEOAsset.HASH_ID, tx.getOutputs().get(0).getAssetId());
         assertEquals("1", tx.getOutputs().get(0).getValue());
-        assertEquals("AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3", tx.getOutputs().get(0).getAddress());
+        assertEquals(ALT_ADDR, tx.getOutputs().get(0).getAddress());
         // Change
         assertEquals(NEOAsset.HASH_ID, tx.getOutputs().get(1).getAssetId());
         assertEquals("99999999", tx.getOutputs().get(1).getValue());
@@ -194,7 +225,7 @@ public class AssetTransferTest {
     @Test(expected = IllegalStateException.class)
     public void test_missing_neow3j() {
         Account a = Account.fromWIF("KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr").build();
-        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", "AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3");
+        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", ALT_ADDR);
 
         AssetTransfer at = new AssetTransfer.Builder(null)
                 .account(a)
@@ -205,7 +236,7 @@ public class AssetTransferTest {
     @Test(expected = IllegalStateException.class)
     public void test_missing_account() {
         Neow3j neow3j = ResponseInterceptor.createNeow3jWithInceptor(null);
-        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", "AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3");
+        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", ALT_ADDR);
 
         AssetTransfer at = new AssetTransfer.Builder(neow3j)
                 .output(output)
@@ -242,7 +273,7 @@ public class AssetTransferTest {
         AssetTransfer at = new AssetTransfer.Builder(neow3j)
                 .account(a)
                 .asset(NEOAsset.HASH_ID)
-                .toAddress("AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3")
+                .toAddress(ALT_ADDR)
                 .build();
     }
 
@@ -254,7 +285,7 @@ public class AssetTransferTest {
         AssetTransfer at = new AssetTransfer.Builder(neow3j)
                 .account(a)
                 .amount(BigDecimal.ONE)
-                .toAddress("AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3")
+                .toAddress(ALT_ADDR)
                 .build();
     }
 
@@ -262,7 +293,7 @@ public class AssetTransferTest {
     public void test_erroneously_add_outputs1() {
         Neow3j neow3j = ResponseInterceptor.createNeow3jWithInceptor(null);
         Account a = Account.fromWIF("KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr").build();
-        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", "AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3");
+        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", ALT_ADDR);
 
         AssetTransfer at = new AssetTransfer.Builder(neow3j)
                 .account(a)
@@ -275,7 +306,7 @@ public class AssetTransferTest {
     public void test_erroneously_add_outputs2() {
         Neow3j neow3j = ResponseInterceptor.createNeow3jWithInceptor(null);
         Account a = Account.fromWIF("KxDgvEKzgSBPPfuVfw67oPQBSjidEiqTHURKSDL1R7yGaGYAeYnr").build();
-        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", "AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3");
+        RawTransactionOutput output = new RawTransactionOutput(NEOAsset.HASH_ID, "1", ALT_ADDR);
 
         AssetTransfer at = new AssetTransfer.Builder(neow3j)
                 .account(a)
@@ -286,12 +317,6 @@ public class AssetTransferTest {
 
     @Test
     public void test_transfer_from_multisig_account() {
-//        String multiSigAddress = Keys.getMultiSigAddress(2, SampleKeys.PUBLIC_KEY_1, SampleKeys.PUBLIC_KEY_2);
-//        Neow3j neow3j = ResponseInterceptor.createNeow3jWithInceptor(multiSigAddress);
-//        List<BigInteger> publicKeys = Arrays.asList(SampleKeys.PUBLIC_KEY_1, SampleKeys.PUBLIC_KEY_2);
-//        Account a = Account.fromMultiSigKeys(publicKeys, 2).build();
-//        RawTransactionOutput txo = new RawTransactionOutput(NEOAsset.HASH_ID, "1", "AJQ6FoaSXDFzA6wLnyZ1nFN7SGSN2oNTc3");
-//        Keys.getVerificationScriptFromPublicKeys(2, SampleKeys.PUBLIC_KEY_1, SampleKeys.PUBLIC_KEY_2);
         // TODO Claude 18.06.19: Implement
     }
 
@@ -303,5 +328,61 @@ public class AssetTransferTest {
     @Test
     public void test_transfer_with_multiple_utxos_needed() {
         // TODO Claude 18.06.19: Implement
+    }
+
+    /**
+     * This test uses a raw transaction string generated with neon-js. The transaction makes an
+     * asset transfer of one NEO from a contract's balance to a normal address. The transaction
+     * input, i.e. the contract's UTXO has to be mocked. As well as the contract state, of which we
+     * only need the number of input parameters.
+     */
+    @Test
+    public void transfer_from_contract() throws IOException {
+        ScriptHash contractScriptHash = new ScriptHash("d994605e4f3960ba8d7422c4c8b1e94d48960a8d");
+        Account contractAccount = Account.fromAddress(contractScriptHash.toAddress()).build();
+
+        // Mock the Unspents response for the UTXO of the contract.
+        UnspentTransaction utxo = new UnspentTransaction(
+                "47cc41bfc0ad504032a73de8e3082a20172984730496ed98336e895c9a54b8b3", 0, BigDecimal.TEN);
+        Balance balance = new Balance(Arrays.asList(utxo), NEOAsset.HASH_ID, NEOAsset.NAME,
+                NEOAsset.NAME, BigDecimal.TEN);
+        Unspents unspents = new Unspents(Arrays.asList(balance), contractScriptHash.toAddress());
+        NeoGetUnspents unspentsResponse = new NeoGetUnspents();
+        unspentsResponse.setResult(unspents);
+        Request<?, NeoGetUnspents> unspentsRequestSpy = spy(new Request<>());
+        doReturn(unspentsResponse).when(unspentsRequestSpy).send();
+
+        // Mock the contract state response for the contract state.
+        ContractState contractState = new ContractState(0, null, null,
+                Arrays.asList(ContractParameterType.STRING), null, null, null, null, null, null, null);
+        NeoGetContractState stateResponse = new NeoGetContractState();
+        stateResponse.setResult(contractState);
+        Request<?, NeoGetContractState> stateRequestSpy = spy(new Request<>());
+        doReturn(stateResponse).when(stateRequestSpy).send();
+
+        Neow3j neow3jSpy = spy(EMPTY_NEOW3J);
+        doReturn(unspentsRequestSpy).when(neow3jSpy).getUnspents(contractAccount.getAddress());
+        doReturn(stateRequestSpy).when(neow3jSpy).getContractState(contractScriptHash.toString());
+
+        AssetTransfer at = new AssetTransfer.Builder(neow3jSpy)
+                .account(acct)
+                .amount(new BigDecimal("1"))
+                .asset(NEOAsset.HASH_ID)
+                .toAddress(acct.getAddress())
+                .fromContract(contractScriptHash)
+                .build()
+                .sign();
+
+        byte[] txBytes = at.getTransaction().toArray();
+        String expectedTx = "8000012023ba2703c53263e8d6e522dc32203339dcd8eee901b3b8549a5c896e3398" +
+                "ed960473842917202a08e3e83da7324050adc0bf41cc470000029b7cffdaa674beae0f930ebe6085" +
+                "af9093e5fe56b34a5c220ccdcf6efc336fc500e1f5050000000023ba2703c53263e8d6e522dc3220" +
+                "3339dcd8eee99b7cffdaa674beae0f930ebe6085af9093e5fe56b34a5c220ccdcf6efc336fc500e9" +
+                "a435000000008d0a96484de9b1c8c422748dba60394f5e6094d9020100004140bda6a86e1d1e325d" +
+                "a2a10cec2ff7792c3bde45852b578ecf024a87183bc98304ce8ff1e491978140b7e29cc0f5dc05b8" +
+                "5eab3e6cd9a72b13cee72082befba0022321031a6c6fbbdf02ca351745fa86b9ba5a9452d785ac4f" +
+                "7fc2b7548ca2a46c4fcf4aac";
+
+        assertEquals(expectedTx, Numeric.toHexStringNoPrefix(txBytes));
     }
 }

--- a/wallet/src/test/java/io/neow3j/wallet/AssetTransferTest.java
+++ b/wallet/src/test/java/io/neow3j/wallet/AssetTransferTest.java
@@ -364,7 +364,7 @@ public class AssetTransferTest {
 
         AssetTransfer at = new AssetTransfer.Builder(neow3jSpy)
                 .account(acct)
-                .amount(new BigDecimal("1"))
+                .amount("1")
                 .asset(NEOAsset.HASH_ID)
                 .toAddress(acct.getAddress())
                 .fromContract(contractScriptHash)


### PR DESCRIPTION
One can now attempt to transfer assets from a smart contracts address. I say 'attempt' because it depends on the smart contract's verification if the transfer will be accepted or not.

```
AssetTransfer at = new AssetTransfer.Builder(neow3jSpy)
    .fromContract(contractScriptHash)
    ...
```