### PR TITLE
Devpack helper methods

### DIFF
--- a/compiler/src/test-integration/java/io/neow3j/compiler/HelperTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/HelperTest.java
@@ -1,0 +1,350 @@
+package io.neow3j.compiler;
+
+import static io.neow3j.contract.ContractParameter.bool;
+import static io.neow3j.contract.ContractParameter.byteArray;
+import static io.neow3j.contract.ContractParameter.integer;
+import static io.neow3j.contract.ContractParameter.string;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThat;
+
+import io.neow3j.devpack.Helper;
+import io.neow3j.model.types.StackItemType;
+import io.neow3j.protocol.core.methods.response.NeoInvokeFunction;
+import io.neow3j.utils.Numeric;
+import java.io.IOException;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+
+public class HelperTest extends ContractTest {
+
+    @BeforeClass
+    public static void setUp() throws Throwable {
+        setUp(HelpersContract.class.getName());
+    }
+
+    @Test
+    public void assertTrue() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(bool(true));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_HALT));
+
+        response = callInvokeFunction(bool(false));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+    }
+
+    @Test
+    public void abort() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(bool(false));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_HALT));
+
+        response = callInvokeFunction(bool(true));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+    }
+
+    @Test
+    public void toByteArrayFromByte() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction();
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BUFFER));
+        assertThat(response.getInvocationResult().getStack().get(0).asBuffer().getValue(),
+                is(new byte[]{8}));
+    }
+
+    @Test
+    public void toByteArrayFromString() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(string("hello, world!"));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BUFFER));
+        assertThat(response.getInvocationResult().getStack().get(0).asBuffer().getAsString(),
+                is("hello, world!"));
+    }
+
+    @Test
+    public void asByte() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(integer(-128));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_HALT));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(-128));
+
+        response = callInvokeFunction(integer(127));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_HALT));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(127));
+
+        response = callInvokeFunction(integer(128));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+
+        response = callInvokeFunction(integer(-129));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+    }
+
+    @Test
+    public void asSignedByte() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(integer(127));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(127));
+
+        response = callInvokeFunction(integer(128));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(-128));
+
+        response = callInvokeFunction(integer(255));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(-1));
+
+        response = callInvokeFunction(integer(0));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(0));
+
+        response = callInvokeFunction(integer(-1));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+
+        response = callInvokeFunction(integer(256));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+    }
+
+    @Test
+    public void toInt() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(byteArray(new byte[]{(byte) 0x80}));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(-128));
+
+        response = callInvokeFunction(byteArray(new byte[]{(byte) 0xff, (byte) 0x80}));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(-32513));
+
+        response = callInvokeFunction(byteArray(new byte[]{}));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(0));
+
+        response = callInvokeFunction(byteArray(new byte[]{(byte) 0xff, 0}));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(255));
+
+        response = callInvokeFunction(byteArray(new byte[]{(byte) 0xfb, (byte) 0xa6, 0}));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asInteger().getValue().intValue(),
+                is(42747));
+    }
+
+    @Test
+    public void toByteString() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(byteArray("68656c6c6f2c20776f726c6421"));
+        assertThat(
+                response.getInvocationResult().getStack().get(0).asByteString().getAsString(),
+                is("hello, world!"));
+    }
+
+    @Test
+    public void within() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(integer(1), integer(0), integer(3));
+        Assert.assertTrue(response.getInvocationResult().getStack().get(0).asBoolean().getValue());
+
+        response = callInvokeFunction(integer(1), integer(2), integer(3));
+        assertFalse(response.getInvocationResult().getStack().get(0).asBoolean().getValue());
+
+        response = callInvokeFunction(integer(1), integer(-20), integer(0));
+        assertFalse(response.getInvocationResult().getStack().get(0).asBoolean().getValue());
+    }
+
+    @Test
+    public void concatByteArray() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(byteArray("0102"), byteArray("0304"));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BUFFER));
+        assertThat(response.getInvocationResult().getStack().get(0).asBuffer().getValue(),
+                is(Numeric.hexStringToByteArray("01020304")));
+    }
+
+    @Test
+    public void concatByteString() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(string("hello"), string(", world!"));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BYTE_STRING));
+        assertThat(response.getInvocationResult().getStack().get(0).asByteString().getAsString(),
+                is("hello, world!"));
+    }
+
+    @Test
+    public void rangeOfByteArray() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(
+                byteArray("010203040506"), integer(1), integer(4));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BUFFER));
+        assertThat(response.getInvocationResult().getStack().get(0).asBuffer().getValue(),
+                is(new byte[]{0x02, 0x03, 0x04, 0x05}));
+    }
+
+    @Test
+    public void rangeOfByteString() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(string("hello, world!"), integer(1),
+                integer(4));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BYTE_STRING));
+        assertThat(response.getInvocationResult().getStack().get(0).asByteString().getAsString(),
+                is("ello"));
+    }
+
+    @Test
+    public void takeFromByteArray() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(byteArray("010203040506"), integer(2));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BUFFER));
+        assertThat(response.getInvocationResult().getStack().get(0).asBuffer().getValue(),
+                is(new byte[]{0x01, 0x02}));
+
+        response = callInvokeFunction(byteArray("010203040506"), integer(-1));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+    }
+
+    @Test
+    public void takeFromByteString() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(string("hello, world!"), integer(7));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BYTE_STRING));
+        assertThat(response.getInvocationResult().getStack().get(0).asByteString().getAsString(),
+                is("hello, "));
+
+        response = callInvokeFunction(string("hello, world!"), integer(-1));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+    }
+
+    @Test
+    public void lastFromByteArray() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(byteArray("010203040506"), integer(2));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BUFFER));
+        assertThat(response.getInvocationResult().getStack().get(0).asBuffer().getValue(),
+                is(new byte[]{0x05, 0x06}));
+
+        response = callInvokeFunction(byteArray("010203040506"), integer(-1));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+    }
+
+    @Test
+    public void lastFromByteString() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(string("hello, world!"), integer(7));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BYTE_STRING));
+        assertThat(response.getInvocationResult().getStack().get(0).asByteString().getAsString(),
+                is(" world!"));
+
+        response = callInvokeFunction(string("hello, world!"), integer(-1));
+        assertThat(response.getInvocationResult().getState(), is(VM_STATE_FAULT));
+    }
+
+    @Test
+    @Ignore("This doesn't work yet because with neo3-preview3 the byte array parameter is not "
+            + "a Buffer StackItem on the neo-vm (but a ByteString). The reverse method therefore "
+            + "fails because it doesn't operate on ByteString. Test again with neo3-preview4.")
+    public void reverseByteArray() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(byteArray("010203040506"));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BUFFER));
+        assertThat(response.getInvocationResult().getStack().get(0).asBuffer().getValue(),
+                is(Numeric.hexStringToByteArray("060504030201")));
+    }
+
+    @Test
+    public void reverseByteString() throws IOException {
+        NeoInvokeFunction response = callInvokeFunction(string("hello, world!"));
+        assertThat(response.getInvocationResult().getStack().get(0).getType(),
+                is(StackItemType.BYTE_STRING));
+        assertThat(response.getInvocationResult().getStack().get(0).asByteString().getAsString(),
+                is("!dlrow ,olleh"));
+    }
+
+    static class HelpersContract {
+
+        public static void assertTrue(boolean bool) {
+            Helper.assertTrue(bool);
+        }
+
+        public static void abort(boolean bool) {
+            if (bool) {
+                Helper.abort();
+            }
+        }
+
+        public static byte[] toByteArrayFromByte() {
+            return Helper.toByteArray((byte) 8);
+        }
+
+        public static byte[] toByteArrayFromString(String s) {
+            return Helper.toByteArray(s);
+        }
+
+        public static byte asByte(int i) {
+            return Helper.asByte(i);
+        }
+
+        public static byte asSignedByte(int i) {
+            return Helper.asSignedByte(i);
+        }
+
+        public static int toInt(byte[] bytes) {
+            return Helper.toInt(bytes);
+        }
+
+        public static String toByteString(byte[] bytes) {
+            return Helper.toByteString(bytes);
+        }
+
+        public static boolean within(int i1, int i2, int i3) {
+            return Helper.within(i1, i2, i3);
+        }
+
+        public static byte[] concatByteArray(byte[] b1, byte[] b2) {
+            return Helper.concat(b1, b2);
+        }
+
+        public static String concatByteString(String s1, String s2) {
+            return Helper.concat(s1, s2);
+        }
+
+        public static byte[] rangeOfByteArray(byte[] b, int i1, int i2) {
+            return Helper.range(b, i1, i2);
+        }
+
+        public static String rangeOfByteString(String s, int i1, int i2) {
+            return Helper.range(s, i1, i2);
+        }
+
+        public static byte[] takeFromByteArray(byte[] b, int i) {
+            return Helper.take(b, i);
+        }
+
+        public static String takeFromByteString(String s, int i) {
+            return Helper.take(s, i);
+        }
+
+        public static byte[] lastFromByteArray(byte[] b, int i) {
+            return Helper.last(b, i);
+        }
+
+        public static String lastFromByteString(String s, int i) {
+            return Helper.last(s, i);
+        }
+
+        public static byte[] reverseByteArray(byte[] b) {
+            return Helper.reverse(b);
+        }
+
+        public static String reverseByteString(String s) {
+            return Helper.reverse(s);
+        }
+    }
+
+}

--- a/devpack/src/main/java/io/neow3j/devpack/Helper.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Helper.java
@@ -3,6 +3,7 @@ package io.neow3j.devpack;
 import io.neow3j.constants.OpCode;
 import io.neow3j.devpack.annotations.Instruction;
 import io.neow3j.model.types.StackItemType;
+import io.neow3j.protocol.core.methods.response.StackItem;
 
 /**
  * Provides helper methods to be used in a smart contract.
@@ -102,15 +103,20 @@ public class Helper {
     }
 
     /**
-     * Converts the given byte array to an integer. No checks are made regarding the value range of
-     * integers.
+     * Converts the given byte array to an integer. The byte array is assumed to be a two's
+     * complement in little-endian format.
+     * <p>
+     * The value of the converted integer can be outside of {@link Integer#MAX_VALUE} because the
+     * neo-vm doesn't have that limit for {@code int} as the JVM has.
      * <p>
      * Examples
      * <ul>
      *  <li>[0x0a]: 10</li>
      *  <li>[0x80]: -128</li>
+     *  <li>[0xff80]: -32513</li>
      *  <li>[]: 0</li>
      *  <li>[0xff00]: 255</li>
+     *  <li>[0xfba600]: 42747</li>
      * </ul>
      *
      * @param source The byte array to convert.
@@ -168,6 +174,29 @@ public class Helper {
     public static native byte[] concat(byte[] first, byte[] second);
 
     /**
+     * Concatenates the two given strings.
+     *
+     * @param first  The first string.
+     * @param second The second string.
+     * @return the concatenation.
+     */
+    @Instruction(opcode = OpCode.CAT)
+    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
+    public static native String concat(String first, String second);
+
+    /**
+     * Returns n consecutive characters from the given string starting at the given index.
+     *
+     * @param source The string to take the bytes from.
+     * @param index  The start index of the range (inclusive).
+     * @param n      The size of the range, i.e. number of characters to take.
+     * @return the defined range of the given string.
+     */
+    @Instruction(opcode = OpCode.SUBSTR)
+    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
+    public static native String range(String source, int index, int n);
+
+    /**
      * Returns n consecutive bytes from the given source starting at the given index.
      *
      * @param source The array to take the bytes from.
@@ -189,7 +218,18 @@ public class Helper {
     public static native byte[] take(byte[] source, int n);
 
     /**
-     * Returns the last n elements from the given byte array. Faults if {@code n} &lt; 0.
+     * Returns the first n characters from the given string. Faults if {@code n} &lt; 0.
+     *
+     * @param source The string to take the characters from.
+     * @param n      The number of characters to return.
+     * @return the first n characters.
+     */
+    @Instruction(opcode = OpCode.LEFT)
+    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
+    public static native String take(String source, int n);
+
+    /**
+     * Returns the last n elements of the given byte array. Faults if {@code n} &lt; 0.
      *
      * @param source The array to take the bytes from.
      * @param n      The number of bytes to return.
@@ -197,6 +237,17 @@ public class Helper {
      */
     @Instruction(opcode = OpCode.RIGHT)
     public static native byte[] last(byte[] source, int n);
+
+    /**
+     * Returns the last n characters of the given String. Faults if {@code n} &lt; 0.
+     *
+     * @param source The string.
+     * @param n      The number characters to return.
+     * @return the last n characters.
+     */
+    @Instruction(opcode = OpCode.RIGHT)
+    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
+    public static native String last(String source, int n);
 
     /**
      * Returns a reversed copy of the given bytes. Example: [0a,0b,0c,0d,0e]: [0e,0d,0c,0b,0a]
@@ -207,5 +258,17 @@ public class Helper {
     @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.REVERSEITEMS)
     public static native byte[] reverse(byte[] source);
+
+    /**
+     * Returns a reversed copy of the given string.
+     *
+     * @param source The string to reverse.
+     * @return The reversed string.
+     */
+    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BUFFER_CODE)
+    @Instruction(opcode = OpCode.DUP)
+    @Instruction(opcode = OpCode.REVERSEITEMS)
+    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
+    public static native String reverse(String source);
 
 }


### PR DESCRIPTION
Cover helper methods with unit tests.
Added a couple of new methods that manipulate strings and already existed for byte arrays.