### PR TITLE
Fix filenames of NEF and debug info files from gradle plugin output

### DIFF
--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginUtils.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginUtils.java
@@ -1,7 +1,5 @@
 package io.neow3j.devpack.gradle;
 
-import static io.neow3j.utils.ClassUtils.getClassName;
-
 import io.neow3j.compiler.DebugInfo;
 import io.neow3j.protocol.ObjectMapperFactory;
 import java.io.File;
@@ -9,6 +7,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
@@ -23,14 +22,6 @@ public class Neow3jPluginUtils {
     protected static final String DEFAULT_FILENAME = "output" + NEF_SUFFIX;
     protected static final String NEFDBGNFO_SUFFIX = ".nefdbgnfo";
     protected static final String DEBUG_JSON_SUFFIX = ".debug.json";
-
-    static String getCompileOutputFileName(String fqClassName) {
-        String className = getClassName(fqClassName);
-        if (className != null && className.length() > 0) {
-            return className + NEF_SUFFIX;
-        }
-        return DEFAULT_FILENAME;
-    }
 
     static URL getBuildDirURL(File buildDir) {
         try {
@@ -88,27 +79,25 @@ public class Neow3jPluginUtils {
     /**
      * Generates a ZIP file containing a JSON file with the given debug information in it.
      *
-     * @param debugInfo The debug information to include in the ZIP file.
-     * @param outDirString The directory (absolute path) where the ZIP file should be stored.
-     * @param fileName The desired name of the ZIP file and the included JSON file. This
-     *                 must not include the file name ending. The ending is added accordingly to
-     *                 what the Neo Debugger expects.
+     * @param debugInfo    The debug information to include in the ZIP file.
+     * @param contractName The name of the contract the debug info belongs to.
+     * @param outDir       The directory (absolute path) where the ZIP file should be stored.
      * @return the absolute path of the generated zip file.
      * @throws IOException If an error occurs when writing the file.
      */
-    public static String generateDebugInfoZip(DebugInfo debugInfo, String outDirString,
-            String fileName) throws IOException {
+    public static String writeDebugInfoZip(DebugInfo debugInfo, String contractName, Path outDir)
+            throws IOException {
 
-        File tmpFile = File.createTempFile("contract", ".debug.json");
-        tmpFile.deleteOnExit();
         // Write the debug JSON to a temporary file.
+        File tmpFile = File.createTempFile("contract", DEBUG_JSON_SUFFIX);
+        tmpFile.deleteOnExit();
         try (FileOutputStream s = new FileOutputStream(tmpFile)) {
             ObjectMapperFactory.getObjectMapper().writeValue(s, debugInfo);
         }
         // Then put it into a ZIP archive.
-        String zipName = fileName + NEFDBGNFO_SUFFIX;
-        String zipEntryName = fileName + DEBUG_JSON_SUFFIX;
-        File zipOutputFile = Paths.get(outDirString, zipName).toFile();
+        String zipName = contractName + NEFDBGNFO_SUFFIX;
+        String zipEntryName = contractName + DEBUG_JSON_SUFFIX;
+        File zipOutputFile = Paths.get(outDir.toString(), zipName).toFile();
         try (ZipOutputStream s = new ZipOutputStream(new FileOutputStream(zipOutputFile))) {
             s.putNextEntry(new ZipEntry(zipEntryName));
             byte[] bytes = ObjectMapperFactory.getObjectMapper().writeValueAsBytes(debugInfo);


### PR DESCRIPTION
The filenames of the NEF and debug info file are not set according to the name attribute in the manifest. 
I refactored the whole file writing process a bit.