### PR TITLE
Prohibit local variables in static constructor

### DIFF
--- a/compiler/src/main/java/io/neow3j/compiler/CompilerException.java
+++ b/compiler/src/main/java/io/neow3j/compiler/CompilerException.java
@@ -9,7 +9,7 @@ public class CompilerException extends RuntimeException {
     }
 
     public CompilerException(NeoMethod neoMethod, String errorMessage) {
-        super(neoMethod.getOwnerClass().sourceFile + ".java: " + neoMethod.getCurrentLine() + ": "
+        super(neoMethod.getOwnerClass().sourceFile + ": " + neoMethod.getCurrentLine() + ": "
                 + "error:\n" + errorMessage);
     }
 

--- a/compiler/src/main/java/io/neow3j/compiler/InitsslotNeoMethod.java
+++ b/compiler/src/main/java/io/neow3j/compiler/InitsslotNeoMethod.java
@@ -1,0 +1,48 @@
+package io.neow3j.compiler;
+
+import io.neow3j.constants.OpCode;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.MethodNode;
+
+import java.io.IOException;
+
+public class InitsslotNeoMethod extends NeoMethod {
+
+    private static final String INITSSLOT_METHOD_NAME = "_initialize";
+
+    /**
+     * Constructs a new INITSSLOT method.
+     *
+     * @param asmMethod   The Java method this Neo method is converted from.
+     * @param sourceClass The Java class from which this method originates.
+     */
+    public InitsslotNeoMethod(MethodNode asmMethod, ClassNode sourceClass) {
+        super(asmMethod, sourceClass);
+        setName(INITSSLOT_METHOD_NAME);
+        setIsAbiMethod(true);
+        byte[] operand = new byte[]{(byte) sourceClass.fields.size()};
+        addInstruction(new NeoInstruction(OpCode.INITSSLOT, operand));
+    }
+
+    @Override
+    public void convert(CompilationUnit compUnit) throws IOException {
+        AbstractInsnNode insn = getAsmMethod().instructions.get(0);
+        while (insn != null) {
+            if (insn.getOpcode() >= JVMOpcode.ISTORE.getOpcode() &&
+                    insn.getOpcode() <= JVMOpcode.SASTORE.getOpcode()) {
+                throw new CompilerException(this, "Local variables are not supported in the " +
+                        "static constructor");
+            }
+            insn = Compiler.handleInsn(insn, this, compUnit);
+            insn = insn.getNext();
+        }
+        insertTryCatchBlocks();
+    }
+
+    @Override
+    public void initialize(CompilationUnit compUnit) {
+        throw new UnsupportedOperationException("The INITSSLOT method cannotneed to be " +
+                "initialized with local variable and parameter slots.");
+    }
+}

--- a/compiler/src/main/java/io/neow3j/compiler/NeoMethod.java
+++ b/compiler/src/main/java/io/neow3j/compiler/NeoMethod.java
@@ -491,7 +491,7 @@ public class NeoMethod {
         insertTryCatchBlocks();
     }
 
-    private void insertTryCatchBlocks() {
+    protected void insertTryCatchBlocks() {
         for (TryCatchFinallyBlock block : tryCatchFinallyBlocks) {
             insertTryInstruction(block);
         }

--- a/compiler/src/test/java/io/neow3j/compiler/CompilerExceptionsTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/CompilerExceptionsTest.java
@@ -28,14 +28,6 @@ public class CompilerExceptionsTest {
     public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
-    public void failOnInstantiatingInheritingClass() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
-                "Found call to super constructor of", ArrayList.class.getCanonicalName())));
-        new Compiler().compileClass(UnsupportedInheritanceInConstructor.class.getName());
-    }
-
-    @Test
     public void throwExceptionIfNonDefaultExceptionInstanceIsUsed() throws IOException {
         exceptionRule.expect(CompilerException.class);
         exceptionRule.expectMessage(new StringContainsInOrder(asList(
@@ -164,6 +156,15 @@ public class CompilerExceptionsTest {
                 "packagePrivateMethod", "safe")));
     }
 
+    @Test
+    public void failIfLocalVariablesAreUsedInStaticConstructor() throws IOException {
+        exceptionRule.expect(CompilerException.class);
+        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+                CompilerExceptionsTest.class.getSimpleName(),
+                "Local variables are not supported in the static constructor")));
+        new Compiler().compileClass(LocalVariableInStaticConstructorContract.class.getName());
+    }
+
     static class UnsupportedInheritanceInConstructor {
 
         public static void method() {
@@ -280,6 +281,20 @@ public class CompilerExceptionsTest {
 
         @Safe
         private static void packagePrivateMethod() {
+        }
+    }
+
+    static class LocalVariableInStaticConstructorContract {
+
+        private static int number;
+
+        static {
+            int i = 1;
+            number = i * 2;
+        }
+
+        public static int method() {
+            return number;
         }
     }
 


### PR DESCRIPTION
The solution to #311 is that we prohibit usage of local variables in static constructors. The neo-vm does not support them (in the INITSSLOT method, which is the corresponding construct of a static constructor.

The alternative solution would be to parse the static constructor and try to produce neo-vm code without using local variables. Creating such a parser obviously implies much higher effort than the solution of this PR.
