### PR TITLE
Fix for a bug in the event compilation

### DIFF
--- a/compiler/src/main/java/io/neow3j/compiler/AsmHelper.java
+++ b/compiler/src/main/java/io/neow3j/compiler/AsmHelper.java
@@ -238,7 +238,7 @@ public class AsmHelper {
             return new ArrayList<>();
         }
         int startIdx = sig.indexOf("<") + 1;
-        int endIdx = sig.indexOf(">");
+        int endIdx = sig.lastIndexOf(">");
         String typesString = sig.substring(startIdx, endIdx);
         return extractTypeParamsFromString(typesString);
     }
@@ -246,7 +246,6 @@ public class AsmHelper {
     private static List<String> extractTypeParamsFromString(String types) {
         // Remove any generic type parameters.
         types = types.replaceAll("<[^<>]*>", "");
-
         List<String> separatedTypes = new ArrayList<>();
         int i = 0;
         while (i < types.length()) {

--- a/compiler/src/main/java/io/neow3j/compiler/AsmHelper.java
+++ b/compiler/src/main/java/io/neow3j/compiler/AsmHelper.java
@@ -30,8 +30,10 @@ import org.objectweb.asm.util.TraceMethodVisitor;
 
 public class AsmHelper {
 
-    /**
-     * Gets the {@code MethodNode} corresponding to the method called in the given instruction.
+    private static final List<Character> PRIMITIVE_TYPE_NAMES = new ArrayList<>(
+            Arrays.asList('V', 'Z', 'C', 'B', 'S', 'I', 'F', 'J', 'D'));
+
+    /** Gets the {@code MethodNode} corresponding to the method called in the given instruction.
      *
      * @param methodInsn The method instruction.
      * @param owner      The class that contains the method to be searched.
@@ -61,9 +63,9 @@ public class AsmHelper {
     /**
      * Gets the {@code ClassNode} for the given class descriptor using the given classloader.
      *
-     * @param descriptor The class' descriptor as provided by ASM, e.g., in {@link
-     *                     Type#getDescriptor()}.
-     * @param classLoader  The classloader to use.
+     * @param descriptor  The class' descriptor as provided by ASM, e.g., in {@link
+     *                    Type#getDescriptor()}.
+     * @param classLoader The classloader to use.
      * @return The class node.
      * @throws IOException If an error occurs when reading class files.
      */
@@ -144,7 +146,8 @@ public class AsmHelper {
     }
 
 
-    public static Optional<AnnotationNode> getAnnotationNode(FieldNode fieldNode, Class<?> annotation) {
+    public static Optional<AnnotationNode> getAnnotationNode(FieldNode fieldNode,
+            Class<?> annotation) {
         if (fieldNode.invisibleAnnotations == null) {
             return Optional.empty();
         }
@@ -237,7 +240,25 @@ public class AsmHelper {
         int startIdx = sig.indexOf("<") + 1;
         int endIdx = sig.indexOf(">");
         String typesString = sig.substring(startIdx, endIdx);
-        return Arrays.stream(typesString.split(";")).map(t -> t + ";").collect(Collectors.toList());
+        return extractTypeParamsFromString(typesString);
+    }
+
+    private static List<String> extractTypeParamsFromString(String types) {
+        // Remove any generic type parameters.
+        types = types.replaceAll("<[^<>]*>", "");
+
+        List<String> separatedTypes = new ArrayList<>();
+        int i = 0;
+        while (i < types.length()) {
+            if (types.charAt(i) == '[' && PRIMITIVE_TYPE_NAMES.contains(types.charAt(i + 1))) {
+                separatedTypes.add(Character.toString(types.charAt(i++)) + types.charAt(i++));
+            } else {
+                String t = types.substring(i, types.indexOf(";", i) + 1);
+                separatedTypes.add(t);
+                i += t.length();
+            }
+        }
+        return separatedTypes;
     }
 
     /**

--- a/compiler/src/test-integration/java/io/neow3j/compiler/ContractEventsIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ContractEventsIntegrationTest.java
@@ -1,13 +1,17 @@
 package io.neow3j.compiler;
 
+import static io.neow3j.contract.ContractParameter.byteArray;
+import static io.neow3j.contract.ContractParameter.integer;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.fail;
 
+import io.neow3j.contract.ContractParameter;
 import io.neow3j.devpack.annotations.DisplayName;
 import io.neow3j.devpack.events.Event2Args;
+import io.neow3j.devpack.events.Event3Args;
 import io.neow3j.devpack.events.Event5Args;
 import io.neow3j.devpack.neo.Blockchain;
 import io.neow3j.devpack.neo.Runtime;
@@ -58,12 +62,31 @@ public class ContractEventsIntegrationTest extends ContractTest {
         assertThat(state.get(1).asInteger().getValue().intValue(), greaterThanOrEqualTo(1));
     }
 
+    @Test
+    public void fireEvent() throws Throwable {
+        String txHash = invokeFunctionAndAwaitExecution(
+                byteArray("0f46dc4287b70117ce8354924b5cb3a47215ad93"),
+                byteArray("d6c712eb53b1a130f59fd4e5864bdac27458a509"),
+                integer(10));
+        NeoApplicationLog log = neow3j.getApplicationLog(txHash).send().getApplicationLog();
+        List<NeoApplicationLog.Notification> notifications = log.getNotifications();
+        NeoApplicationLog.Notification event = notifications.get(0);
+        ArrayStackItem state = event.getState().asArray();
+        assertThat(state.get(0).asByteString().getAsHexString(),
+                is("0f46dc4287b70117ce8354924b5cb3a47215ad93"));
+        assertThat(state.get(1).asByteString().getAsHexString(),
+                is("d6c712eb53b1a130f59fd4e5864bdac27458a509"));
+        assertThat(state.get(2).asArray().get(0).asInteger().getValue().intValue(), is(10));
+    }
+
     static class ContractEvents {
 
         private static Event2Args<String, Integer> event1;
 
         @DisplayName("displayName")
         private static Event5Args<String, Integer, Boolean, String, Object> event2;
+
+        private static Event3Args<byte[], byte[], int[]> event3;
 
         public static boolean fireTwoEvents() {
             event1.notify("event text", 10);
@@ -73,6 +96,10 @@ public class ContractEventsIntegrationTest extends ContractTest {
 
         public static void fireEventWithMethodReturnValueAsArgument() {
             event1.notify(Runtime.getPlatform(), (int)Blockchain.getHeight());
+        }
+
+        public static void fireEvent(byte[] from, byte[] to, int i) {
+            event3.notify(from, to, new int[]{i});
         }
     }
 

--- a/compiler/src/test/java/io/neow3j/compiler/AsmHelperTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/AsmHelperTest.java
@@ -117,18 +117,69 @@ public class AsmHelperTest {
     }
 
     @Test
-    public void extractingTypeParametersShouldReturnTheCorrectTypeStrings() {
+    public void extractTypeParamFromSignatureWithOneParam() {
+        // One non-generic event parameter
         FieldNode field = new FieldNode(0, null, null,
                 "Lio/neow3j/devpack/events/Event1Arg<Ljava/lang/Integer;>;", null);
         List<String> types = extractTypeParametersFromSignature(field);
         assertThat(types.get(0), is("Ljava/lang/Integer;"));
+    }
 
-        field = new FieldNode(0, null, null,
+    @Test
+    public void extractTypeParamFromSignatureWithTwoParams() {
+        // Two non-generic event parameters
+        FieldNode field = new FieldNode(0, null, null,
                 "Lio/neow3j/devpack/events/Event2Args<Ljava/lang/Integer;Ljava/lang/String;>;",
                 null);
-        types = extractTypeParametersFromSignature(field);
+        List<String> types = extractTypeParametersFromSignature(field);
         assertThat(types.get(0), is("Ljava/lang/Integer;"));
         assertThat(types.get(1), is("Ljava/lang/String;"));
+    }
+
+    @Test
+    public void extractTypeParamFromSignatureWithOneParamThatAlsoHasATypeParam() {
+        // One event parameter with a generic type parameter, i.e., List<Integer>.
+        FieldNode field = new FieldNode(0, null, null, "Lio/neow3j/devpack/events/Event1Arg<"
+                + "Lio/neow3j/devpack/List<Ljava/lang/Integer;>;>;", null);
+        List<String> types = extractTypeParametersFromSignature(field);
+        assertThat(types.get(0), is("Lio/neow3j/devpack/List;"));
+    }
+
+    @Test
+    public void extractTypeParamFromSignatureWithParamThatHasTwoTypeParamsItself() {
+        // One event parameter with two generic type parameters.
+        FieldNode field = new FieldNode(0, null, null, "Lio/neow3j/devpack/events/Event2Args<"
+                + "Lio/neow3j/devpack/List<Ljava/lang/Integer;>;"
+                + "Lio/neow3j/devpack/List<Ljava/lang/String;>;>;", null);
+        List<String> types = extractTypeParametersFromSignature(field);
+        assertThat(types.get(0), is("Lio/neow3j/devpack/List;"));
+        assertThat(types.get(1), is("Lio/neow3j/devpack/List;"));
+    }
+
+    @Test
+    public void extractTypeParamFromSignatureWithPrimitiveArrayParamAndOtherParams() {
+        // One event parameter with two generic type parameters.
+        FieldNode field = new FieldNode(0, null, null, "Lio/neow3j/devpack/events/Event2Args<"
+                + "[B" + "Lio/neow3j/devpack/List<Ljava/lang/Integer;>;>;",
+                null);
+        List<String> types = extractTypeParametersFromSignature(field);
+        assertThat(types.get(0), is("[B"));
+        assertThat(types.get(1), is("Lio/neow3j/devpack/List;"));
+    }
+
+    @Test
+    public void extractTypeParamFromSignatureWithMultiplePrimitiveArrayParamAndOtherParams() {
+        // One event parameter with two generic type parameters.
+        FieldNode field = new FieldNode(0, null, null, "Lio/neow3j/devpack/events/Event5Args<"
+                + "[B" + "[C" + "[Lio/neow3j/devpack/List<Ljava/lang/Integer;>;" + "[I" +
+                "[Ljava/lang/Integer;>;",
+                null);
+        List<String> types = extractTypeParametersFromSignature(field);
+        assertThat(types.get(0), is("[B"));
+        assertThat(types.get(1), is("[C"));
+        assertThat(types.get(2), is("[Lio/neow3j/devpack/List;"));
+        assertThat(types.get(3), is("[I"));
+        assertThat(types.get(4), is("[Ljava/lang/Integer;"));
     }
 
     @Test
@@ -139,7 +190,6 @@ public class AsmHelperTest {
         assertThat(c.sourceFile, is("Storage.java"));
         assertThat(c.methods, not(hasSize(0)));
     }
-
 
     @Test
     public void gettingAnnotationFromAFieldNodeShouldReturnTheCorrectAnnotationNode() {


### PR DESCRIPTION
The compilation of events with primitive array type parameters, e.g., `Event2Args<byte[], Integer>` had a bug. The type parameters weren't parsed correctly leading to errors in the manifest and debugging information.