### PR TITLE
Decimals check for transfers

### DIFF
--- a/contract/src/main/java/io/neow3j/contract/Nep5Token.java
+++ b/contract/src/main/java/io/neow3j/contract/Nep5Token.java
@@ -162,6 +162,11 @@ public class Nep5Token extends Token {
             throw new IllegalArgumentException(
                     "The parameter amount must be greater than or equal to 0");
         }
+        if (!amountDecimalsIsValid(amount)) {
+            throw new IllegalArgumentException("The amount contains more decimal places than this token " +
+                    "can handle. This token has " + getDecimals() + " decimals. The amount provided " +
+                    "had " + amount.stripTrailingZeros().scale() + " decimal places.");
+        }
 
         List<Account> accountsOrdered = new ArrayList<>(wallet.getAccounts());
         accountsOrdered.remove(wallet.getDefaultAccount());
@@ -216,6 +221,11 @@ public class Nep5Token extends Token {
         if (amount.signum() < 0) {
             throw new IllegalArgumentException(
                     "The parameter amount must be greater than or equal to 0");
+        }
+        if (!amountDecimalsIsValid(amount)) {
+            throw new IllegalArgumentException("The amount contains more decimal places than this token " +
+                    "can handle. This token has " + getDecimals() + " decimals. The amount provided " +
+                    "had " + amount.stripTrailingZeros().scale() + " decimal places.");
         }
 
         List<Account> accounts = new ArrayList<>();
@@ -329,8 +339,12 @@ public class Nep5Token extends Token {
     public TransactionBuilder transferFromDefaultAccount(Wallet wallet, ScriptHash to,
             BigDecimal amount) throws IOException {
         if (amount.signum() < 0) {
-            throw new IllegalArgumentException(
-                    "The parameter amount must be greater than or equal to 0");
+            throw new IllegalArgumentException("The amount must be greater than or equal to 0.");
+        }
+        if (!amountDecimalsIsValid(amount)) {
+            throw new IllegalArgumentException("The amount contains more decimal places than this token " +
+                    "can handle. This token has " + getDecimals() + " decimals. The amount provided " +
+                    "had " + amount.stripTrailingZeros().scale() + " decimal places.");
         }
 
         Account acc = wallet.getDefaultAccount();
@@ -348,5 +362,9 @@ public class Nep5Token extends Token {
                 ContractParameter.integer(fractions))
                 .wallet(wallet)
                 .signers(Signer.calledByEntry(acc.getScriptHash()));
+    }
+
+    private boolean amountDecimalsIsValid(BigDecimal amount) throws IOException {
+        return amount.stripTrailingZeros().scale() <= getDecimals();
     }
 }

--- a/contract/src/main/java/io/neow3j/contract/Token.java
+++ b/contract/src/main/java/io/neow3j/contract/Token.java
@@ -16,7 +16,6 @@ public class Token extends SmartContract {
     private static final String TOTAL_SUPPLY = "totalSupply";
     private static final String SYMBOL = "symbol";
     private static final String DECIMALS = "decimals";
-    private static final String TRANSFER = "transfer";
 
     private String name;
     // It is expected that token contracts return the total supply in fractions of their token.
@@ -41,6 +40,14 @@ public class Token extends SmartContract {
      *                                       interpretable as a string.
      */
     public String getName() throws IOException, UnexpectedReturnTypeException {
+        if (isNeoToken()) {
+            name = NeoToken.NAME;
+            return name;
+        }
+        if (isGasToken()) {
+            name = GasToken.NAME;
+            return name;
+        }
         if (name == null) {
             name = callFuncReturningString(NAME);
         }
@@ -59,6 +66,14 @@ public class Token extends SmartContract {
      *                                       interpretable as a string.
      */
     public String getSymbol() throws IOException, UnexpectedReturnTypeException {
+        if (isNeoToken()) {
+            symbol = NeoToken.SYMBOL;
+            return symbol;
+        }
+        if (isGasToken()) {
+            symbol = GasToken.SYMBOL;
+            return symbol;
+        }
         if (symbol == null) {
             symbol = callFuncReturningString(SYMBOL);
         }
@@ -77,6 +92,10 @@ public class Token extends SmartContract {
      *                                       interpretable as a number.
      */
     public BigInteger getTotalSupply() throws IOException, UnexpectedReturnTypeException {
+        if (isNeoToken()) {
+            totalSupply = NeoToken.TOTAL_SUPPLY;
+            return totalSupply;
+        }
         if (totalSupply == null) {
             totalSupply = callFuncReturningInt(TOTAL_SUPPLY);
         }
@@ -95,6 +114,14 @@ public class Token extends SmartContract {
      *                                       interpretable as a number.
      */
     public int getDecimals() throws IOException, UnexpectedReturnTypeException {
+        if (isNeoToken()) {
+            decimals = NeoToken.DECIMALS;
+            return decimals;
+        }
+        if (isGasToken()) {
+            decimals = GasToken.DECIMALS;
+            return decimals;
+        }
         if (decimals == null) {
             decimals = callFuncReturningInt(DECIMALS).intValue();
         }
@@ -124,5 +151,13 @@ public class Token extends SmartContract {
         BigDecimal a = new BigDecimal(amount);
         BigDecimal divisor = BigDecimal.TEN.pow(getDecimals());
         return a.divide(divisor);
+    }
+
+    private boolean isNeoToken() {
+        return scriptHash.equals(NeoToken.SCRIPT_HASH);
+    }
+
+    private boolean isGasToken() {
+        return scriptHash.equals(GasToken.SCRIPT_HASH);
     }
 }

--- a/contract/src/main/java/io/neow3j/contract/Token.java
+++ b/contract/src/main/java/io/neow3j/contract/Token.java
@@ -40,14 +40,6 @@ public class Token extends SmartContract {
      *                                       interpretable as a string.
      */
     public String getName() throws IOException, UnexpectedReturnTypeException {
-        if (isNeoToken()) {
-            name = NeoToken.NAME;
-            return name;
-        }
-        if (isGasToken()) {
-            name = GasToken.NAME;
-            return name;
-        }
         if (name == null) {
             name = callFuncReturningString(NAME);
         }
@@ -66,14 +58,6 @@ public class Token extends SmartContract {
      *                                       interpretable as a string.
      */
     public String getSymbol() throws IOException, UnexpectedReturnTypeException {
-        if (isNeoToken()) {
-            symbol = NeoToken.SYMBOL;
-            return symbol;
-        }
-        if (isGasToken()) {
-            symbol = GasToken.SYMBOL;
-            return symbol;
-        }
         if (symbol == null) {
             symbol = callFuncReturningString(SYMBOL);
         }
@@ -92,10 +76,6 @@ public class Token extends SmartContract {
      *                                       interpretable as a number.
      */
     public BigInteger getTotalSupply() throws IOException, UnexpectedReturnTypeException {
-        if (isNeoToken()) {
-            totalSupply = NeoToken.TOTAL_SUPPLY;
-            return totalSupply;
-        }
         if (totalSupply == null) {
             totalSupply = callFuncReturningInt(TOTAL_SUPPLY);
         }
@@ -114,14 +94,6 @@ public class Token extends SmartContract {
      *                                       interpretable as a number.
      */
     public int getDecimals() throws IOException, UnexpectedReturnTypeException {
-        if (isNeoToken()) {
-            decimals = NeoToken.DECIMALS;
-            return decimals;
-        }
-        if (isGasToken()) {
-            decimals = GasToken.DECIMALS;
-            return decimals;
-        }
         if (decimals == null) {
             decimals = callFuncReturningInt(DECIMALS).intValue();
         }
@@ -151,13 +123,5 @@ public class Token extends SmartContract {
         BigDecimal a = new BigDecimal(amount);
         BigDecimal divisor = BigDecimal.TEN.pow(getDecimals());
         return a.divide(divisor);
-    }
-
-    private boolean isNeoToken() {
-        return scriptHash.equals(NeoToken.SCRIPT_HASH);
-    }
-
-    private boolean isGasToken() {
-        return scriptHash.equals(GasToken.SCRIPT_HASH);
     }
 }

--- a/contract/src/test/java/io/neow3j/contract/Nep5TokenTest.java
+++ b/contract/src/test/java/io/neow3j/contract/Nep5TokenTest.java
@@ -6,6 +6,7 @@ import static io.neow3j.contract.ContractTestHelper.setUpWireMockForCall;
 import static io.neow3j.contract.ContractTestHelper.setUpWireMockForGetBlockCount;
 import static io.neow3j.contract.ContractTestHelper.setUpWireMockForInvokeFunction;
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -19,6 +20,8 @@ import io.neow3j.utils.Numeric;
 import io.neow3j.wallet.Account;
 import io.neow3j.wallet.Wallet;
 import io.neow3j.wallet.exceptions.InsufficientFundsException;
+
+import java.awt.*;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -26,11 +29,15 @@ import java.util.Arrays;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
 public class Nep5TokenTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none();
 
     private Nep5Token neoToken;
     private Nep5Token gasToken;
@@ -73,7 +80,6 @@ public class Nep5TokenTest {
     @Test
     public void transferFromDefaultAccountShouldAddAccountAsSigner() throws Throwable {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals_gas.json");
         setUpWireMockForGetBlockCount(1000);
         setUpWireMockForBalanceOf(account1.getScriptHash(),
                 "invokefunction_balanceOf_300000000.json");
@@ -88,11 +94,27 @@ public class Nep5TokenTest {
     }
 
     @Test
+    public void transferFromDefaultAccountShouldAddAccountAsSigner_RecipientAsAddress() throws Throwable {
+        setUpWireMockForCall("invokescript", "invokescript_transfer.json");
+        setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForBalanceOf(account1.getScriptHash(),
+                "invokefunction_balanceOf_300000000.json");
+
+        Transaction tx = gasToken.transferFromDefaultAccount(Wallet.withAccounts(account1),
+                RECIPIENT_SCRIPT_HASH.toAddress(), BigDecimal.ONE)
+                .buildTransaction();
+
+        assertThat(tx.getSigners().get(0).getScriptHash(), is(account1.getScriptHash()));
+        assertThat(tx.getSigners().get(0).getScopes().get(0), is(WitnessScope.CALLED_BY_ENTRY));
+        assertThat(tx.getSender(), is(account1.getScriptHash()));
+    }
+
+    @Test
     public void transferFromDefaultAccountShouldCreateTheCorrectScript() throws Throwable {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals_gas.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("balanceOf", "invokefunction_balanceOf_300000000.json");
+        setUpWireMockForInvokeFunction("balanceOf",
+                "invokefunction_balanceOf_300000000.json");
 
         byte[] expectedScript = new ScriptBuilder().contractCall(GAS_TOKEN_SCRIPT_HASH,
                 NEP5_TRANSFER, Arrays.asList(
@@ -102,6 +124,26 @@ public class Nep5TokenTest {
 
         Transaction tx = gasToken.transferFromDefaultAccount(Wallet.withAccounts(account1, account2),
                 RECIPIENT_SCRIPT_HASH, BigDecimal.ONE)
+                .buildTransaction();
+
+        assertThat(tx.getScript(), is(expectedScript));
+    }
+
+    @Test
+    public void transferFromSpecificAccount_RecipientAsAddress() throws Throwable {
+        setUpWireMockForCall("invokescript", "invokescript_transfer.json");
+        setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("balanceOf",
+                "invokefunction_balanceOf_300000000.json");
+
+        byte[] expectedScript = new ScriptBuilder().contractCall(GAS_TOKEN_SCRIPT_HASH,
+                NEP5_TRANSFER, Arrays.asList(
+                        ContractParameter.hash160(account1.getScriptHash()),
+                        ContractParameter.hash160(RECIPIENT_SCRIPT_HASH),
+                        ContractParameter.integer(100000000))).toArray(); // 1 GAS
+
+        Transaction tx = gasToken.transferFromSpecificAccounts(Wallet.withAccounts(account1, account2),
+                RECIPIENT_SCRIPT_HASH.toAddress(), BigDecimal.ONE, account1.getScriptHash())
                 .buildTransaction();
 
         assertThat(tx.getScript(), is(expectedScript));
@@ -141,22 +183,67 @@ public class Nep5TokenTest {
                 is(new BigInteger("600000000")));
     }
 
-    @Test(expected = InsufficientFundsException.class)
+    @Test
     public void testFailTransferFromDefaultAccount_InsufficientBalance() throws Exception {
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals_gas.json");
         setUpWireMockForGetBlockCount(1000);
         setUpWireMockForBalanceOf(account1.getScriptHash(),
                 "invokefunction_balanceOf_300000000.json");
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
 
+        exceptionRule.expect(InsufficientFundsException.class);
+        exceptionRule.expectMessage("default account does not hold enough tokens");
         gasToken.transferFromDefaultAccount(Wallet.withAccounts(account1), RECIPIENT_SCRIPT_HASH,
                 new BigDecimal("4"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testTransferFromDefaultAccount_negativeAmount() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("amount must be greater than or equal to 0");
         neoToken.transferFromDefaultAccount(Wallet.withAccounts(account1), RECIPIENT_SCRIPT_HASH,
                 new BigDecimal("-1"));
+    }
+
+    @Test
+    public void testTransferInvalidDecimalsInAmount() throws Throwable {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("amount contains more decimal places than this token can handle");
+        neoToken.transferFromDefaultAccount(Wallet.withAccounts(account1),
+                RECIPIENT_SCRIPT_HASH, new BigDecimal("0.1"));
+    }
+
+    @Test
+    public void testTransferInvalidDecimalsInAmount_trailingZeros() throws IOException {
+        setUpWireMockForBalanceOf(account1.getScriptHash(),
+                "invokefunction_balanceOf_300000000.json");
+
+        // Trailing zeros should be ignored - this should not throw an exception.
+        neoToken.transferFromDefaultAccount(Wallet.withAccounts(account1),
+                RECIPIENT_SCRIPT_HASH, new BigDecimal("1.0"));
+    }
+
+    @Test
+    public void testInvalidDecimals_TransferFromDefaultAccount() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("amount contains more decimal places than this token can handle");
+        neoToken.transferFromDefaultAccount(Wallet.withAccounts(account1),
+                RECIPIENT_SCRIPT_HASH, new BigDecimal("1.1"));
+    }
+
+    @Test
+    public void testInvalidDecimals_TransferFromSpecificAccounts() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("amount contains more decimal places than this token can handle");
+        gasToken.transferFromSpecificAccounts(Wallet.withAccounts(account1), RECIPIENT_SCRIPT_HASH,
+                new BigDecimal("0.0000000002"), account1.getScriptHash());
+    }
+
+    @Test
+    public void testInvalidDecimals_Transfer() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("amount contains more decimal places than this token can handle");
+        neoToken.transfer(Wallet.withAccounts(account1), RECIPIENT_SCRIPT_HASH,
+                new BigDecimal("0.2"));
     }
 
     /*
@@ -175,7 +262,6 @@ public class Nep5TokenTest {
     public void testTransferWithTheFirstTwoAccountsNeededToCoverAmount() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
 
@@ -196,6 +282,31 @@ public class Nep5TokenTest {
         assertThat(b.getScript(), is(expectedScript));
     }
 
+    @Test
+    public void testTransferWithTheFirstTwoAccountsNeededToCoverAmount_RecipientAsAddress()
+            throws IOException {
+        setUpWireMockForCall("invokescript", "invokescript_transfer.json");
+        setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
+        setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
+
+        byte[] expectedScript = new ScriptBuilder()
+                .contractCall(NEO_TOKEN_SCRIPT_HASH,
+                        NEP5_TRANSFER, Arrays.asList(
+                                ContractParameter.hash160(account1.getScriptHash()),
+                                ContractParameter.hash160(RECIPIENT_SCRIPT_HASH),
+                                ContractParameter.integer(5)))
+                .contractCall(NEO_TOKEN_SCRIPT_HASH, NEP5_TRANSFER, Arrays.asList(
+                        ContractParameter.hash160(account2.getScriptHash()),
+                        ContractParameter.hash160(RECIPIENT_SCRIPT_HASH),
+                        ContractParameter.integer(2))).toArray();
+
+        TransactionBuilder b = neoToken.transfer(Wallet.withAccounts(account1,
+                account2, account3), RECIPIENT_SCRIPT_HASH.toAddress(), new BigDecimal("7"));
+
+        assertThat(b.getScript(), is(expectedScript));
+    }
+
     /*
      *  In this test case, 12 neo should be transferred.
      *  Result: Account 1 should transfer 5 neo, 2 should transfer 4 neo and 3 should transfer 3
@@ -205,7 +316,6 @@ public class Nep5TokenTest {
     public void testTransfer_allAccountsNeededToCoverAmount() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
@@ -239,7 +349,6 @@ public class Nep5TokenTest {
     public void testTransfer_defaultAccountCoversAmount() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
 
         byte[] expectedScript = new ScriptBuilder().contractCall(NEO_TOKEN_SCRIPT_HASH,
@@ -263,7 +372,6 @@ public class Nep5TokenTest {
     public void testTransfer_defaultAccountHasNoBalance() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_0.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_0.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
@@ -292,7 +400,6 @@ public class Nep5TokenTest {
     public void testTransfer_MultiSig() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(multiSigAccount.getScriptHash(),
                 "invokefunction_balanceOf_3.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_4.json");
@@ -328,7 +435,6 @@ public class Nep5TokenTest {
     public void testTransfer_MultiSig_NotEnoughSignersPresent() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_4.json");
         setUpWireMockForBalanceOf(multiSigAccount.getScriptHash(),
                 "invokefunction_balanceOf_3.json");
@@ -348,31 +454,33 @@ public class Nep5TokenTest {
     /*
      *  For this test, the wallet contains only a multi-sig account.
      */
-    @Test(expected = InsufficientFundsException.class)
+    @Test
     public void testTransfer_MultiSigNotEnoughSignersPresent_NoOtherAccountPresent()
             throws IOException {
-
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
-        setUpWireMockForInvokeFunction("symbol", "invokefunction_symbol.json");
         setUpWireMockForBalanceOf(multiSigAccount.getScriptHash(),
                 "invokefunction_balanceOf_3.json");
         Wallet wallet = Wallet.withAccounts(multiSigAccount);
+
+        exceptionRule.expect(InsufficientFundsException.class);
+        exceptionRule.expectMessage("wallet does not hold enough tokens");
         neoToken.transfer(wallet, RECIPIENT_SCRIPT_HASH, new BigDecimal("2"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testTransfer_InvalidAmount() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("amount must be greater than or equal to 0");
         neoToken.transfer(Wallet.create(), RECIPIENT_SCRIPT_HASH, new BigDecimal(-1));
     }
 
-    @Test(expected = InsufficientFundsException.class)
+    @Test
     public void testTransfer_insufficientBalance() throws IOException {
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
-        setUpWireMockForInvokeFunction("symbol", "invokefunction_symbol.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
 
+        exceptionRule.expect(InsufficientFundsException.class);
+        exceptionRule.expectMessage("wallet does not hold enough tokens");
         neoToken.transfer(Wallet.withAccounts(account1, account2, account3),
                 RECIPIENT_SCRIPT_HASH, new BigDecimal("20"));
     }
@@ -385,7 +493,6 @@ public class Nep5TokenTest {
     public void testTransferFromSpecificAccounts() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
 
@@ -416,7 +523,6 @@ public class Nep5TokenTest {
     public void testTransferFromSpecificAccounts_firstAccountCoversAmount() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
 
         byte[] expectedScript = new ScriptBuilder().contractCall(NEO_TOKEN_SCRIPT_HASH,
@@ -440,10 +546,8 @@ public class Nep5TokenTest {
     @Test
     public void testTransferFromSpecificAccounts_firstConsideredAccountHasNoBalance()
             throws IOException {
-
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_0.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
 
@@ -464,7 +568,6 @@ public class Nep5TokenTest {
     public void testTransferFromSpecificAccounts_firstAccountHasNoBalance() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_0.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
 
@@ -484,13 +587,15 @@ public class Nep5TokenTest {
     /*
      *  For this test, the wallet contains only a multi-sig account.
      */
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testTransferFromSpecificAccounts_MultiSigNotEnoughSignersPresent_NoOtherAccountPresent()
             throws IOException {
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(multiSigAccount.getScriptHash(),
                 "invokefunction_balanceOf_3.json");
         Wallet wallet = Wallet.withAccounts(multiSigAccount);
+
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("does not have the corresponding private keys in the wallet");
         neoToken.transferFromSpecificAccounts(wallet, RECIPIENT_SCRIPT_HASH, new BigDecimal("2"),
                 multiSigAccount.getScriptHash());
     }
@@ -499,30 +604,35 @@ public class Nep5TokenTest {
      *  In this test case, 12 neo should be transferred from only accounts 1 and 3.
      *  Result: This should fail, since accounts 1 and 3 only hold 8 neo in total.
      */
-    @Test(expected = InsufficientFundsException.class)
+    @Test
     public void testTransferFromSpecificAccounts_insufficientBalance() throws IOException {
         // Required for fetching the block height used for setting the validUntilBlock.
         setUpWireMockForGetBlockCount(1000);
-        setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals.json");
-        setUpWireMockForInvokeFunction("symbol", "invokefunction_symbol.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(),
                 "invokefunction_balanceOf_5.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(),
                 "invokefunction_balanceOf_3.json");
 
         Wallet w = Wallet.withAccounts(account1, account2, account3);
+
+        exceptionRule.expect(InsufficientFundsException.class);
+        exceptionRule.expectMessage("wallet does not hold enough tokens");
         neoToken.buildMultiTransferInvocation(w, RECIPIENT_SCRIPT_HASH,
                 new BigDecimal("12"), Arrays.asList(account1, account3));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testTransferFromSpecificAccounts_noAccountProvided() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("account address must be provided to build an invocation");
         neoToken.transferFromSpecificAccounts(Wallet.create(), RECIPIENT_SCRIPT_HASH,
                 new BigDecimal("1"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testTransferFromSpecificAccounts_illegalAmountProvided() throws IOException {
+        exceptionRule.expect(IllegalArgumentException.class);
+        exceptionRule.expectMessage("amount must be greater than or equal to 0");
         neoToken.transferFromSpecificAccounts(Wallet.create(), RECIPIENT_SCRIPT_HASH,
                 new BigDecimal("-2"), account1.getScriptHash());
     }

--- a/contract/src/test/java/io/neow3j/contract/Nep5TokenTest.java
+++ b/contract/src/test/java/io/neow3j/contract/Nep5TokenTest.java
@@ -26,6 +26,8 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Arrays;
+
+import static org.junit.Assert.fail;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -83,6 +85,8 @@ public class Nep5TokenTest {
         setUpWireMockForGetBlockCount(1000);
         setUpWireMockForBalanceOf(account1.getScriptHash(),
                 "invokefunction_balanceOf_300000000.json");
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals_gas.json");
 
         Transaction tx = gasToken.transferFromDefaultAccount(Wallet.withAccounts(account1),
                 RECIPIENT_SCRIPT_HASH, BigDecimal.ONE)
@@ -97,6 +101,8 @@ public class Nep5TokenTest {
     public void transferFromDefaultAccountShouldAddAccountAsSigner_RecipientAsAddress() throws Throwable {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals_gas.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(),
                 "invokefunction_balanceOf_300000000.json");
 
@@ -113,6 +119,8 @@ public class Nep5TokenTest {
     public void transferFromDefaultAccountShouldCreateTheCorrectScript() throws Throwable {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals_gas.json");
         setUpWireMockForInvokeFunction("balanceOf",
                 "invokefunction_balanceOf_300000000.json");
 
@@ -133,6 +141,8 @@ public class Nep5TokenTest {
     public void transferFromSpecificAccount_RecipientAsAddress() throws Throwable {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals_gas.json");
         setUpWireMockForInvokeFunction("balanceOf",
                 "invokefunction_balanceOf_300000000.json");
 
@@ -188,6 +198,8 @@ public class Nep5TokenTest {
         setUpWireMockForGetBlockCount(1000);
         setUpWireMockForBalanceOf(account1.getScriptHash(),
                 "invokefunction_balanceOf_300000000.json");
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals_gas.json");
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
 
         exceptionRule.expect(InsufficientFundsException.class);
@@ -206,6 +218,8 @@ public class Nep5TokenTest {
 
     @Test
     public void testTransferInvalidDecimalsInAmount() throws Throwable {
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("amount contains more decimal places than this token can handle");
         neoToken.transferFromDefaultAccount(Wallet.withAccounts(account1),
@@ -216,14 +230,22 @@ public class Nep5TokenTest {
     public void testTransferInvalidDecimalsInAmount_trailingZeros() throws IOException {
         setUpWireMockForBalanceOf(account1.getScriptHash(),
                 "invokefunction_balanceOf_300000000.json");
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
 
-        // Trailing zeros should be ignored - this should not throw an exception.
-        neoToken.transferFromDefaultAccount(Wallet.withAccounts(account1),
-                RECIPIENT_SCRIPT_HASH, new BigDecimal("1.0"));
+        try {
+            // Trailing zeros should be ignored - this code should not produce any exception.
+            neoToken.transferFromDefaultAccount(Wallet.withAccounts(account1),
+                    RECIPIENT_SCRIPT_HASH, new BigDecimal("1.0"));
+        } catch (Exception e) {
+            fail();
+        }
     }
 
     @Test
     public void testInvalidDecimals_TransferFromDefaultAccount() throws IOException {
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("amount contains more decimal places than this token can handle");
         neoToken.transferFromDefaultAccount(Wallet.withAccounts(account1),
@@ -232,6 +254,8 @@ public class Nep5TokenTest {
 
     @Test
     public void testInvalidDecimals_TransferFromSpecificAccounts() throws IOException {
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals_gas.json");
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("amount contains more decimal places than this token can handle");
         gasToken.transferFromSpecificAccounts(Wallet.withAccounts(account1), RECIPIENT_SCRIPT_HASH,
@@ -240,6 +264,8 @@ public class Nep5TokenTest {
 
     @Test
     public void testInvalidDecimals_Transfer() throws IOException {
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         exceptionRule.expect(IllegalArgumentException.class);
         exceptionRule.expectMessage("amount contains more decimal places than this token can handle");
         neoToken.transfer(Wallet.withAccounts(account1), RECIPIENT_SCRIPT_HASH,
@@ -262,6 +288,8 @@ public class Nep5TokenTest {
     public void testTransferWithTheFirstTwoAccountsNeededToCoverAmount() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
 
@@ -287,6 +315,8 @@ public class Nep5TokenTest {
             throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
 
@@ -316,6 +346,8 @@ public class Nep5TokenTest {
     public void testTransfer_allAccountsNeededToCoverAmount() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
@@ -349,6 +381,8 @@ public class Nep5TokenTest {
     public void testTransfer_defaultAccountCoversAmount() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
 
         byte[] expectedScript = new ScriptBuilder().contractCall(NEO_TOKEN_SCRIPT_HASH,
@@ -372,6 +406,8 @@ public class Nep5TokenTest {
     public void testTransfer_defaultAccountHasNoBalance() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_0.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_0.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
@@ -400,6 +436,8 @@ public class Nep5TokenTest {
     public void testTransfer_MultiSig() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(multiSigAccount.getScriptHash(),
                 "invokefunction_balanceOf_3.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_4.json");
@@ -434,6 +472,8 @@ public class Nep5TokenTest {
     @Test
     public void testTransfer_MultiSig_NotEnoughSignersPresent() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForGetBlockCount(1000);
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_4.json");
         setUpWireMockForBalanceOf(multiSigAccount.getScriptHash(),
@@ -459,6 +499,10 @@ public class Nep5TokenTest {
             throws IOException {
         setUpWireMockForBalanceOf(multiSigAccount.getScriptHash(),
                 "invokefunction_balanceOf_3.json");
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
+        setUpWireMockForInvokeFunction("symbol",
+                "invokefunction_symbol_neo.json");
         Wallet wallet = Wallet.withAccounts(multiSigAccount);
 
         exceptionRule.expect(InsufficientFundsException.class);
@@ -478,6 +522,10 @@ public class Nep5TokenTest {
         setUpWireMockForBalanceOf(account1.getScriptHash(), "invokefunction_balanceOf_5.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
+        setUpWireMockForInvokeFunction("symbol",
+                "invokefunction_symbol_neo.json");
 
         exceptionRule.expect(InsufficientFundsException.class);
         exceptionRule.expectMessage("wallet does not hold enough tokens");
@@ -493,6 +541,8 @@ public class Nep5TokenTest {
     public void testTransferFromSpecificAccounts() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
 
@@ -523,6 +573,8 @@ public class Nep5TokenTest {
     public void testTransferFromSpecificAccounts_firstAccountCoversAmount() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_4.json");
 
         byte[] expectedScript = new ScriptBuilder().contractCall(NEO_TOKEN_SCRIPT_HASH,
@@ -548,6 +600,8 @@ public class Nep5TokenTest {
             throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_0.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
 
@@ -568,6 +622,8 @@ public class Nep5TokenTest {
     public void testTransferFromSpecificAccounts_firstAccountHasNoBalance() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_transfer.json");
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account2.getScriptHash(), "invokefunction_balanceOf_0.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(), "invokefunction_balanceOf_3.json");
 
@@ -592,6 +648,8 @@ public class Nep5TokenTest {
             throws IOException {
         setUpWireMockForBalanceOf(multiSigAccount.getScriptHash(),
                 "invokefunction_balanceOf_3.json");
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         Wallet wallet = Wallet.withAccounts(multiSigAccount);
 
         exceptionRule.expect(IllegalArgumentException.class);
@@ -608,10 +666,14 @@ public class Nep5TokenTest {
     public void testTransferFromSpecificAccounts_insufficientBalance() throws IOException {
         // Required for fetching the block height used for setting the validUntilBlock.
         setUpWireMockForGetBlockCount(1000);
+        setUpWireMockForInvokeFunction("decimals",
+                "invokefunction_decimals.json");
         setUpWireMockForBalanceOf(account1.getScriptHash(),
                 "invokefunction_balanceOf_5.json");
         setUpWireMockForBalanceOf(account3.getScriptHash(),
                 "invokefunction_balanceOf_3.json");
+        setUpWireMockForInvokeFunction("symbol",
+                "invokefunction_symbol_neo.json");
 
         Wallet w = Wallet.withAccounts(account1, account2, account3);
 

--- a/contract/src/test/java/io/neow3j/contract/SmartContractTest.java
+++ b/contract/src/test/java/io/neow3j/contract/SmartContractTest.java
@@ -39,6 +39,8 @@ import org.junit.rules.ExpectedException;
 public class SmartContractTest {
 
     private static final ScriptHash NEO_SCRIPT_HASH = NeoToken.SCRIPT_HASH;
+    private static final ScriptHash SOME_SCRIPT_HASH =
+            new ScriptHash("969a77db482f74ce27105f760efa139223431394");
     private static final String NEP5_TRANSFER = "transfer";
     private static final String NEP5_BALANCEOF = "balanceOf";
     private static final String NEP5_NAME = "name";
@@ -195,10 +197,10 @@ public class SmartContractTest {
     @Test
     public void callFunctionReturningString() throws IOException {
         setUpWireMockForCall("invokefunction", "invokefunction_name.json",
-                NEO_SCRIPT_HASH.toString(), NEP5_NAME);
-        SmartContract sc = new SmartContract(NEO_SCRIPT_HASH, this.neow);
-        String name = sc.callFuncReturningString(NEP5_NAME);
-        assertThat(name, is("NEO"));
+                SOME_SCRIPT_HASH.toString(), "name");
+        SmartContract sc = new SmartContract(SOME_SCRIPT_HASH, this.neow);
+        String name = sc.callFuncReturningString("name");
+        assertThat(name, is("ANT"));
     }
 
     @Test
@@ -245,16 +247,15 @@ public class SmartContractTest {
     public void invokingFunctionPerformsCorrectCall_WithoutParameters() throws IOException {
         setUpWireMockForCall("invokefunction",
                 "invokefunction_name.json",
-                NeoToken.SCRIPT_HASH.toString(),
+                SOME_SCRIPT_HASH.toString(),
                 "name",
                 "[\"721e1376b75fe93889023d47832c160fcc5d4a06\"]"
         );
-        Wallet w = Wallet.withAccounts(account1);
 
-        NeoInvokeFunction i = new NeoToken(neow)
+        NeoInvokeFunction i = new SmartContract(SOME_SCRIPT_HASH, neow)
                 .callInvokeFunction("name");
 
-        assertThat(i.getResult().getStack().get(0).asByteString().getAsString(), Matchers.is("NEO"));
+        assertThat(i.getResult().getStack().get(0).asByteString().getAsString(), Matchers.is("ANT"));
         assertThat(i.getResult().getScript(), Matchers.is(SCRIPT_NEO_INVOKEFUNCTION_NAME));
     }
 

--- a/contract/src/test/java/io/neow3j/contract/TokenTest.java
+++ b/contract/src/test/java/io/neow3j/contract/TokenTest.java
@@ -21,11 +21,7 @@ public class TokenTest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
 
-    private Token neoToken;
-    private Token gasToken;
     private Token someToken;
-    private static final ScriptHash NEO_TOKEN_SCRIPT_HASH = NeoToken.SCRIPT_HASH;
-    private static final ScriptHash GAS_TOKEN_SCRIPT_HASH = GasToken.SCRIPT_HASH;
     private static final ScriptHash SOME_TOKEN_SCRIPT_HASH =
             new ScriptHash("f7014e6d52fe8f94f7c57acd8cfb875b4ac2a1c6");
 
@@ -36,8 +32,6 @@ public class TokenTest {
         WireMock.configureFor(port);
 
         Neow3j neow = Neow3j.build(new HttpService("http://127.0.0.1:" + port));
-        neoToken = new Token(NEO_TOKEN_SCRIPT_HASH, neow);
-        gasToken = new Token(GAS_TOKEN_SCRIPT_HASH, neow);
         someToken = new Token(SOME_TOKEN_SCRIPT_HASH, neow);
     }
 
@@ -48,29 +42,9 @@ public class TokenTest {
     }
 
     @Test
-    public void testGetName_Neo() throws IOException {
-        assertThat(neoToken.getName(), is(NeoToken.NAME));
-    }
-
-    @Test
-    public void testGetName_Gas() throws IOException {
-        assertThat(gasToken.getName(), is(GasToken.NAME));
-    }
-
-    @Test
     public void testGetSymbol() throws IOException {
         setUpWireMockForInvokeFunction("symbol", "invokefunction_symbol.json");
         assertThat(someToken.getSymbol(), is("ant"));
-    }
-
-    @Test
-    public void testGetSymbol_Neo() throws IOException {
-        assertThat(neoToken.getSymbol(), is(NeoToken.SYMBOL));
-    }
-
-    @Test
-    public void testGetSymbol_Gas() throws IOException {
-        assertThat(gasToken.getSymbol(), is(GasToken.SYMBOL));
     }
 
     @Test
@@ -81,24 +55,9 @@ public class TokenTest {
     }
 
     @Test
-    public void testGetDecimals_Neo() throws Exception {
-        assertThat(neoToken.getDecimals(), is(NeoToken.DECIMALS));
-    }
-
-    @Test
-    public void testGetDecimals_Gas() throws Exception {
-        assertThat(gasToken.getDecimals(), is(GasToken.DECIMALS));
-    }
-
-    @Test
     public void testGetTotalSupply() throws Exception {
         setUpWireMockForInvokeFunction("totalSupply",
                 "invokefunction_totalSupply.json");
         assertThat(someToken.getTotalSupply(), is(new BigInteger("3000000000000000")));
-    }
-
-    @Test
-    public void testGetTotalSupply_Neo() throws Exception {
-        assertThat(neoToken.getTotalSupply(), is(NeoToken.TOTAL_SUPPLY));
     }
 }

--- a/contract/src/test/java/io/neow3j/contract/TokenTest.java
+++ b/contract/src/test/java/io/neow3j/contract/TokenTest.java
@@ -23,8 +23,11 @@ public class TokenTest {
 
     private Token neoToken;
     private Token gasToken;
+    private Token someToken;
     private static final ScriptHash NEO_TOKEN_SCRIPT_HASH = NeoToken.SCRIPT_HASH;
     private static final ScriptHash GAS_TOKEN_SCRIPT_HASH = GasToken.SCRIPT_HASH;
+    private static final ScriptHash SOME_TOKEN_SCRIPT_HASH =
+            new ScriptHash("f7014e6d52fe8f94f7c57acd8cfb875b4ac2a1c6");
 
     @Before
     public void setUp() {
@@ -35,31 +38,67 @@ public class TokenTest {
         Neow3j neow = Neow3j.build(new HttpService("http://127.0.0.1:" + port));
         neoToken = new Token(NEO_TOKEN_SCRIPT_HASH, neow);
         gasToken = new Token(GAS_TOKEN_SCRIPT_HASH, neow);
+        someToken = new Token(SOME_TOKEN_SCRIPT_HASH, neow);
     }
 
     @Test
     public void testGetName() throws IOException {
         setUpWireMockForInvokeFunction("name", "invokefunction_name.json");
-        assertThat(neoToken.getName(), is("NEO"));
+        assertThat(someToken.getName(), is("ANT"));
+    }
+
+    @Test
+    public void testGetName_Neo() throws IOException {
+        assertThat(neoToken.getName(), is(NeoToken.NAME));
+    }
+
+    @Test
+    public void testGetName_Gas() throws IOException {
+        assertThat(gasToken.getName(), is(GasToken.NAME));
     }
 
     @Test
     public void testGetSymbol() throws IOException {
         setUpWireMockForInvokeFunction("symbol", "invokefunction_symbol.json");
-        assertThat(neoToken.getSymbol(), is("neo"));
+        assertThat(someToken.getSymbol(), is("ant"));
+    }
+
+    @Test
+    public void testGetSymbol_Neo() throws IOException {
+        assertThat(neoToken.getSymbol(), is(NeoToken.SYMBOL));
+    }
+
+    @Test
+    public void testGetSymbol_Gas() throws IOException {
+        assertThat(gasToken.getSymbol(), is(GasToken.SYMBOL));
     }
 
     @Test
     public void testGetDecimals() throws Exception {
         setUpWireMockForInvokeFunction("decimals",
-                "invokefunction_decimals_gas.json");
-        assertThat(gasToken.getDecimals(), is(8));
+                "invokefunction_decimals_nep5.json");
+        assertThat(someToken.getDecimals(), is(2));
+    }
+
+    @Test
+    public void testGetDecimals_Neo() throws Exception {
+        assertThat(neoToken.getDecimals(), is(NeoToken.DECIMALS));
+    }
+
+    @Test
+    public void testGetDecimals_Gas() throws Exception {
+        assertThat(gasToken.getDecimals(), is(GasToken.DECIMALS));
     }
 
     @Test
     public void testGetTotalSupply() throws Exception {
         setUpWireMockForInvokeFunction("totalSupply",
                 "invokefunction_totalSupply.json");
-        assertThat(gasToken.getTotalSupply(), is(new BigInteger("3000000000000000")));
+        assertThat(someToken.getTotalSupply(), is(new BigInteger("3000000000000000")));
+    }
+
+    @Test
+    public void testGetTotalSupply_Neo() throws Exception {
+        assertThat(neoToken.getTotalSupply(), is(NeoToken.TOTAL_SUPPLY));
     }
 }

--- a/contract/src/test/resources/responses/invokefunction_name.json
+++ b/contract/src/test/resources/responses/invokefunction_name.json
@@ -8,7 +8,7 @@
     "stack": [
       {
         "type": "ByteString",
-        "value": "TkVP"
+        "value": "QU5U"
       }
     ]
   }

--- a/contract/src/test/resources/responses/invokefunction_symbol.json
+++ b/contract/src/test/resources/responses/invokefunction_symbol.json
@@ -8,7 +8,7 @@
     "stack": [
       {
         "type": "ByteString",
-        "value": "bmVv"
+        "value": "YW50"
       }
     ]
   }

--- a/contract/src/test/resources/responses/invokefunction_symbol_neo.json
+++ b/contract/src/test/resources/responses/invokefunction_symbol_neo.json
@@ -1,0 +1,15 @@
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "script": "10c00c0673796d626f6c0c1425059ecb4878d3a875f91c51ceded330d4575fde41627d5b52",
+    "state": "HALT",
+    "gasconsumed": "1007390",
+    "stack": [
+      {
+        "type": "ByteString",
+        "value": "TkVP"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Added a check to throw an exception, when the provided amount has more decimals than the token supports and increased the test coverage of the class `Nep5Token`.

Closes #257 