### PR TITLE
Reuse CallFlags values in devpack 

### DIFF
--- a/devpack/src/main/java/io/neow3j/devpack/CallFlags.java
+++ b/devpack/src/main/java/io/neow3j/devpack/CallFlags.java
@@ -1,18 +1,20 @@
 package io.neow3j.devpack;
 
+import java.io.WriteAbortedException;
+
 /**
  * Defines flags for invoking smart contracts.
  */
 public class CallFlags {
 
-    public static final byte NONE = 0x00;
-    public static final byte READ_STATES = 0b00000001;
-    public static final byte WRITE_STATES = 0b00000010;
-    public static final byte ALLOW_CALL = 0b00000100;
-    public static final byte ALLOW_NOTIFY = 0b00001000;
+    public static final byte NONE = io.neow3j.model.types.CallFlags.NONE.getValue();
+    public static final byte READ_STATES = io.neow3j.model.types.CallFlags.READ_STATES.getValue();
+    public static final byte WRITE_STATES = io.neow3j.model.types.CallFlags.WRITE_STATES.getValue();
+    public static final byte ALLOW_CALL = io.neow3j.model.types.CallFlags.ALLOW_CALL.getValue();
+    public static final byte ALLOW_NOTIFY = io.neow3j.model.types.CallFlags.ALLOW_NOTIFY.getValue();
 
-    public static final byte STATES = READ_STATES | WRITE_STATES;
-    public static final byte READ_ONLY = READ_STATES | ALLOW_CALL;
-    public static final byte ALL = STATES | ALLOW_CALL | ALLOW_NOTIFY;
+    public static final byte STATES = io.neow3j.model.types.CallFlags.STATES.getValue();
+    public static final byte READ_ONLY = io.neow3j.model.types.CallFlags.READ_ONLY.getValue();
+    public static final byte ALL = io.neow3j.model.types.CallFlags.ALL.getValue();
 
 }


### PR DESCRIPTION
Reuse callflag values from contract package in devpack package to avoid having to update callflags in multiple places.