### PR TITLE
Shift Base64 encoding/decoding of byte array ContractParameters to the JSON serializer/deserializer

### DIFF
--- a/compiler/src/test-integration/java/io/neow3j/compiler/BinaryTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/BinaryTest.java
@@ -1,12 +1,13 @@
 package io.neow3j.compiler;
 
 import static io.neow3j.contract.ContractParameter.bool;
-import static io.neow3j.contract.ContractParameter.byteArrayAsBase64;
+import static io.neow3j.contract.ContractParameter.byteArray;
 import static io.neow3j.contract.ContractParameter.integer;
 import static io.neow3j.contract.ContractParameter.string;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
+import io.neow3j.contract.ContractParameter;
 import io.neow3j.devpack.neo.Binary;
 import io.neow3j.model.types.StackItemType;
 import io.neow3j.protocol.core.methods.response.NeoInvokeFunction;
@@ -56,7 +57,7 @@ public class BinaryTest extends ContractTest {
     public void base64Encode() throws IOException {
         String bytes =
                 "54686520717569636b2062726f776e20666f78206a756d7073206f766572203133206c617a7920646f67732e";
-        NeoInvokeFunction response = callInvokeFunction(byteArrayAsBase64(bytes));
+        NeoInvokeFunction response = callInvokeFunction(ContractParameter.byteArray(bytes));
         String encoded = response.getInvocationResult().getStack().get(0).asByteString()
                 .getAsString();
         String expected = "VGhlIHF1aWNrIGJyb3duIGZveCBqdW1wcyBvdmVyIDEzIGxhenkgZG9ncy4=";

--- a/compiler/src/test-integration/java/io/neow3j/compiler/ByteArrayTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ByteArrayTest.java
@@ -45,7 +45,7 @@ public class ByteArrayTest extends ContractTest {
 
     @Test
     public void getAndSetSingleByte() throws IOException {
-        NeoInvokeFunction response = callInvokeFunction(ContractParameter.byteArrayAsBase64("01020304"));
+        NeoInvokeFunction response = callInvokeFunction(ContractParameter.byteArray("01020304"));
         StackItem result = response.getInvocationResult().getStack().get(0);
         assertThat(result.getType(), is(StackItemType.BUFFER));
         assertThat(result.asBuffer().getValue(), is(new byte[]{0x00, 0x00, 0x01, 0x00, 0x00}));

--- a/compiler/src/test-integration/java/io/neow3j/compiler/StringConcatenationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/StringConcatenationTest.java
@@ -34,7 +34,7 @@ public class StringConcatenationTest extends ContractTest {
         NeoInvokeFunction response = callInvokeFunction(
                 ContractParameter.string("one"),
                 ContractParameter.string("two"),
-                ContractParameter.byteArrayAsBase64("4e656f")); // byte array representation of "Neo".
+                ContractParameter.byteArray("4e656f")); // byte array representation of "Neo".
 
         assertThat(response.getInvocationResult().getStack().get(0).asByteString().getAsString(),
                 is("onetwothreeNeoNEO"));

--- a/contract/src/main/java/io/neow3j/contract/NFToken.java
+++ b/contract/src/main/java/io/neow3j/contract/NFToken.java
@@ -141,7 +141,7 @@ public class NFToken extends Token {
     // TODO: 15.10.20 Michael: Adapt this method as soon as an implementation of the NEP-11 proposal exists.
     public List<ScriptHash> ownerOf(byte[] tokenID) throws IOException {
         return callFunctionReturningListOfScriptHashes(OWNER_OF,
-                Arrays.asList(ContractParameter.byteArrayAsBase64(tokenID)));
+                Arrays.asList(ContractParameter.byteArray(tokenID)));
     }
 
     private List<ScriptHash> callFunctionReturningListOfScriptHashes(String function,
@@ -191,7 +191,7 @@ public class NFToken extends Token {
     public BigInteger balanceOf(ScriptHash owner, byte[] tokenID) throws IOException {
         return callFuncReturningInt(BALANCE_OF,
                 ContractParameter.hash160(owner),
-                ContractParameter.byteArrayAsBase64(tokenID));
+                ContractParameter.byteArray(tokenID));
     }
 
     /**
@@ -213,7 +213,7 @@ public class NFToken extends Token {
      */
     public NFTokenProperties properties(byte[] tokenID) throws IOException {
         StackItem item = callInvokeFunction(PROPERTIES,
-                Arrays.asList(ContractParameter.byteArrayAsBase64(tokenID)))
+                Arrays.asList(ContractParameter.byteArray(tokenID)))
                 .getInvocationResult().getStack().get(0);
         if (item.getType().equals(StackItemType.BYTE_STRING)) {
             return item.asByteString().getAsJson(NFTokenProperties.class);

--- a/utils/src/main/java/io/neow3j/contract/ContractParameter.java
+++ b/utils/src/main/java/io/neow3j/contract/ContractParameter.java
@@ -75,8 +75,7 @@ public class ContractParameter {
     /**
      * Creates a byte array parameter from the given value.
      * <p>
-     * Make sure that the array is already in the right order. E.g. Fixed8 numbers need to be in
-     * little-endian order. It will be sent in the order provided.
+     * Make sure that the array is in the right byte order, i.e., endianness.
      *
      * @param byteArray The parameter value.
      * @return the contract parameter.
@@ -86,31 +85,16 @@ public class ContractParameter {
     }
 
     /**
-     * Creates a byte array parameter from the given value. Base64 encodes the given byte array.
-     * <p>
-     * Use this for RPC calls to neo-nodes.
-     * <p>
-     * Make sure that the array is already in the right order. E.g. Fixed8 numbers need to be in
-     * little-endian order. It will be sent in the order provided.
-     *
-     * @param byteArray The parameter value.
-     * @return the contract parameter.
-     */
-    public static ContractParameter byteArrayAsBase64(byte[] byteArray) {
-        return new ContractParameter(ContractParameterType.BYTE_ARRAY, Base64.encode(byteArray));
-    }
-
-    /**
      * Creates a byte array parameter from the given hex string.
      *
      * @param hexString The hexadecimal string.
      * @return the contract parameter.
      */
-    public static ContractParameter byteArrayAsBase64(String hexString) {
+    public static ContractParameter byteArray(String hexString) {
         if (!Numeric.isValidHexString(hexString)) {
             throw new IllegalArgumentException("Argument is not a valid hex number");
         }
-        return byteArrayAsBase64(Numeric.hexStringToByteArray(hexString));
+        return byteArray(Numeric.hexStringToByteArray(hexString));
     }
 
     /**
@@ -121,7 +105,7 @@ public class ContractParameter {
      * @return the contract parameter.
      */
     public static ContractParameter byteArrayFromString(String value) {
-        return byteArrayAsBase64(value.getBytes(UTF_8));
+        return byteArray(value.getBytes(UTF_8));
     }
 
     /**
@@ -327,7 +311,7 @@ public class ContractParameter {
                     break;
                 case BYTE_ARRAY:
                     // The value is expected to be a Base64 encoded byte array.
-                    gen.writeStringField("value", ((String) p.getValue()));
+                    gen.writeStringField("value", Base64.encode((byte[]) p.getValue()));
                     break;
                 case BOOLEAN:
                     // Convert to true or false without quotes

--- a/utils/src/main/java/io/neow3j/contract/ContractParameter.java
+++ b/utils/src/main/java/io/neow3j/contract/ContractParameter.java
@@ -310,7 +310,6 @@ public class ContractParameter {
                             Numeric.toHexStringNoPrefix((byte[]) p.getValue()));
                     break;
                 case BYTE_ARRAY:
-                    // The value is expected to be a Base64 encoded byte array.
                     gen.writeStringField("value", Base64.encode((byte[]) p.getValue()));
                     break;
                 case BOOLEAN:

--- a/utils/src/test/java/io/neow3j/contract/ContractParameterTest.java
+++ b/utils/src/test/java/io/neow3j/contract/ContractParameterTest.java
@@ -37,37 +37,36 @@ public class ContractParameterTest {
     @Test
     public void testByteArrayParamCreation() {
         byte[] bytes = new byte[]{0x01, 0x01};
-        ContractParameter p = ContractParameter.byteArrayAsBase64(bytes);
-        assertThat((String) p.getValue(), is(Base64.encode(bytes)));
+        ContractParameter p = ContractParameter.byteArray(bytes);
+        assertThat((byte[]) p.getValue(), is(bytes));
         assertEquals(ContractParameterType.BYTE_ARRAY, p.getParamType());
     }
 
     @Test
     public void testByteArrayParamCreationFromHexString() {
-        ContractParameter p = ContractParameter.byteArrayAsBase64("0xa602");
-        assertThat(Base64.decode((String) p.getValue()), is(new byte[]{(byte) 0xa6, 0x02}));
+        ContractParameter p = ContractParameter.byteArray("0xa602");
+        assertThat((byte[]) p.getValue(), is(new byte[]{(byte) 0xa6, 0x02}));
         assertEquals(ContractParameterType.BYTE_ARRAY, p.getParamType());
     }
 
     @Test
     public void testByteArrayParamCreationFromString() {
         ContractParameter p =ContractParameter.byteArrayFromString("Neo");
-        assertThat(Base64.decode((String) p.getValue()),
-        is(new byte[] {(byte) 0x4e, (byte) 0x65, (byte) 0x6f}));
+        assertThat(((byte[]) p.getValue()), is(new byte[] {(byte) 0x4e, (byte) 0x65, (byte) 0x6f}));
         assertEquals(ContractParameterType.BYTE_ARRAY, p.getParamType());
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void testByteArrayParamCreationFromInvalidHexString() {
         String value = "value";
-        ContractParameter.byteArrayAsBase64(value);
+        ContractParameter.byteArray(value);
     }
 
     @Test
     public void testArrayParamCreationFromList() {
         List<ContractParameter> params = new ArrayList<>();
         ContractParameter p1 = ContractParameter.string("value");
-        ContractParameter p2 = ContractParameter.byteArrayAsBase64("0x0101");
+        ContractParameter p2 = ContractParameter.byteArray("0x0101");
         params.add(p1);
         params.add(p2);
         ContractParameter p = ContractParameter.array(params);
@@ -81,7 +80,7 @@ public class ContractParameterTest {
     @Test
     public void testArrayParamCreationFromArray() {
         ContractParameter p1 = ContractParameter.string("value");
-        ContractParameter p2 = ContractParameter.byteArrayAsBase64("0x0101");
+        ContractParameter p2 = ContractParameter.byteArray("0x0101");
         ContractParameter p = ContractParameter.array(p1, p2);
 
         assertEquals(ContractParameterType.ARRAY, p.getParamType());


### PR DESCRIPTION
@mialbu and I had to adapt the byte array ContractParameter creation method not too long ago because of a bug. I stumbled upon this change again and realized it can be done a bit prettier by putting the Base64 encoding into the `ContractParameter` serializer/deserializer.