### PR TITLE
Update imports and correct returns of StackItem methods

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
     ext.jetbrainsAnnotationsVersion = '20.1.0'
     ext.mockitoVersion = '3.6.0'
     ext.hamcrestVersion = '1.3'
-    ext.testcontainersVersion = '1.15.0-rc2'
+    ext.testcontainersVersion = '1.15.0'
     ext.awaitility = '3.1.5'
     ext.wiremockVersion = '2.25.1'
 

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/AnyStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/AnyStackItem.java
@@ -17,6 +17,7 @@ public class AnyStackItem extends StackItem {
     }
 
     public AnyStackItem(Object value) {
+        super(StackItemType.ANY);
         this.value = value;
     }
 

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/AnyStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/AnyStackItem.java
@@ -39,7 +39,7 @@ public class AnyStackItem extends StackItem {
         if (!(o instanceof AnyStackItem)) return false;
         AnyStackItem other = (AnyStackItem) o;
         return getType() == other.getType() &&
-                getValue() == other.getValue();
+                getValue().equals(other.getValue());
     }
 
     @Override

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/BufferStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/BufferStackItem.java
@@ -2,7 +2,6 @@ package io.neow3j.protocol.core.methods.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 import io.neow3j.contract.ScriptHash;
 import io.neow3j.model.types.StackItemType;
@@ -10,6 +9,8 @@ import io.neow3j.utils.BigIntegers;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BufferStackItem extends StackItem {

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/ByteStringStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/ByteStringStackItem.java
@@ -100,12 +100,8 @@ public class ByteStringStackItem extends StackItem {
 
     @Override
     public boolean equals(Object o) {
-        if (this == o) {
-            return true;
-        }
-        if (!(o instanceof ByteStringStackItem)) {
-            return false;
-        }
+        if (this == o) return true;
+        if (!(o instanceof ByteStringStackItem)) return false;
         ByteStringStackItem other = (ByteStringStackItem) o;
         return getType() == other.getType() && Arrays.equals(this.getValue(), other.getValue());
     }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/InteropInterfaceStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/InteropInterfaceStackItem.java
@@ -10,13 +10,13 @@ import java.util.Objects;
 public class InteropInterfaceStackItem extends StackItem {
 
     @JsonProperty("value")
-    private String value;
+    private Object value;
 
     public InteropInterfaceStackItem() {
         super(StackItemType.INTEROP_INTERFACE);
     }
 
-    public InteropInterfaceStackItem(String value) {
+    public InteropInterfaceStackItem(Object value) {
         super(StackItemType.INTEROP_INTERFACE);
         this.value = value;
     }
@@ -26,7 +26,7 @@ public class InteropInterfaceStackItem extends StackItem {
      *
      * @return the value of this stack item.
      */
-    public String getValue() {
+    public Object getValue() {
         return this.value;
     }
 

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/InteropInterfaceStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/InteropInterfaceStackItem.java
@@ -35,8 +35,8 @@ public class InteropInterfaceStackItem extends StackItem {
         if (this == o) return true;
         if (!(o instanceof InteropInterfaceStackItem)) return false;
         InteropInterfaceStackItem other = (InteropInterfaceStackItem) o;
-        return getType() == other.getType()
-                && getValue().equals(other.getValue());
+        return getType() == other.getType() &&
+                getValue().equals(other.getValue());
     }
 
     @Override

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/MapStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/MapStackItem.java
@@ -161,5 +161,4 @@ public class MapStackItem extends StackItem {
             return new MapStackItem(map);
         }
     }
-
 }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/StackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/StackItem.java
@@ -173,18 +173,18 @@ public abstract class StackItem {
     }
 
     @JsonIgnore
-    public Object asAny() {
+    public AnyStackItem asAny() {
         if (this instanceof AnyStackItem) {
-            return this;
+            return (AnyStackItem) this;
         }
         throw new IllegalStateException("This stack item is not of type " +
                 StackItemType.ANY.jsonValue() + " but of " + this.type.jsonValue());
     }
 
     @JsonIgnore
-    public Object asInteropInterface() {
+    public InteropInterfaceStackItem asInteropInterface() {
         if (this instanceof InteropInterfaceStackItem) {
-            return this;
+            return (InteropInterfaceStackItem) this;
         }
         throw new IllegalStateException("This stack item is not of type " +
                 StackItemType.INTEROP_INTERFACE.jsonValue() + " but of " + this.type.jsonValue());

--- a/core/src/test/java/io/neow3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/ResponseTest.java
@@ -6,6 +6,7 @@ import io.neow3j.contract.ScriptHash;
 import io.neow3j.model.types.ContractParameterType;
 import io.neow3j.model.types.NodePluginType;
 import io.neow3j.model.types.StackItemType;
+import io.neow3j.protocol.core.methods.response.AnyStackItem;
 import io.neow3j.protocol.core.methods.response.ArrayStackItem;
 import io.neow3j.protocol.core.methods.response.ByteStringStackItem;
 import io.neow3j.protocol.core.methods.response.ConsensusData;
@@ -2203,7 +2204,7 @@ public class ResponseTest extends ResponseTester {
         ArrayStackItem notification0Array = notification0.getState().asArray();
 
         String eventName0 = notification0Array.get(0).asByteString().getAsString();
-        Object from0 = notification0Array.get(1).asAny();
+        AnyStackItem from0 = notification0Array.get(1).asAny();
         String to0 = notification0Array.get(2).asByteString().getAsAddress();
         BigInteger amount0 = notification0Array.get(3).asInteger().getValue();
 
@@ -2222,7 +2223,7 @@ public class ResponseTest extends ResponseTester {
         ArrayStackItem notification1Array = notification1.getState().asArray();
 
         String eventName1 = notification1Array.get(0).asByteString().getAsString();
-        Object from1 = notification1Array.get(1).asByteString().getAsAddress();
+        String from1 = notification1Array.get(1).asByteString().getAsAddress();
         String to1 = notification1Array.get(2).asByteString().getAsAddress();
         BigInteger amount1 = notification1Array.get(3).asInteger().getValue();
 

--- a/core/src/test/java/io/neow3j/protocol/core/methods/response/StackItemTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/methods/response/StackItemTest.java
@@ -70,6 +70,23 @@ public class StackItemTest extends ResponseTester {
     }
 
     @Test
+    public void testDeserializeAnyStackItem() throws IOException {
+        String json = ""
+                + " {"
+                + "   \"type\": \"Any\",\n"
+                + "   \"value\": \"dGVzdGluZw==\"\n"
+                + " }";
+        StackItem rawItem = OBJECT_MAPPER.readValue(json, StackItem.class);
+        assertThat(rawItem.getType(), is(StackItemType.ANY));
+        AnyStackItem item = rawItem.asAny();
+        assertThat(item.getValue(), is("dGVzdGluZw=="));
+
+        AnyStackItem other = new AnyStackItem("dGVzdGluZw==");
+        assertEquals(other, item);
+        assertEquals(other.hashCode(), item.hashCode());
+    }
+
+    @Test
     public void testDeserializeByteStringStackItem() throws IOException {
         StackItem rawItem = OBJECT_MAPPER.readValue(BYTESTRING_JSON, StackItem.class);
         assertEquals(StackItemType.BYTE_STRING, rawItem.getType());
@@ -322,6 +339,23 @@ public class StackItemTest extends ResponseTester {
         assertTrue(item.isEmpty());
 
         other = new MapStackItem(new HashMap<>());
+        assertEquals(other, item);
+        assertEquals(other.hashCode(), item.hashCode());
+    }
+
+    @Test
+    public void testDeserializeInteropInterfaceStackItem() throws IOException {
+        String json = ""
+                + " {"
+                + "   \"type\": \"InteropInterface\",\n"
+                + "   \"value\": \"dGVzdGluZw==\"\n"
+                + " }";
+        StackItem rawItem = OBJECT_MAPPER.readValue(json, StackItem.class);
+        assertThat(rawItem.getType(), is(StackItemType.INTEROP_INTERFACE));
+        InteropInterfaceStackItem item = rawItem.asInteropInterface();
+        assertThat(item.getValue(), is("dGVzdGluZw=="));
+
+        InteropInterfaceStackItem other = new InteropInterfaceStackItem("dGVzdGluZw==");
         assertEquals(other, item);
         assertEquals(other.hashCode(), item.hashCode());
     }

--- a/core/src/test/java/io/neow3j/protocol/rx/JsonRpc2_0RxTest.java
+++ b/core/src/test/java/io/neow3j/protocol/rx/JsonRpc2_0RxTest.java
@@ -5,11 +5,10 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.eq;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 
 import io.neow3j.protocol.Neow3j;
 import io.neow3j.protocol.Neow3jService;
@@ -30,7 +29,6 @@ import java.util.concurrent.TimeUnit;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
-import org.mockito.internal.matchers.apachecommons.ReflectionEquals;
 import org.mockito.stubbing.OngoingStubbing;
 
 public class JsonRpc2_0RxTest {

--- a/model/src/main/java/io/neow3j/model/types/StackItemType.java
+++ b/model/src/main/java/io/neow3j/model/types/StackItemType.java
@@ -32,8 +32,8 @@ public enum StackItemType {
     public static final byte BYTE_STRING_CODE = 0x28;
     public static final byte BUFFER_CODE = 0x30;
 
-    private String jsonValue;
-    private byte byteValue;
+    private final String jsonValue;
+    private final byte byteValue;
 
     StackItemType(String jsonValue, int v) {
         this.jsonValue = jsonValue;
@@ -59,7 +59,8 @@ public enum StackItemType {
                 return e;
             }
         }
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("There exists no stack item with the provided byte value." +
+                " The provided byte value was " + byteValue + ".");
     }
 
     public static StackItemType fromJsonValue(String jsonValue) {
@@ -68,6 +69,7 @@ public enum StackItemType {
                 return e;
             }
         }
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("There exists no stack item with the provided json value." +
+                " The provided json value was " + jsonValue + ".");
     }
 }


### PR DESCRIPTION
Corrected the return types to StackItem subtypes of `asAny` and `asInteropInterface`.
Updated dependency testcontainers-java to latest released version (1.15.0). 
Changed deprecated import `Mockito.Matchers` to `Mockito.ArgumentMatchers`.

Closes #228 #252 