### PR TITLE
Refactor `StackItem` to use Jackson annotations

### DIFF
--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/AnyStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/AnyStackItem.java
@@ -1,11 +1,27 @@
 package io.neow3j.protocol.core.methods.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.neow3j.model.types.StackItemType;
 
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AnyStackItem extends StackItem {
 
+    @JsonProperty("value")
+    private Object value;
+
     public AnyStackItem() {
-        super(StackItemType.ANY, null);
+        super(StackItemType.ANY);
+    }
+
+    public AnyStackItem(Object value) {
+        this.value = value;
+    }
+
+    public Object getValue() {
+        return this.value;
     }
 
     @Override
@@ -14,5 +30,19 @@ public class AnyStackItem extends StackItem {
                 "type=" + type +
                 ", value=" + value +
                 '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof AnyStackItem)) return false;
+        AnyStackItem other = (AnyStackItem) o;
+        return getType() == other.getType() &&
+                getValue() == other.getValue();
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
     }
 }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/ArrayStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/ArrayStackItem.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.neow3j.model.types.StackItemType;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
 

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/ArrayStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/ArrayStackItem.java
@@ -1,19 +1,30 @@
 package io.neow3j.protocol.core.methods.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.neow3j.model.types.StackItemType;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ArrayStackItem extends StackItem {
 
-    public ArrayStackItem(List<StackItem> value) {
-        super(StackItemType.ARRAY, value);
+    @JsonProperty("value")
+    private List<StackItem> value;
+
+    public ArrayStackItem() {
+        super(StackItemType.ARRAY);
     }
 
-    @Override
-    @SuppressWarnings(value = "unchecked")
+    public ArrayStackItem(List<StackItem> value) {
+        super(StackItemType.ARRAY);
+        this.value = value;
+    }
+
     public List<StackItem> getValue() {
-        return (List<StackItem>) this.value;
+        return this.value;
     }
 
     /**
@@ -44,4 +55,17 @@ public class ArrayStackItem extends StackItem {
         return getValue().isEmpty();
     }
 
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof ArrayStackItem)) return false;
+        ArrayStackItem other = (ArrayStackItem) o;
+        return getType() == other.getType() &&
+                Objects.equals(getValue(), other.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
 }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/BooleanStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/BooleanStackItem.java
@@ -1,16 +1,41 @@
 package io.neow3j.protocol.core.methods.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.neow3j.model.types.StackItemType;
 
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class BooleanStackItem extends StackItem {
 
+    @JsonProperty("value")
+    private Boolean value;
+
+    public BooleanStackItem() {
+        super(StackItemType.BOOLEAN);
+    }
+
     public BooleanStackItem(Boolean value) {
-        super(StackItemType.BOOLEAN, value);
+        super(StackItemType.BOOLEAN);
+        this.value = value;
+    }
+
+    public Boolean getValue() {
+        return this.value;
     }
 
     @Override
-    public Boolean getValue() {
-        return (Boolean) this.value;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof BooleanStackItem)) return false;
+        BooleanStackItem other = (BooleanStackItem) o;
+        return getType() == other.getType() &&
+                getValue() == other.getValue();
     }
 
+    @Override
+    public int hashCode() {
+        return Objects.hash(getType(), getValue());
+    }
 }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/ByteStringStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/ByteStringStackItem.java
@@ -1,5 +1,7 @@
 package io.neow3j.protocol.core.methods.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.neow3j.contract.ScriptHash;
@@ -9,10 +11,19 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ByteStringStackItem extends StackItem {
 
+    @JsonProperty("value")
+    private byte[] value;
+
+    public ByteStringStackItem() {
+        super(StackItemType.BYTE_STRING);
+    }
+
     public ByteStringStackItem(byte[] value) {
-        super(StackItemType.BYTE_STRING, value);
+        super(StackItemType.BYTE_STRING);
+        this.value = value;
     }
 
     /**
@@ -20,9 +31,8 @@ public class ByteStringStackItem extends StackItem {
      *
      * @return the value of this stack item.
      */
-    @Override
     public byte[] getValue() {
-        return (byte[]) this.value;
+        return this.value;
     }
 
     /**
@@ -63,14 +73,13 @@ public class ByteStringStackItem extends StackItem {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (o == null || this.getClass() != o.getClass()) return false;
+        if (!(o instanceof ByteStringStackItem)) return false;
         ByteStringStackItem other = (ByteStringStackItem) o;
-        return this.type == other.type && Arrays.equals(this.getValue(), other.getValue());
+        return getType() == other.getType() && Arrays.equals(this.getValue(), other.getValue());
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(type, Arrays.hashCode(getValue()));
     }
-
 }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/IntegerStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/IntegerStackItem.java
@@ -1,17 +1,55 @@
 package io.neow3j.protocol.core.methods.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSetter;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.annotation.Nulls;
 import io.neow3j.model.types.StackItemType;
 
 import java.math.BigInteger;
+import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class IntegerStackItem extends StackItem {
 
+    @JsonProperty("value")
+    private BigInteger value;
+
+    public IntegerStackItem() {
+        super(StackItemType.INTEGER);
+    }
+
     public IntegerStackItem(BigInteger value) {
-        super(StackItemType.INTEGER, value);
+        super(StackItemType.INTEGER);
+        this.value = value;
+    }
+
+    @JsonSetter("value")
+    public void setValue(BigInteger value) {
+        if (value != null) {
+            this.value = value;
+        } else {
+            this.value = BigInteger.ZERO;
+        }
+    }
+
+    @JsonValue
+    public BigInteger getValue() {
+        return this.value;
     }
 
     @Override
-    public BigInteger getValue() {
-        return (BigInteger) this.value;
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof IntegerStackItem)) return false;
+        IntegerStackItem other = (IntegerStackItem) o;
+        return getType() == other.getType() &&
+                getValue().equals(other.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getType(), getValue());
     }
 }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/IntegerStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/IntegerStackItem.java
@@ -4,7 +4,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonSetter;
 import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.annotation.Nulls;
 import io.neow3j.model.types.StackItemType;
 
 import java.math.BigInteger;

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/InteropInterfaceStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/InteropInterfaceStackItem.java
@@ -1,0 +1,52 @@
+package io.neow3j.protocol.core.methods.response;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.neow3j.contract.ScriptHash;
+import io.neow3j.model.types.StackItemType;
+import io.neow3j.utils.BigIntegers;
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Objects;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class InteropInterfaceStackItem extends StackItem {
+
+    @JsonProperty("value")
+    private String value;
+
+    public InteropInterfaceStackItem() {
+        super(StackItemType.INTEROP_INTERFACE);
+    }
+
+    public InteropInterfaceStackItem(String value) {
+        super(StackItemType.INTEROP_INTERFACE);
+        this.value = value;
+    }
+
+    /**
+     * Decodes the stack item's value and returns it.
+     *
+     * @return the value of this stack item.
+     */
+    public String getValue() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof io.neow3j.protocol.core.methods.response.InteropInterfaceStackItem)) return false;
+        io.neow3j.protocol.core.methods.response.InteropInterfaceStackItem other =
+                (io.neow3j.protocol.core.methods.response.InteropInterfaceStackItem) o;
+        return getType() == other.getType()
+                && getValue().equals(other.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
+    }
+}

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/InteropInterfaceStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/InteropInterfaceStackItem.java
@@ -2,13 +2,8 @@ package io.neow3j.protocol.core.methods.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import io.neow3j.contract.ScriptHash;
 import io.neow3j.model.types.StackItemType;
-import io.neow3j.utils.BigIntegers;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
-import java.math.BigInteger;
-import java.util.Arrays;
 import java.util.Objects;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -38,9 +33,8 @@ public class InteropInterfaceStackItem extends StackItem {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof io.neow3j.protocol.core.methods.response.InteropInterfaceStackItem)) return false;
-        io.neow3j.protocol.core.methods.response.InteropInterfaceStackItem other =
-                (io.neow3j.protocol.core.methods.response.InteropInterfaceStackItem) o;
+        if (!(o instanceof InteropInterfaceStackItem)) return false;
+        InteropInterfaceStackItem other = (InteropInterfaceStackItem) o;
         return getType() == other.getType()
                 && getValue().equals(other.getValue());
     }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/StackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/StackItem.java
@@ -13,10 +13,14 @@ import io.neow3j.model.types.StackItemType;
 @JsonSubTypes(value = {
         @JsonSubTypes.Type(value = AnyStackItem.class, name = StackItemType.ANY_VALUE),
 //        @JsonSubTypes.Type(value = PointerStackItem.class, name = StackItemType.POINTER_VALUE),
+        // TODO: 01.07.20 Michael: The library does not yet have a class to handle StackItems of type Pointer.
+        //  A class PointerStackItem should be added.
         @JsonSubTypes.Type(value = BooleanStackItem.class, name = StackItemType.BOOLEAN_VALUE),
         @JsonSubTypes.Type(value = IntegerStackItem.class, name = StackItemType.INTEGER_VALUE),
         @JsonSubTypes.Type(value = ByteStringStackItem.class, name = StackItemType.BYTE_STRING_VALUE),
 //        @JsonSubTypes.Type(value = BufferStackItem.class, name = StackItemType.BUFFER_VALUE),
+        // TODO: 01.07.20 Michael: The library does not yet have a class to handle StackItems of type Buffer.
+        //  A class BufferStackItem should be added.
         @JsonSubTypes.Type(value = ArrayStackItem.class, name = StackItemType.ARRAY_VALUE),
         @JsonSubTypes.Type(value = StructStackItem.class, name = StackItemType.STRUCT_VALUE),
         @JsonSubTypes.Type(value = MapStackItem.class, name = StackItemType.MAP_VALUE),

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/StackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/StackItem.java
@@ -7,20 +7,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
-import com.fasterxml.jackson.core.JsonParser;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.TreeNode;
-import com.fasterxml.jackson.databind.DeserializationContext;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import io.neow3j.model.types.StackItemType;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Map;
-
 
 @JsonTypeInfo(use = Id.NAME, property = "type", include = As.EXISTING_PROPERTY)
 @JsonSubTypes(value = {

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/StackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/StackItem.java
@@ -1,32 +1,51 @@
 package io.neow3j.protocol.core.methods.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
-import io.neow3j.crypto.Base64;
 import io.neow3j.model.types.StackItemType;
-import io.neow3j.protocol.core.methods.response.StackItem.StackDeserializer;
+
 import java.io.IOException;
-import java.math.BigInteger;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
-@JsonDeserialize(using = StackDeserializer.class)
-public class StackItem {
 
+@JsonTypeInfo(use = Id.NAME, property = "type", include = As.EXISTING_PROPERTY)
+@JsonSubTypes(value = {
+        @JsonSubTypes.Type(value = AnyStackItem.class, name = StackItemType.ANY_VALUE),
+//        @JsonSubTypes.Type(value = PointerStackItem.class, name = StackItemType.POINTER_VALUE),
+        @JsonSubTypes.Type(value = BooleanStackItem.class, name = StackItemType.BOOLEAN_VALUE),
+        @JsonSubTypes.Type(value = IntegerStackItem.class, name = StackItemType.INTEGER_VALUE),
+        @JsonSubTypes.Type(value = ByteStringStackItem.class, name = StackItemType.BYTE_STRING_VALUE),
+//        @JsonSubTypes.Type(value = BufferStackItem.class, name = StackItemType.BUFFER_VALUE),
+        @JsonSubTypes.Type(value = ArrayStackItem.class, name = StackItemType.ARRAY_VALUE),
+        @JsonSubTypes.Type(value = StructStackItem.class, name = StackItemType.STRUCT_VALUE),
+        @JsonSubTypes.Type(value = MapStackItem.class, name = StackItemType.MAP_VALUE),
+        @JsonSubTypes.Type(value = InteropInterfaceStackItem.class, name = StackItemType.INTEROP_INTERFACE_VALUE)
+})
+@JsonIgnoreProperties(ignoreUnknown = true)
+public abstract class StackItem {
+
+    @JsonProperty("type")
     protected StackItemType type;
-    protected Object value;
 
-    public StackItem(StackItemType type, Object value) {
+    public StackItem() {
+    }
+
+    public StackItem(StackItemType type) {
         this.type = type;
-        this.value = value;
     }
 
     /**
@@ -39,42 +58,13 @@ public class StackItem {
     }
 
     /**
-     * Returns the value of this stack item.
-     *
-     * @return the value of this stack item.
-     */
-    public Object getValue() {
-        return this.value;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        StackItem other = (StackItem) o;
-        return this.type == other.type && Objects.equals(this.value, other.value);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(this.type, this.value);
-    }
-
-    @Override
-    public String toString() {
-        return "StackItem{" +
-                "type=" + this.type +
-                ", value=" + this.value +
-                '}';
-    }
-
-    /**
      * Casts this stack item to a {@link ByteStringStackItem}, if possible, and returns it.
      *
      * @return this stack item as a {@link ByteStringStackItem}.
      * @throws IllegalStateException if this stack item is not an instance of
      *                               {@link ByteStringStackItem}.
      */
+    @JsonIgnore
     public ByteStringStackItem asByteString() {
         if (this instanceof ByteStringStackItem) {
             return (ByteStringStackItem) this;
@@ -90,6 +80,7 @@ public class StackItem {
      * @throws IllegalStateException if this stack item is not an instance of
      *                               {@link BooleanStackItem}.
      */
+    @JsonIgnore
     public BooleanStackItem asBoolean() {
         if (this instanceof BooleanStackItem) {
             return (BooleanStackItem) this;
@@ -105,6 +96,7 @@ public class StackItem {
      * @throws IllegalStateException if this stack item is not an instance of
      *                               {@link IntegerStackItem}.
      */
+    @JsonIgnore
     public IntegerStackItem asInteger() {
         if (this instanceof IntegerStackItem) {
             return (IntegerStackItem) this;
@@ -120,6 +112,7 @@ public class StackItem {
      * @throws IllegalStateException if this stack item is not an instance of
      *                               {@link ArrayStackItem}.
      */
+    @JsonIgnore
     public ArrayStackItem asArray() {
         if (this instanceof ArrayStackItem) {
             return (ArrayStackItem) this;
@@ -135,6 +128,7 @@ public class StackItem {
      * @throws IllegalStateException if this stack item is not an instance of
      *                               {@link MapStackItem}.
      */
+    @JsonIgnore
     public MapStackItem asMap() {
         if (this instanceof MapStackItem) {
             return (MapStackItem) this;
@@ -150,6 +144,7 @@ public class StackItem {
      * @throws IllegalStateException if this stack item is not an instance of
      *                               {@link StructStackItem}.
      */
+    @JsonIgnore
     public StructStackItem asStruct() {
         if (this instanceof StructStackItem) {
             return (StructStackItem) this;
@@ -158,78 +153,21 @@ public class StackItem {
                 StackItemType.STRUCT.jsonValue() + " but of " + this.type.jsonValue());
     }
 
-    public static class StackDeserializer extends StdDeserializer<StackItem> {
-
-        protected StackDeserializer() {
-            this(null);
+    @JsonIgnore
+    public Object asAny() {
+        if (this instanceof AnyStackItem) {
+            return this;
         }
+        throw new IllegalStateException("This stack item is not of type " +
+                StackItemType.ANY.jsonValue() + " but of " + this.type.jsonValue());
+    }
 
-        protected StackDeserializer(Class<StackItem> vc) {
-            super(vc);
+    @JsonIgnore
+    public Object asInteropInterface() {
+        if (this instanceof InteropInterfaceStackItem) {
+            return this;
         }
-
-        public StackItem deserialize(JsonParser jp, DeserializationContext ctxt)
-                throws IOException {
-
-            JsonNode node = jp.getCodec().readTree(jp);
-            return deserializeStackItem(node, jp);
-        }
-
-        private StackItem deserializeStackItem(JsonNode itemNode, JsonParser jp)
-                throws JsonProcessingException {
-
-            JsonNode typeNode = itemNode.get("type");
-            JsonNode valueNode = itemNode.get("value");
-            StackItemType type = null;
-            if (typeNode != null) {
-                type = jp.getCodec().treeToValue(typeNode, StackItemType.class);
-            }
-            if (valueNode == null) {
-                return new StackItem(type, null);
-            }
-            if (type == null) {
-                return new StackItem(null, valueNode.asText());
-            }
-            switch (type) {
-                case ANY:
-                    return new AnyStackItem();
-                case BYTE_STRING:
-                    return new ByteStringStackItem(Base64.decode(valueNode.asText()));
-                case BOOLEAN:
-                    return new BooleanStackItem(valueNode.asBoolean());
-                case INTEGER:
-                    if (valueNode.asText().isEmpty()) {
-                        return new IntegerStackItem(BigInteger.ZERO);
-                    }
-                    return new IntegerStackItem(new BigInteger(valueNode.asText()));
-                case ARRAY:
-                    List<StackItem> items = new ArrayList<>();
-                    for (final JsonNode item : valueNode) {
-                        items.add(deserializeStackItem(item, jp));
-                    }
-                    return new ArrayStackItem(items);
-                case MAP:
-                    Iterator<JsonNode> elements = valueNode.elements();
-                    Map<StackItem, StackItem> map = new HashMap<>();
-                    while (elements.hasNext()) {
-                        JsonNode element = elements.next();
-                        StackItem keyItem = deserializeStackItem(element.get("key"), jp);
-                        StackItem valueItem = deserializeStackItem(element.get("value"), jp);
-                        map.put(keyItem, valueItem);
-                    }
-                    return new MapStackItem(map);
-                case STRUCT:
-                    items = new ArrayList<>();
-                    for (final JsonNode item : valueNode) {
-                        items.add(deserializeStackItem(item, jp));
-                    }
-                    return new StructStackItem(items);
-                case INTEROP_INTERFACE:
-                    return new StackItem(type, valueNode.asText());
-                default:
-                    throw new UnsupportedOperationException("Parameter type \'" + type +
-                            "\' not supported.");
-            }
-        }
+        throw new IllegalStateException("This stack item is not of type " +
+                StackItemType.INTEROP_INTERFACE.jsonValue() + " but of " + this.type.jsonValue());
     }
 }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/StructStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/StructStackItem.java
@@ -1,19 +1,29 @@
 package io.neow3j.protocol.core.methods.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import io.neow3j.model.types.StackItemType;
 
 import java.util.List;
+import java.util.Objects;
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class StructStackItem extends StackItem {
 
-    public StructStackItem(List<StackItem> value) {
-        super(StackItemType.STRUCT, value);
+    @JsonProperty("value")
+    private List<StackItem> value;
+
+    public StructStackItem() {
+        super(StackItemType.STRUCT);
     }
 
-    @Override
-    @SuppressWarnings(value = "unchecked")
+    public StructStackItem(List<StackItem> value) {
+        super(StackItemType.STRUCT);
+        this.value = value;
+    }
+
     public List<StackItem> getValue() {
-        return (List<StackItem>) this.value;
+        return this.value;
     }
 
     /**
@@ -33,5 +43,19 @@ public class StructStackItem extends StackItem {
      */
     public int size() {
         return getValue().size();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof StructStackItem)) return false;
+        StructStackItem other = (StructStackItem) o;
+        return getType() == other.getType() &&
+                Objects.equals(getValue(), other.getValue());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getValue());
     }
 }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/TransactionCosigner.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/TransactionCosigner.java
@@ -41,9 +41,9 @@ public class TransactionCosigner extends TransactionAttribute {
         if (!(o instanceof TransactionCosigner)) {
             return false;
         }
-        TransactionCosigner that = (TransactionCosigner) o;
-        return Objects.equals(getAccount(), that.getAccount()) &&
-                getScopes() == that.getScopes();
+        TransactionCosigner other = (TransactionCosigner) o;
+        return Objects.equals(getAccount(), other.getAccount()) &&
+                getScopes() == other.getScopes();
     }
 
     @Override

--- a/core/src/test/java/io/neow3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/ResponseTest.java
@@ -67,6 +67,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import org.junit.Test;
@@ -2124,7 +2125,7 @@ public class ResponseTest extends ResponseTester {
         assertThat(neoAppLog.getStack(), hasSize(1));
         assertThat(neoAppLog.getStack().get(0).getType(),
                 is(StackItemType.INTEGER));
-        assertThat(neoAppLog.getStack().get(0).getValue(),
+        assertThat(neoAppLog.getStack().get(0).asInteger().getValue(),
                 is(BigInteger.valueOf(1)));
 
         assertThat(neoAppLog.getNotifications(), is(notNullValue()));
@@ -2139,12 +2140,12 @@ public class ResponseTest extends ResponseTester {
         ArrayStackItem notification0Array = notification0.getState().asArray();
 
         String eventName0 = notification0Array.get(0).asByteString().getAsString();
-        Object from0 = notification0Array.get(1).getValue();
+        Object from0 = notification0Array.get(1).asAny();
         String to0 = notification0Array.get(2).asByteString().getAsAddress();
         BigInteger amount0 = notification0Array.get(3).asInteger().getValue();
 
         assertThat(eventName0, is("Transfer"));
-        assertThat(from0, is(nullValue()));
+        assertNotNull(from0);
         assertThat(to0, is("AVGpjFiocR1BdYhbYWqB6Ls6kcmzx4FWhm"));
         assertThat(amount0, is(BigInteger.valueOf(600000000)));
 

--- a/core/src/test/java/io/neow3j/protocol/core/methods/response/StackItemTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/methods/response/StackItemTest.java
@@ -115,6 +115,7 @@ public class StackItemTest extends ResponseTester {
         IntegerStackItem item = rawItem.asInteger();
         assertEquals(new BigInteger("1124"), item.getValue());
 
+        // TODO: 23.06.20 Michael: set empty content to default value - here to BigInteger.ZERO
         json = ""
                 + " {"
                 + "   \"type\": \"Integer\",\n"

--- a/core/src/test/java/io/neow3j/protocol/core/methods/response/StackItemTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/methods/response/StackItemTest.java
@@ -115,7 +115,6 @@ public class StackItemTest extends ResponseTester {
         IntegerStackItem item = rawItem.asInteger();
         assertEquals(new BigInteger("1124"), item.getValue());
 
-        // TODO: 23.06.20 Michael: set empty content to default value - here to BigInteger.ZERO
         json = ""
                 + " {"
                 + "   \"type\": \"Integer\",\n"

--- a/model/src/main/java/io/neow3j/model/types/StackItemType.java
+++ b/model/src/main/java/io/neow3j/model/types/StackItemType.java
@@ -15,6 +15,17 @@ public enum StackItemType {
     MAP("Map", 0x48),
     INTEROP_INTERFACE("InteropInterface", 0x60);
 
+    public static final String ANY_VALUE = "Any";
+    public static final String POINTER_VALUE = "Pointer";
+    public static final String BOOLEAN_VALUE = "Boolean";
+    public static final String INTEGER_VALUE = "Integer";
+    public static final String BYTE_STRING_VALUE = "ByteString";
+    public static final String BUFFER_VALUE = "Buffer";
+    public static final String ARRAY_VALUE = "Array";
+    public static final String STRUCT_VALUE = "Struct";
+    public static final String MAP_VALUE = "Map";
+    public static final String INTEROP_INTERFACE_VALUE = "InteropInterface";
+
     private String jsonValue;
     private byte byteValue;
 
@@ -49,5 +60,4 @@ public enum StackItemType {
         }
         throw new IllegalArgumentException();
     }
-
 }

--- a/model/src/main/java/io/neow3j/model/types/StackItemType.java
+++ b/model/src/main/java/io/neow3j/model/types/StackItemType.java
@@ -4,16 +4,16 @@ import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum StackItemType {
 
-    ANY("Any", 0x00),
-    POINTER("Pointer", 0x10),
-    BOOLEAN("Boolean", 0x20),
-    INTEGER("Integer", 0x21),
-    BYTE_STRING("ByteString", 0x28),
-    BUFFER("Buffer", 0x30),
-    ARRAY("Array", 0x40),
-    STRUCT("Struct", 0x41),
-    MAP("Map", 0x48),
-    INTEROP_INTERFACE("InteropInterface", 0x60);
+    ANY(StackItemType.ANY_VALUE, 0x00),
+    POINTER(StackItemType.POINTER_VALUE, 0x10),
+    BOOLEAN(StackItemType.BOOLEAN_VALUE, 0x20),
+    INTEGER(StackItemType.INTEGER_VALUE, 0x21),
+    BYTE_STRING(StackItemType.BYTE_STRING_VALUE, 0x28),
+    BUFFER(StackItemType.BUFFER_VALUE, 0x30),
+    ARRAY(StackItemType.ARRAY_VALUE, 0x40),
+    STRUCT(StackItemType.STRUCT_VALUE, 0x41),
+    MAP(StackItemType.MAP_VALUE, 0x48),
+    INTEROP_INTERFACE(StackItemType.INTEROP_INTERFACE_VALUE, 0x60);
 
     public static final String ANY_VALUE = "Any";
     public static final String POINTER_VALUE = "Pointer";
@@ -32,6 +32,10 @@ public enum StackItemType {
     StackItemType(String jsonValue, int v) {
         this.jsonValue = jsonValue;
         this.byteValue = (byte) v;
+    }
+
+    public String getValue() {
+        return this.jsonValue;
     }
 
     @JsonValue


### PR DESCRIPTION
According to issue #131,  StackItems could potentially be deserialised using Jackson annotations.

Resolves #131 