### PR TITLE
Feature/gradle debug info

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -153,10 +153,12 @@ subprojects {
 
     artifacts { archives sourcesJar, javadocsJar, testsJar }
 
-    // Avoid to publish gradle-plugin module.
-    // See "gradle-plugin/README.md" for Gradle Plugin release procedures
-    if (!project.name.startsWith('gradle-plugin') &&
-            !project.name.startsWith(rootProject.name)) {
+    // We just avoid to publish the root project.
+    // The gradle-plugin module is fine and desirable to publish to JFrog/SonaType.
+    // In addition the gradle-plugin module should be published to the Gradle Plugin
+    // global repository. See "gradle-plugin/README.md" for Gradle Plugin
+    // release procedures.
+    if (!project.name.startsWith(rootProject.name)) {
 
         apply plugin: 'com.jfrog.bintray'
         apply plugin: 'maven-publish'

--- a/compiler/src/main/java/io/neow3j/compiler/CompilationUnit.java
+++ b/compiler/src/main/java/io/neow3j/compiler/CompilationUnit.java
@@ -91,7 +91,7 @@ public class CompilationUnit {
 
     /**
      * Adds the given {@code ClassNode} to the list of classes that form the smart contract. I.e.,
-     * only classes that are added here will can contribute to a contract's public interface.
+     * only classes that are added here can contribute to a contract's public interface.
      *
      * @param classNode The class to add.
      */

--- a/compiler/src/main/java/io/neow3j/compiler/Compiler.java
+++ b/compiler/src/main/java/io/neow3j/compiler/Compiler.java
@@ -236,6 +236,7 @@ public class Compiler {
         for (NeoMethod neoMethod : new ArrayList<>(compUnit.getNeoModule().getSortedMethods())) {
             compileMethod(neoMethod, compUnit);
         }
+        finalizeCompilation();
         return compUnit;
     }
 

--- a/compiler/src/main/java/io/neow3j/compiler/Compiler.java
+++ b/compiler/src/main/java/io/neow3j/compiler/Compiler.java
@@ -182,7 +182,7 @@ public class Compiler {
      *
      * @param className      The fully qualified name of the class to compile.
      * @param sourceFilePath The absolute path of the class' source file.
-     * @return THe compilation unit holding the NEF, contract manifest and {@code DebugInfo}.
+     * @return The compilation unit holding the NEF, contract manifest, and {@code DebugInfo}.
      * @throws IOException If an error occurs when reading the class and source files.
      */
     public CompilationUnit compileClass(String className, String sourceFilePath)

--- a/compiler/src/main/java/io/neow3j/compiler/NeoMethod.java
+++ b/compiler/src/main/java/io/neow3j/compiler/NeoMethod.java
@@ -87,7 +87,7 @@ public class NeoMethod {
     // Tells if the current line number should be added to an instruction that is added to this
     // method. If it is the first instruction corresponding to the current line, then the line
     // number is added to the instruction.
-    private boolean isFreshNewLine = true;
+    private boolean isFreshNewLine = false;
 
     /**
      * Constructs a new Neo method.

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileAction.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileAction.java
@@ -88,15 +88,18 @@ public class Neow3jCompileAction implements Action<Neow3jCompileTask> {
                     compilationUnit.getManifest(),
                     outDirPath.toFile());
 
-            // Pack the debug info into a ZIP archive.
-            String debugInfoZipFileName = generateDebugInfoZip(compilationUnit.getDebugInfo(),
-                    outDirString, ClassUtils.getClassName(firstCanonicalClassName));
-
             // if everything goes fine, print info
             System.out.println("Compilation succeeded!");
             System.out.println("NEF file: " + outputFile.toAbsolutePath());
             System.out.println("Manifest file: " + manifestOutFileName);
-            System.out.println("Debug info zip file: " + debugInfoZipFileName);
+
+            if (debugSymbols) {
+                // Pack the debug info into a ZIP archive.
+                String debugInfoZipFileName = generateDebugInfoZip(compilationUnit.getDebugInfo(),
+                        outDirString, ClassUtils.getClassName(firstCanonicalClassName));
+                System.out.println("Debug info zip file: " + debugInfoZipFileName);
+            }
+
         } catch (Exception e) {
             System.out.println("Compilation failed. Reason: " + e.getMessage());
             e.printStackTrace();

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileAction.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileAction.java
@@ -79,6 +79,7 @@ public class Neow3jCompileAction implements Action<Neow3jCompileTask> {
             // TODO: when there's multiple class names, which one to use for the final NEF?
             String firstCanonicalClassName = canonicalClassNames
                     .stream().findFirst().orElse(null);
+
             String nefOutFileName = getCompileOutputFileName(firstCanonicalClassName);
             Path outputFile = Paths.get(outDirString, nefOutFileName);
             writeToFile(outputFile.toFile(), nefBytes);

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginOptions.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginOptions.java
@@ -7,10 +7,9 @@ import java.util.Set;
 
 public class Neow3jPluginOptions {
 
-    public static final String CLASSNAMES_NAME = "classNames";
-    public static final String DEBUG_NAME = "debug";
+    public static final String CLASSNAME_NAME = "className";
 
-    private LinkedHashSet<String> classNames;
+    private String className;
 
     // Default behavior: generate debug symbols
     private Boolean debug = true;
@@ -18,20 +17,16 @@ public class Neow3jPluginOptions {
     public Neow3jPluginOptions() {
     }
 
-    public Set<String> getClassNames() {
-        return classNames;
-    }
-
-    public void setClassNames(String... classNames) {
-        this.classNames = new LinkedHashSet<>(asList(classNames));
-    }
-
-    public void classNames(String... classNames) {
-        setClassNames(classNames);
+    public String getClassName() {
+        return className;
     }
 
     public void setClassName(String className) {
-        setClassNames(className);
+        this.className = className;
+    }
+
+    public void className(String className) {
+        this.className = className;
     }
 
     public Boolean getDebug() {

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginOptions.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginOptions.java
@@ -1,23 +1,41 @@
 package io.neow3j.devpack.gradle;
 
+import static java.util.Arrays.asList;
+
+import java.util.HashSet;
+import java.util.Set;
+
 public class Neow3jPluginOptions {
 
-    public static final String CLASSNAME_NAME = "className";
+    public static final String CLASSNAMES_NAME = "classNames";
+    public static final String DEBUG_NAME = "debug";
 
-    private String className;
+    private Set<String> classNames;
+
+    // Default behavior: generate debug symbols
+    private Boolean debug = true;
 
     public Neow3jPluginOptions() {
     }
 
-    public Neow3jPluginOptions(String path) {
-        this.className = path;
+    public Neow3jPluginOptions(Set<String> classNames) {
+        this.classNames = classNames;
     }
 
-    public String getClassName() {
-        return className;
+    public Set<String> getClassNames() {
+        return classNames;
     }
 
-    public void setClassName(String className) {
-        this.className = className;
+    public void setClassNames(String... classNames) {
+        this.classNames = new HashSet<>(asList(classNames));
     }
+
+    public Boolean getDebug() {
+        return debug;
+    }
+
+    public void setDebug(Boolean debug) {
+        this.debug = debug;
+    }
+
 }

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginOptions.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginOptions.java
@@ -2,7 +2,7 @@ package io.neow3j.devpack.gradle;
 
 import static java.util.Arrays.asList;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 
 public class Neow3jPluginOptions {
@@ -10,7 +10,7 @@ public class Neow3jPluginOptions {
     public static final String CLASSNAMES_NAME = "classNames";
     public static final String DEBUG_NAME = "debug";
 
-    private Set<String> classNames;
+    private LinkedHashSet<String> classNames;
 
     // Default behavior: generate debug symbols
     private Boolean debug = true;
@@ -23,7 +23,7 @@ public class Neow3jPluginOptions {
     }
 
     public void setClassNames(String... classNames) {
-        this.classNames = new HashSet<>(asList(classNames));
+        this.classNames = new LinkedHashSet<>(asList(classNames));
     }
 
     public void classNames(String... classNames) {

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginOptions.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginOptions.java
@@ -18,10 +18,6 @@ public class Neow3jPluginOptions {
     public Neow3jPluginOptions() {
     }
 
-    public Neow3jPluginOptions(Set<String> classNames) {
-        this.classNames = classNames;
-    }
-
     public Set<String> getClassNames() {
         return classNames;
     }
@@ -30,12 +26,24 @@ public class Neow3jPluginOptions {
         this.classNames = new HashSet<>(asList(classNames));
     }
 
+    public void classNames(String... classNames) {
+        setClassNames(classNames);
+    }
+
+    public void setClassName(String className) {
+        setClassNames(className);
+    }
+
     public Boolean getDebug() {
         return debug;
     }
 
     public void setDebug(Boolean debug) {
         this.debug = debug;
+    }
+
+    public void debug(Boolean debug) {
+        setDebug(debug);
     }
 
 }

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginUtils.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginUtils.java
@@ -42,6 +42,23 @@ public class Neow3jPluginUtils {
         return null;
     }
 
+    static List<URL> getSourceSetsFilesURL(Project project) {
+        final JavaPluginConvention pluginConv = project.getConvention()
+                .getPlugin(JavaPluginConvention.class);
+        List<URL> urls = new ArrayList<>();
+        pluginConv.getSourceSets().forEach(ss -> {
+            ss.getAllSource().forEach(f -> {
+                try {
+                    urls.add(f.toURI().toURL());
+                } catch (Exception e) {
+                    System.out.println("Error on converting ("
+                            + f.getAbsolutePath() + ") to URL: " + e);
+                }
+            });
+        });
+        return urls;
+    }
+
     static List<URL> getSourceSetsDirsURL(Project project) {
         final JavaPluginConvention pluginConv = project.getConvention()
                 .getPlugin(JavaPluginConvention.class);

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginUtils.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginUtils.java
@@ -19,15 +19,15 @@ import org.gradle.api.plugins.JavaPluginConvention;
 
 public class Neow3jPluginUtils {
 
-    protected static final String SUFFIX_FILENAME = ".nef";
-    protected static final String DEFAULT_FILENAME = "output" + SUFFIX_FILENAME;
+    protected static final String NEF_SUFFIX = ".nef";
+    protected static final String DEFAULT_FILENAME = "output" + NEF_SUFFIX;
     protected static final String NEFDBGNFO_SUFFIX = ".nefdbgnfo";
     protected static final String DEBUG_JSON_SUFFIX = ".debug.json";
 
     static String getCompileOutputFileName(String fqClassName) {
         String className = getClassName(fqClassName);
         if (className != null && className.length() > 0) {
-            return className + SUFFIX_FILENAME;
+            return className + NEF_SUFFIX;
         }
         return DEFAULT_FILENAME;
     }

--- a/utils/src/main/java/io/neow3j/constants/InteropServiceCode.java
+++ b/utils/src/main/java/io/neow3j/constants/InteropServiceCode.java
@@ -146,6 +146,7 @@ public enum InteropServiceCode {
      * If the interop service has a fixed price, the parameter is simply ignored and the fixed price
      * is returned.
      *
+     * @param param The parameter representing the interop service code
      * @return the price
      */
     public long getPrice(int param) {

--- a/utils/src/main/java/io/neow3j/io/BinaryReader.java
+++ b/utils/src/main/java/io/neow3j/io/BinaryReader.java
@@ -295,6 +295,7 @@ public class BinaryReader implements AutoCloseable {
     /**
      * Tries to read a PUSHDATA OpCode and the following data from the underlying byte stream.
      *
+     * @throws DeserializationException if the sequence of data cannot be deserialized
      * @return The data read
      */
     public byte[] readPushData() throws DeserializationException {

--- a/wallet/src/main/java/io/neow3j/wallet/Wallet.java
+++ b/wallet/src/main/java/io/neow3j/wallet/Wallet.java
@@ -73,6 +73,7 @@ public class Wallet {
      *
      * @param accountScriptHash The new default account.
      * @throws IllegalArgumentException if the given account is not in this wallet.
+     * @return the Wallet
      */
     public Wallet defaultAccount(ScriptHash accountScriptHash) {
         if (accountScriptHash == null) throw new IllegalArgumentException("No account provided to set default.");


### PR DESCRIPTION
There are two things to be discussed, still:

- [ ] When the method `.compileClasses(canonicalClassNames, setOfSourceSetFilesPath)` is used, meaning that we give several Smart Contract classes to be compiled, as well as with multiple sources, shouldn't we return also multiple `CompilationUnit` objects?
- [ ] If the answer from the previous question is "no, just one `CompilationUnit` is required", then, how should we infer the NEF, Debug Info, and Manifest file names?

Now, there are multiple ways to specify Smart Contract class names to be compiled! 🎉 

For multiple files:

```
neow3jCompiler {
    classNames "io.neow3j.examples.NameService", "io.neow3j.examples.NEP5"
    debug false
}
```

For single file:

```
neow3jCompiler {
    classNames "io.neow3j.examples.NameService"
    debug false
}
```

For multiple files with array:

```
neow3jCompiler {
    classNames = [ "io.neow3j.examples.NameService", "io.neow3j.examples.NEP5" ]
    debug false
}
```

For single file with array:

```
neow3jCompiler {
    classNames = [ "io.neow3j.examples.NameService" ]
    debug false
}
```

For single file, keeping backwards compatibility:

```
neow3jCompiler {
    className = "io.neow3j.examples.NameService"
    debug = false
}
```