### PR TITLE
Fix conversion of JVM's special DUP and POP opcodes.

### DIFF
--- a/compiler/src/test-integration/java/io/neow3j/compiler/ArithmeticOperatorsTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ArithmeticOperatorsTest.java
@@ -29,8 +29,6 @@ public class ArithmeticOperatorsTest extends CompilerTest {
         assertThat(response.getInvocationResult().getStack().get(0), is(expected));
     }
 
-    @Ignore("The assignment operators in connection with arrays produce a DUP2 JVM opcode which is "
-            + "not correctly handled by the compiler at the moment.")
     @Test
     public void allAssignmentOperators() throws IOException {
         NeoInvokeFunction response = contract.invokeFunction(

--- a/compiler/src/test-integration/resources/responses/ArithmeticOperators/allAssignmentOperators.json
+++ b/compiler/src/test-integration/resources/responses/ArithmeticOperators/allAssignmentOperators.json
@@ -19,7 +19,7 @@
     },
     {
       "type": "Integer",
-      "value": -90
+      "value": 10
     }
   ]
 }


### PR DESCRIPTION
This fixes one point of issue #199.

I can't write tests for all the new code that I added, e.g., for the handling DUP_X2 JVM opcode. I simply don't know which Java code will result in such opcodes.