### PR TITLE
Add method to subscribe to new blocks without catching up

### DIFF
--- a/core/src/main/java/io/neow3j/protocol/core/JsonRpc2_0Neow3j.java
+++ b/core/src/main/java/io/neow3j/protocol/core/JsonRpc2_0Neow3j.java
@@ -1296,6 +1296,13 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     }
 
     @Override
+    public Observable<NeoGetBlock> subscribeToNewBlocksObservable(boolean fullTransactionObjects)
+            throws IOException {
+
+        return neow3jRx.subscribeToNewBlocksObservable(fullTransactionObjects, blockTime);
+    }
+
+    @Override
     public void shutdown() {
         scheduledExecutorService.shutdown();
         try {

--- a/core/src/main/java/io/neow3j/protocol/rx/JsonRpc2_0Rx.java
+++ b/core/src/main/java/io/neow3j/protocol/rx/JsonRpc2_0Rx.java
@@ -12,6 +12,7 @@ import io.reactivex.schedulers.Schedulers;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.stream.Collectors;
@@ -137,8 +138,16 @@ public class JsonRpc2_0Rx {
                         neow3j.getBlock(blockIndex, fullTransactionObjects).observable());
     }
 
+    public Observable<NeoGetBlock> subscribeToNewBlocksObservable(boolean fullTransactionObjects,
+            long pollingInterval) throws IOException {
+
+        return catchUpToLatestAndSubscribeToNewBlocksObservable(
+                getLatestBlockNumber(), fullTransactionObjects, pollingInterval);
+
+    }
+
     private static List<Transaction> toTransactions(NeoGetBlock neoGetBlock) {
-        return neoGetBlock.getBlock().getTransactions().stream().collect(Collectors.toList());
+        return new ArrayList<>(neoGetBlock.getBlock().getTransactions());
     }
 
     private BigInteger getLatestBlockNumber() throws IOException {

--- a/core/src/main/java/io/neow3j/protocol/rx/Neow3jRx.java
+++ b/core/src/main/java/io/neow3j/protocol/rx/Neow3jRx.java
@@ -5,6 +5,7 @@ import io.neow3j.protocol.core.methods.response.NeoGetBlock;
 import io.neow3j.protocol.core.methods.response.Transaction;
 import io.reactivex.Observable;
 
+import java.io.IOException;
 import java.math.BigInteger;
 
 /**
@@ -43,7 +44,8 @@ public interface Neow3jRx {
      * @param endBlock               block number to finish with
      * @param fullTransactionObjects if true, provides transactions embedded in blocks, otherwise
      *                               transaction hashes
-     * @param ascending              if true, emits blocks in ascending order between range, otherwise
+     * @param ascending              if true, emits blocks in ascending order between range,
+     *                               otherwise
      *                               in descending order
      * @return Observable to emit these blocks
      */
@@ -57,7 +59,7 @@ public interface Neow3jRx {
      * Observable is invoked.</p>
      * <br>
      * <p>To automatically subscribe to new blocks, use
-     * {@link #catchUpToLatestAndSubscribeToNewBlocksObservable(BlockParameter, boolean)}.</p>
+     * {@link #catchUpToLatestAndSubscribeToNewBlocksObservable(BigInteger, boolean)}.</p>
      *
      * @param startBlock             the block number we wish to request from
      * @param fullTransactionObjects if we require full {@link Transaction} objects to be provided
@@ -95,4 +97,16 @@ public interface Neow3jRx {
     Observable<NeoGetBlock> catchUpToLatestAndSubscribeToNewBlocksObservable(
             BigInteger startBlock, boolean fullTransactionObjects);
 
+
+    /**
+     * Creates an Observable that emits new blocks as they are created on the blockchain
+     * (starting from the latest block).
+     *
+     * @param fullTransactionObjects if we require full {@link Transaction} objects to be provided
+     *                               in the {@link NeoBlock} responses
+     * @return Observable to emit all requested blocks and future
+     * @throws IOException if the latest block number cannot be fetched.
+     */
+    Observable<NeoGetBlock> subscribeToNewBlocksObservable(boolean fullTransactionObjects)
+            throws IOException;
 }


### PR DESCRIPTION
This PR adds only a convenience method to subscribe to new incoming blocks.