### PR TITLE
Added JavaDoc to RPC call methods

### DIFF
--- a/core/src/main/java/io/neow3j/protocol/core/JsonRpc2_0Neow3j.java
+++ b/core/src/main/java/io/neow3j/protocol/core/JsonRpc2_0Neow3j.java
@@ -91,6 +91,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
 
     // Blockchain Methods
 
+    /**
+     * Gets the hash of the latest block in the main chain.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoBlockHash> getBestBlockHash() {
         return new Request<>(
@@ -100,6 +105,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoBlockHash.class);
     }
 
+    /**
+     * Gets the block hash of the corresponding block based on the specified
+     * index.
+     *
+     * @param blockIndex the block index.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoBlockHash> getBlockHash(BlockParameterIndex blockIndex) {
         return new Request<>(
@@ -109,8 +121,19 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoBlockHash.class);
     }
 
+    /**
+     * Gets the corresponding block information according to the specified hash
+     * or index.
+     *
+     * @param address the block hash.
+     * @param returnFullTransactionObjects whether to get block information
+     *                                     with all transaction objects or
+     *                                     just the block header.
+     * @return the request object.
+     */
     @Override
-    public Request<?, NeoGetBlock> getBlock(String address, boolean returnFullTransactionObjects) {
+    public Request<?, NeoGetBlock> getBlock(String address,
+            boolean returnFullTransactionObjects) {
         if (returnFullTransactionObjects) {
             return new Request<>(
                     "getblock",
@@ -122,6 +145,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
         }
     }
 
+    /**
+     * Gets the corresponding block information according to the specified hash
+     * in hexadecimal.
+     *
+     * @param address the block hash.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetRawBlock> getRawBlock(String address) {
         return new Request<>(
@@ -131,6 +161,16 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetRawBlock.class);
     }
 
+    /**
+     * Gets the corresponding block information according to the specified
+     * index.
+     *
+     * @param blockIndex the block index.
+     * @param returnFullTransactionObjects whether to get block information
+     *                                     with all transaction objects or
+     *                                     just the block header.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetBlock> getBlock(BlockParameterIndex blockIndex,
             boolean returnFullTransactionObjects) {
@@ -145,6 +185,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
         }
     }
 
+    /**
+     * Gets the corresponding block information according to the specified hash
+     * in hexadecimal.
+     *
+     * @param blockIndex the block index.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetRawBlock> getRawBlock(BlockParameterIndex blockIndex) {
         return new Request<>(
@@ -154,6 +201,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetRawBlock.class);
     }
 
+    /**
+     * Gets the block count of the main chain.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoBlockCount> getBlockCount() {
         return new Request<>(
@@ -163,6 +215,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoBlockCount.class);
     }
 
+    /**
+     * Gets the corresponding block header information according to the
+     * specified script hash.
+     *
+     * @param hash the block script hash.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetBlock> getBlockHeader(String hash) {
         return new Request<>(
@@ -172,6 +231,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetBlock.class);
     }
 
+    /**
+     * Gets the corresponding block header information according to the
+     * specified index.
+     *
+     * @param blockIndex the block index.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetBlock> getBlockHeader(BlockParameterIndex blockIndex) {
         return new Request<>(
@@ -181,6 +247,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetBlock.class);
     }
 
+    /**
+     * Gets the corresponding block header information according to the
+     * specified script hash in hexadecimal.
+     *
+     * @param hash the block script hash.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetRawBlock> getRawBlockHeader(String hash) {
         return new Request<>(
@@ -190,6 +263,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetRawBlock.class);
     }
 
+    /**
+     * Gets the corresponding block header information according to the
+     * specified script hash in hexadecimal.
+     *
+     * @param blockIndex the block index.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetRawBlock> getRawBlockHeader(BlockParameterIndex blockIndex) {
         return new Request<>(
@@ -199,6 +279,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetRawBlock.class);
     }
 
+    /**
+     * Gets the contract information.
+     *
+     * @param scriptHash the contract script hash.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetContractState> getContractState(String scriptHash) {
         return new Request<>(
@@ -208,6 +294,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetContractState.class);
     }
 
+    /**
+     * Gets a list of unconfirmed or confirmed transactions in memory.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetMemPool> getMemPool() {
         return new Request<>(
@@ -217,6 +308,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetMemPool.class);
     }
 
+    /**
+     * Gets a list of confirmed transactions in memory.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetRawMemPool> getRawMemPool() {
         return new Request<>(
@@ -226,6 +322,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetRawMemPool.class);
     }
 
+    /**
+     * Gets the corresponding transaction information based on the specified
+     * hash value.
+     *
+     * @param txId the transaction id.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetTransaction> getTransaction(String txId) {
         return new Request<>(
@@ -235,6 +338,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetTransaction.class);
     }
 
+    /**
+     * Gets the corresponding transaction information based on the specified
+     * hash value in hexadecimal.
+     *
+     * @param txId the transaction id.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetRawTransaction> getRawTransaction(String txId) {
         return new Request<>(
@@ -244,11 +354,28 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetRawTransaction.class);
     }
 
+    /**
+     * Gets the stored value according to the contract script hash and the
+     * stored key.
+     *
+     * @param contractAddress the contract address.
+     * @param keyToLookUp the key to look up in storage.
+     * @return the request object.
+     */
     @Override
-    public Request<?, NeoGetStorage> getStorage(String contractAddress, HexParameter keyToLookUp) {
+    public Request<?, NeoGetStorage> getStorage(String contractAddress,
+            HexParameter keyToLookUp) {
         return getStorage(contractAddress, keyToLookUp.getHexValue());
     }
 
+    /**
+     * Gets the stored value according to the contract script hash and the
+     * stored key.
+     *
+     * @param contractAddress the contract address.
+     * @param keyToLookUpAsHexString the key to look up in storage.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetStorage> getStorage(String contractAddress,
             String keyToLookUpAsHexString) {
@@ -259,6 +386,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetStorage.class);
     }
 
+    /**
+     * Gets the transaction height with the specified transaction hash.
+     *
+     * @param txId the transaction id.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetTransactionHeight> getTransactionHeight(String txId) {
         return new Request<>(
@@ -268,6 +401,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetTransactionHeight.class);
     }
 
+    /**
+     * Gets the validators of the next block.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetNextBlockValidators> getNextBlockValidators() {
         return new Request<>(
@@ -277,6 +415,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetNextBlockValidators.class);
     }
 
+    /**
+     * Gets the public key list of current Neo committee members.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetCommittee> getCommittee() {
         return new Request<>(
@@ -288,6 +431,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
 
     // Node Methods
 
+    /**
+     * Gets the current number of connections for the node.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoConnectionCount> getConnectionCount() {
         return new Request<>(
@@ -297,6 +445,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoConnectionCount.class);
     }
 
+    /**
+     * Gets a list of nodes that the node is currently connected or
+     * disconnected from.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetPeers> getPeers() {
         return new Request<>(
@@ -306,6 +460,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetPeers.class);
     }
 
+    /**
+     * Gets the version information of the node.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetVersion> getVersion() {
         return new Request<>(
@@ -315,6 +474,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetVersion.class);
     }
 
+    /**
+     * Broadcasts a transaction over the NEO network.
+     *
+     * @param rawTransactionHex the raw transaction in hexadecimal.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoSendRawTransaction> sendRawTransaction(String rawTransactionHex) {
         return new Request<>(
@@ -324,6 +489,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoSendRawTransaction.class);
     }
 
+    /**
+     * Broadcasts a new block over the NEO network.
+     *
+     * @param serializedBlockAsHex the block in hexadecimal.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoSubmitBlock> submitBlock(String serializedBlockAsHex) {
         return new Request<>(
@@ -335,36 +506,64 @@ public class JsonRpc2_0Neow3j implements Neow3j {
 
     // SmartContract Methods
 
+    /**
+     * Invokes a smart contract with its script hash based on the specified
+     * operation.
+     *
+     * @param contractScriptHash the contract script hash to invoke.
+     * @param functionName the function to invoke.
+     * @param signers the signers.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoInvokeFunction> invokeFunction(String contractScriptHash,
-            String functionName, Signer... witnesses) {
-        return invokeFunction(contractScriptHash, functionName, null, witnesses);
+            String functionName, Signer... signers) {
+        return invokeFunction(contractScriptHash, functionName, null, signers);
     }
 
+    /**
+     * Invokes a smart contract based on the specified function and parameters.
+     *
+     * @param contractScriptHash the contract script hash to invoke.
+     * @param functionName the function to invoke.
+     * @param contractParams the parameters of the function.
+     * @param signers the signers.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoInvokeFunction> invokeFunction(String contractScriptHash,
-            String functionName, List<ContractParameter> contractParams, Signer... witnesses) {
+            String functionName, List<ContractParameter> contractParams,
+            Signer... signers) {
 
         if (contractParams == null) {
             contractParams = new ArrayList<>();
         }
-        List<TransactionSigner> signers = new ArrayList<>();
-        Arrays.stream(witnesses).map(TransactionSigner::new).forEach(signers::add);
+        List<TransactionSigner> txSigners = Arrays.stream(signers)
+                .map(TransactionSigner::new).collect(Collectors.toList());
         List<?> params;
-        if (signers.size() > 0) {
-            params = asList(contractScriptHash, functionName, contractParams, signers);
+        if (txSigners.size() > 0) {
+            params = asList(contractScriptHash, functionName, contractParams, txSigners);
         } else {
             params = asList(contractScriptHash, functionName, contractParams);
         }
         return new Request<>(
                 "invokefunction",
-                params.stream().filter(Objects::nonNull).collect(Collectors.toList()),
+                params.stream().filter(Objects::nonNull)
+                        .collect(Collectors.toList()),
                 neow3jService,
                 NeoInvokeFunction.class);
     }
 
+    /**
+     * Invokes a script.
+     *
+     * @param script the script to invoke.
+     * @param signers the signers.
+     * @return the request object.
+     */
     @Override
-    public Request<?, NeoInvokeScript> invokeScript(String script, Signer... signers) {
+    public Request<?, NeoInvokeScript> invokeScript(String script,
+            Signer... signers) {
         List<?> params;
         if (signers.length > 0) {
             params = asList(script, Arrays.stream(signers)
@@ -380,6 +579,14 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoInvokeScript.class);
     }
 
+    /**
+     * Invokes a contract in verification mode.
+     *
+     * @param scriptHash the contract script hash.
+     * @param methodParams a list of parameters of the verify function.
+     * @param signers the signers.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoInvokeContractVerify> invokeContractVerify(String scriptHash,
             List<ContractParameter> methodParams, Signer... signers) {
@@ -387,8 +594,8 @@ public class JsonRpc2_0Neow3j implements Neow3j {
         if (methodParams == null) {
             methodParams = new ArrayList<>();
         }
-        List<TransactionSigner> txSigners =
-                Arrays.stream(signers).map(TransactionSigner::new).collect(Collectors.toList());
+        List<TransactionSigner> txSigners = Arrays.stream(signers)
+                .map(TransactionSigner::new).collect(Collectors.toList());
         List<?> params = asList(scriptHash, methodParams, txSigners);
         return new Request<>(
                 "invokecontractverify",
@@ -397,6 +604,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoInvokeContractVerify.class);
     }
 
+    /**
+     * Gets the unclaimed GAS of the specified address.
+     *
+     * @param address the address.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetUnclaimedGas> getUnclaimedGas(String address) {
         return new Request<>(
@@ -408,6 +621,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
 
     // Utilities Methods
 
+    /**
+     * Gets a list of plugins loaded by the node.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoListPlugins> listPlugins() {
         return new Request<>(
@@ -417,6 +635,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoListPlugins.class);
     }
 
+    /**
+     * Verifies whether the address is a valid NEO address.
+     *
+     * @param address the address to verify.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoValidateAddress> validateAddress(String address) {
         return new Request<>(
@@ -428,6 +652,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
 
     // Wallet Methods
 
+    /**
+     * Closes the current wallet.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoCloseWallet> closeWallet() {
         return new Request<>(
@@ -437,6 +666,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoCloseWallet.class);
     }
 
+    /**
+     * Exports the private key of the specified address.
+     *
+     * @param address the address.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoDumpPrivKey> dumpPrivKey(String address) {
         return new Request<>(
@@ -446,6 +681,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoDumpPrivKey.class);
     }
 
+    /**
+     * Gets the balance of the corresponding asset in the wallet.
+     *
+     * @param assetId the asset id.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetWalletBalance> getWalletBalance(String assetId) {
         return new Request<>(
@@ -455,6 +696,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetWalletBalance.class);
     }
 
+    /**
+     * Creates a new address.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetNewAddress> getNewAddress() {
         return new Request<>(
@@ -464,6 +710,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetNewAddress.class);
     }
 
+    /**
+     * Gets the amount of unclaimed GAS in the wallet.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetWalletUnclaimedGas> getWalletUnclaimedGas() {
         return new Request<>(
@@ -473,6 +724,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetWalletUnclaimedGas.class);
     }
 
+    /**
+     * Imports a private key to the wallet.
+     *
+     * @param privateKeyInWIF the private key in WIF-format.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoImportPrivKey> importPrivKey(String privateKeyInWIF) {
         return new Request<>(
@@ -482,6 +739,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoImportPrivKey.class);
     }
 
+    /**
+     * Calculates the network fee for the specified transaction.
+     *
+     * @param txHex the transaction in hexadecimal.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoCalculateNetworkFee> calculateNetworkFee(String txHex) {
         return new Request<>(
@@ -491,6 +754,11 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoCalculateNetworkFee.class);
     }
 
+    /**
+     * Lists all the addresses in the current wallet.
+     *
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoListAddress> listAddress() {
         return new Request<>(
@@ -500,6 +768,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoListAddress.class);
     }
 
+    /**
+     * Opens the specified wallet.
+     *
+     * @param walletPath the wallet file path.
+     * @param password the password for the wallet.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoOpenWallet> openWallet(String walletPath, String password) {
         return new Request<>(
@@ -509,6 +784,15 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoOpenWallet.class);
     }
 
+    /**
+     * Transfers an amount of an asset from an address to another address.
+     *
+     * @param fromAddress the transferring address.
+     * @param assetId the script hash of the NEP17 contract.
+     * @param toAddress the destination address.
+     * @param value the transfer amount.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoSendFrom> sendFrom(String fromAddress, String assetId,
             String toAddress, String value) {
@@ -519,12 +803,30 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoSendFrom.class);
     }
 
+    /**
+     * Transfers an amount of an asset from an address to another address.
+     *
+     * @param fromAddress the transferring address.
+     * @param txSendAsset a {@code TransactionSendAsset} object containing the
+     *                    asset, the destination address and the transfer
+     *                    amount.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoSendFrom> sendFrom(String fromAddress, TransactionSendAsset txSendAsset) {
         return sendFrom(fromAddress, txSendAsset.getAsset(), txSendAsset.getAddress(),
                 txSendAsset.getValue());
     }
 
+    /**
+     * Initiates multiple transfers to multiple addresses from the open wallet
+     * in a transaction.
+     *
+     * @param txSendAsset a list of {@code TransactoinSendAsset} objects, that
+     *                    each contains the asset, destination address and
+     *                    transfer amount.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoSendMany> sendMany(List<TransactionSendAsset> txSendAsset) {
         return new Request<>(
@@ -534,6 +836,16 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoSendMany.class);
     }
 
+    /**
+     * Initiates multiple transfers to multiple addresses from one specific
+     * address in a transaction.
+     *
+     * @param fromAddress the transferring address.
+     * @param txSendAsset a list of {@code TransactoinSendAsset} objects, that
+     *                    each contains the asset, destination address and
+     *                    transfer amount.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoSendMany> sendMany(String fromAddress,
             List<TransactionSendAsset> txSendAsset) {
@@ -546,6 +858,14 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoSendMany.class);
     }
 
+    /**
+     * Transfers an amount of an asset to another address.
+     *
+     * @param assetId the script hash of the NEP17 contract.
+     * @param toAddress the destination address.
+     * @param value the transfer amount.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoSendToAddress> sendToAddress(String assetId, String toAddress,
             String value) {
@@ -558,6 +878,14 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoSendToAddress.class);
     }
 
+    /**
+     * Transfers an amount of an asset to another address.
+     *
+     * @param txSendAsset a {@code TransactionSendAsset} object containing the
+     *                    asset, the destination address and the transfer
+     *                    amount.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoSendToAddress> sendToAddress(TransactionSendAsset txSendAsset) {
         return sendToAddress(txSendAsset.getAsset(), txSendAsset.getAddress(),
@@ -566,6 +894,14 @@ public class JsonRpc2_0Neow3j implements Neow3j {
 
     // ApplicationLogs
 
+    /**
+     * Gets the contract event information based on the specified transaction
+     * id. The contract event information is stored under the ApplicationLogs
+     * directory.
+     *
+     * @param txId the transaction id.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetApplicationLog> getApplicationLog(String txId) {
         return new Request<>(
@@ -577,6 +913,12 @@ public class JsonRpc2_0Neow3j implements Neow3j {
 
     // RpcNep17Tracker
 
+    /**
+     * Gets the balance of all NEP17 assets in the specified address.
+     *
+     * @param address the address.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetNep17Balances> getNep17Balances(String address) {
         return new Request<>(
@@ -586,6 +928,13 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetNep17Balances.class);
     }
 
+    /**
+     * Gets all the NEP17 transaction information occurred in the specified
+     * address.
+     *
+     * @param address the address.
+     * @return the request object.
+     */
     @Override
     public Request<?, NeoGetNep17Transfers> getNep17Transfers(String address) {
         return new Request<>(
@@ -595,20 +944,37 @@ public class JsonRpc2_0Neow3j implements Neow3j {
                 NeoGetNep17Transfers.class);
     }
 
+    /**
+     * Gets all the NEP17 transaction information occurred in the specified
+     * address since the specified time.
+     *
+     * @param address the address.
+     * @param from the timestamp transactions occurred since.
+     * @return the request object.
+     */
     @Override
-    public Request<?, NeoGetNep17Transfers> getNep17Transfers(String address, Date until) {
+    public Request<?, NeoGetNep17Transfers> getNep17Transfers(String address, Date from) {
         return new Request<>(
                 "getnep17transfers",
-                asList(address, until.getTime()),
+                asList(address, from.getTime()),
                 neow3jService,
                 NeoGetNep17Transfers.class);
     }
 
+    /**
+     * Gets all the NEP17 transaction information occurred in the specified
+     * address in the specified time range.
+     *
+     * @param address the address.
+     * @param from the start timestamp.
+     * @param until the end timestamp.
+     * @return the request object.
+     */
     @Override
-    public Request<?, NeoGetNep17Transfers> getNep17Transfers(String address, Date from, Date to) {
+    public Request<?, NeoGetNep17Transfers> getNep17Transfers(String address, Date from, Date until) {
         return new Request<>(
                 "getnep17transfers",
-                asList(address, from.getTime(), to.getTime()),
+                asList(address, from.getTime(), until.getTime()),
                 neow3jService,
                 NeoGetNep17Transfers.class);
     }


### PR DESCRIPTION
Further, renamed `witnesses` to `signers` in `invokeFunction` method and adapted the mapping lambda expression.