### PR TITLE
Uniform hash endianness handling

### DIFF
--- a/compiler/src/main/java/io/neow3j/compiler/converters/MethodsConverter.java
+++ b/compiler/src/main/java/io/neow3j/compiler/converters/MethodsConverter.java
@@ -353,7 +353,7 @@ public class MethodsConverter implements Converter {
         // If its a call to the `getHash()` method, simply add PUSHDATA <scriptHash>.
         if (calledAsmMethod.name.equals(GET_CONTRACT_HASH_METHOD_NAME)) {
             callingNeoMethod.addInstruction(
-                    buildPushDataInsn(ArrayUtils.reverseArray(scriptHash.toArray())));
+                    buildPushDataInsn(scriptHash.toArray()));
             return;
         }
 

--- a/compiler/src/test-integration/java/io/neow3j/compiler/ContractTestRule.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ContractTestRule.java
@@ -29,9 +29,11 @@ import java.math.BigDecimal;
 
 import static io.neow3j.TestProperties.defaultAccountWIF;
 import static io.neow3j.NeoTestContainer.getNodeUrl;
+import static io.neow3j.utils.ArrayUtils.reverseArray;
 import static io.neow3j.utils.Await.waitUntilBlockCountIsGreaterThanZero;
 import static io.neow3j.utils.Await.waitUntilContractIsDeployed;
 import static io.neow3j.utils.Await.waitUntilTransactionIsExecuted;
+import static io.neow3j.utils.Numeric.hexStringToByteArray;
 import static java.lang.String.format;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static java.util.Arrays.asList;
@@ -117,7 +119,7 @@ public class ContractTestRule implements TestRule {
                     + "message was: '%s'", fullyQualifiedName, execution.getException()));
         }
         String scriptHashHex = execution.getStack().get(0).getList().get(2).getHexString();
-        Hash160 scriptHash = new Hash160(Numeric.hexStringToByteArray(scriptHashHex));
+        Hash160 scriptHash = new Hash160(reverseArray(hexStringToByteArray(scriptHashHex)));
         return new SmartContract(scriptHash, neow3j);
     }
 

--- a/contract/src/main/java/io/neow3j/contract/NeoURI.java
+++ b/contract/src/main/java/io/neow3j/contract/NeoURI.java
@@ -197,7 +197,7 @@ public class NeoURI {
      * @return this NeoURI object.
      */
     public NeoURI asset(byte[] asset) {
-        this.asset = new Hash160(ArrayUtils.reverseArray(asset));
+        this.asset = new Hash160(asset);
         return this;
     }
 

--- a/contract/src/main/java/io/neow3j/contract/SmartContract.java
+++ b/contract/src/main/java/io/neow3j/contract/SmartContract.java
@@ -262,7 +262,7 @@ public class SmartContract {
         return Hash160.fromScript(
                 new ScriptBuilder()
                         .opCode(OpCode.ABORT)
-                        .pushData(sender.toArray())
+                        .pushData(sender.toLittleEndianArray())
                         .pushInteger(nefCheckSum)
                         .pushData(contractName).toArray());
     }

--- a/contract/src/test/java/io/neow3j/contract/FungibleTokenTest.java
+++ b/contract/src/test/java/io/neow3j/contract/FungibleTokenTest.java
@@ -490,7 +490,7 @@ public class FungibleTokenTest {
                         byteArray(new byte[]{0x42}))).toArray();
 
         TransactionBuilder b = neoToken.transfer(Wallet.withAccounts(account1, account2),
-                scriptHashToAddress(RECIPIENT_SCRIPT_HASH.toLittleEndianArray()),
+                RECIPIENT_SCRIPT_HASH.toAddress(),
                 new BigDecimal("4"), byteArray(new byte[]{0x42}));
 
         assertThat(b.getScript(), is(expectedScript));

--- a/contract/src/test/java/io/neow3j/contract/FungibleTokenTest.java
+++ b/contract/src/test/java/io/neow3j/contract/FungibleTokenTest.java
@@ -11,6 +11,7 @@ import static io.neow3j.contract.ContractTestHelper.setUpWireMockForBalanceOf;
 import static io.neow3j.contract.ContractTestHelper.setUpWireMockForCall;
 import static io.neow3j.contract.ContractTestHelper.setUpWireMockForGetBlockCount;
 import static io.neow3j.contract.ContractTestHelper.setUpWireMockForInvokeFunction;
+import static io.neow3j.utils.AddressUtils.scriptHashToAddress;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
@@ -489,7 +490,7 @@ public class FungibleTokenTest {
                         byteArray(new byte[]{0x42}))).toArray();
 
         TransactionBuilder b = neoToken.transfer(Wallet.withAccounts(account1, account2),
-                AddressUtils.scriptHashToAddress(RECIPIENT_SCRIPT_HASH.toArray()),
+                scriptHashToAddress(RECIPIENT_SCRIPT_HASH.toLittleEndianArray()),
                 new BigDecimal("4"), byteArray(new byte[]{0x42}));
 
         assertThat(b.getScript(), is(expectedScript));

--- a/core/src/main/java/io/neow3j/contract/ContractParameter.java
+++ b/core/src/main/java/io/neow3j/contract/ContractParameter.java
@@ -298,7 +298,7 @@ public class ContractParameter {
      * @return the contract parameter.
      */
     public static ContractParameter hash256(Hash256 hash) {
-        return hash256(hash.toArray());
+        return hash256(hash.toLittleEndianArray());
     }
 
     /**

--- a/core/src/main/java/io/neow3j/contract/Hash160.java
+++ b/core/src/main/java/io/neow3j/contract/Hash160.java
@@ -9,6 +9,7 @@ import static io.neow3j.utils.Numeric.hexStringToByteArray;
 import static io.neow3j.utils.Numeric.isValidHexString;
 import static io.neow3j.utils.Numeric.toHexStringNoPrefix;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.neow3j.constants.NeoConstants;
 import io.neow3j.io.BinaryReader;
 import io.neow3j.io.BinaryWriter;
@@ -113,6 +114,7 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
      *
      * @return the script hash as hex string in big-endian order.
      */
+    @JsonValue
     public String toString() {
         return toHexStringNoPrefix(hash);
     }

--- a/core/src/main/java/io/neow3j/contract/Hash160.java
+++ b/core/src/main/java/io/neow3j/contract/Hash160.java
@@ -1,14 +1,19 @@
 package io.neow3j.contract;
 
+import static io.neow3j.contract.ScriptBuilder.buildVerificationScript;
+import static io.neow3j.crypto.Hash.sha256AndThenRipemd160;
+import static io.neow3j.utils.AddressUtils.addressToScriptHash;
+import static io.neow3j.utils.AddressUtils.scriptHashToAddress;
+import static io.neow3j.utils.ArrayUtils.reverseArray;
+import static io.neow3j.utils.Numeric.hexStringToByteArray;
+import static io.neow3j.utils.Numeric.isValidHexString;
+import static io.neow3j.utils.Numeric.toHexStringNoPrefix;
+
 import io.neow3j.constants.NeoConstants;
-import io.neow3j.crypto.Hash;
 import io.neow3j.io.BinaryReader;
 import io.neow3j.io.BinaryWriter;
 import io.neow3j.io.NeoSerializable;
 import io.neow3j.io.exceptions.DeserializationException;
-import io.neow3j.utils.AddressUtils;
-import io.neow3j.utils.ArrayUtils;
-import io.neow3j.utils.Numeric;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -23,7 +28,7 @@ import java.util.List;
 public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
 
     /**
-     * The hash is stored as an unsigned integer in little-endian order.
+     * The hash is stored as an unsigned integer in big-endian order.
      */
     private byte[] hash;
 
@@ -36,14 +41,14 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
      * Constructs a new hash with 20 zero bytes.
      */
     public Hash160() {
-        this.hash = new byte[NeoConstants.HASH160_SIZE];
+        hash = new byte[NeoConstants.HASH160_SIZE];
     }
 
     /**
-     * Constructs a new hash from the given byte array. The byte array must be in little-endian
+     * Constructs a new hash from the given byte array. The byte array must be in big-endian
      * order and 160 bits long.
      *
-     * @param hash the hash in little-endian order.
+     * @param hash the hash in big-endian order.
      */
     public Hash160(byte[] hash) {
         checkAndThrowHashLength(hash);
@@ -57,8 +62,8 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
      * @param hash the hash in big-endian order.
      */
     public Hash160(String hash) {
-        if (Numeric.isValidHexString(hash)) {
-            this.hash = ArrayUtils.reverseArray(Numeric.hexStringToByteArray(hash));
+        if (isValidHexString(hash)) {
+            this.hash = hexStringToByteArray(hash);
             checkAndThrowHashLength(this.hash);
         } else {
             throw new IllegalArgumentException("String argument is not hexadecimal.");
@@ -68,7 +73,7 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
     @Override
     public void deserialize(BinaryReader reader) throws DeserializationException {
         try {
-            this.hash = reader.readBytes(NeoConstants.HASH160_SIZE);
+            hash = reverseArray(reader.readBytes(NeoConstants.HASH160_SIZE));
         } catch (IOException e) {
             throw new DeserializationException(e);
         }
@@ -76,7 +81,7 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
 
     @Override
     public void serialize(BinaryWriter writer) throws IOException {
-        writer.write(this.hash);
+        writer.write(reverseArray(hash));
     }
 
     @Override
@@ -85,13 +90,22 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
     }
 
     /**
+     * Gets the script hash as a byte array in big-endian order.
+     *
+     * @return the script hash byte array in big-endian order.
+     */
+    @Override
+    public byte[] toArray() {
+        return hash;
+    }
+
+    /**
      * Gets the script hash as a byte array in little-endian order.
      *
      * @return the script hash byte array in little-endian order.
      */
-    @Override
-    public byte[] toArray() {
-        return super.toArray();
+    public byte[] toLittleEndianArray() {
+        return reverseArray(hash);
     }
 
     /**
@@ -100,7 +114,7 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
      * @return the script hash as hex string in big-endian order.
      */
     public String toString() {
-        return Numeric.toHexStringNoPrefix(ArrayUtils.reverseArray(hash));
+        return toHexStringNoPrefix(hash);
     }
 
     /**
@@ -109,7 +123,7 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
      * @return the address.
      */
     public String toAddress() {
-        return AddressUtils.scriptHashToAddress(this.hash);
+        return scriptHashToAddress(reverseArray(hash));
     }
 
     /**
@@ -119,7 +133,7 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
      * @return the script hash.
      */
     public static Hash160 fromAddress(String address) {
-        return new Hash160(AddressUtils.addressToScriptHash(address));
+        return new Hash160(reverseArray(addressToScriptHash(address)));
     }
 
     /**
@@ -129,18 +143,15 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
      * @return the script hash.
      */
     public static Hash160 fromScript(byte[] script) {
-        // There is no need to reverse the hash. The hashing method returns the script hash in
-        // little-endian format.
-        return new Hash160(Hash.sha256AndThenRipemd160(script));
+        return new Hash160(reverseArray(sha256AndThenRipemd160(script)));
     }
 
     public static Hash160 fromPublicKey(byte[] encodedPublicKey) {
-        return fromScript(ScriptBuilder.buildVerificationScript(encodedPublicKey));
+        return fromScript(buildVerificationScript(encodedPublicKey));
     }
 
     public static Hash160 fromPublicKeys(List<byte[]> encodedPublicKeys, int signingThreshold) {
-        return fromScript(ScriptBuilder.buildVerificationScript(encodedPublicKeys,
-                signingThreshold));
+        return fromScript(buildVerificationScript(encodedPublicKeys, signingThreshold));
     }
 
     /**
@@ -150,7 +161,7 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
      * @return the script hash.
      */
     public static Hash160 fromScript(String script) {
-        return fromScript(Numeric.hexStringToByteArray(script));
+        return fromScript(hexStringToByteArray(script));
     }
 
     private void checkAndThrowHashLength(byte[] hash) {
@@ -162,8 +173,8 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
 
     @Override
     public int compareTo(Hash160 o) {
-        return new BigInteger(1, ArrayUtils.reverseArray(hash))
-                .compareTo(new BigInteger(1, ArrayUtils.reverseArray(o.toArray())));
+        return new BigInteger(1, hash)
+                .compareTo(new BigInteger(1, o.toArray()));
     }
 
     @Override
@@ -180,7 +191,7 @@ public class Hash160 extends NeoSerializable implements Comparable<Hash160> {
 
     @Override
     public int hashCode() {
-        return Arrays.hashCode(this.hash);
+        return Arrays.hashCode(hash);
     }
 
 }

--- a/core/src/main/java/io/neow3j/contract/Hash256.java
+++ b/core/src/main/java/io/neow3j/contract/Hash256.java
@@ -1,12 +1,15 @@
 package io.neow3j.contract;
 
+import static io.neow3j.utils.ArrayUtils.reverseArray;
+import static io.neow3j.utils.Numeric.hexStringToByteArray;
+import static io.neow3j.utils.Numeric.isValidHexString;
+import static io.neow3j.utils.Numeric.toHexStringNoPrefix;
+
 import io.neow3j.constants.NeoConstants;
 import io.neow3j.io.BinaryReader;
 import io.neow3j.io.BinaryWriter;
 import io.neow3j.io.NeoSerializable;
 import io.neow3j.io.exceptions.DeserializationException;
-import io.neow3j.utils.ArrayUtils;
-import io.neow3j.utils.Numeric;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -19,7 +22,7 @@ import java.util.Arrays;
 public class Hash256 extends NeoSerializable implements Comparable<Hash256> {
 
     /**
-     * The hash is stored as an unsigned integer in little-endian order.
+     * The hash is stored as an unsigned integer in big-endian order.
      */
     private byte[] hash;
 
@@ -37,10 +40,10 @@ public class Hash256 extends NeoSerializable implements Comparable<Hash256> {
     }
 
     /**
-     * Constructs a new hash from the given byte array. The byte array must be in little-endian
+     * Constructs a new hash from the given byte array. The byte array must be in big-endian
      * order and 256 bits long.
      *
-     * @param hash the hash in little-endian order.
+     * @param hash the hash in big-endian order.
      */
     public Hash256(byte[] hash) {
         checkAndThrowHashLength(hash);
@@ -54,8 +57,8 @@ public class Hash256 extends NeoSerializable implements Comparable<Hash256> {
      * @param hash the hash in big-endian order.
      */
     public Hash256(String hash) {
-        if (Numeric.isValidHexString(hash)) {
-            this.hash = ArrayUtils.reverseArray(Numeric.hexStringToByteArray(hash));
+        if (isValidHexString(hash)) {
+            this.hash = hexStringToByteArray(hash);
             checkAndThrowHashLength(this.hash);
         } else {
             throw new IllegalArgumentException("String argument is not hexadecimal.");
@@ -65,7 +68,7 @@ public class Hash256 extends NeoSerializable implements Comparable<Hash256> {
     @Override
     public void deserialize(BinaryReader reader) throws DeserializationException {
         try {
-            hash = reader.readBytes(NeoConstants.HASH256_SIZE);
+            hash = reverseArray(reader.readBytes(NeoConstants.HASH256_SIZE));
         } catch (IOException e) {
             throw new DeserializationException(e);
         }
@@ -73,7 +76,7 @@ public class Hash256 extends NeoSerializable implements Comparable<Hash256> {
 
     @Override
     public void serialize(BinaryWriter writer) throws IOException {
-        writer.write(hash);
+        writer.write(reverseArray(hash));
     }
 
     @Override
@@ -82,13 +85,22 @@ public class Hash256 extends NeoSerializable implements Comparable<Hash256> {
     }
 
     /**
+     * Gets the hash as a byte array in big-endian order.
+     *
+     * @return the hash byte array in big-endian order.
+     */
+    @Override
+    public byte[] toArray() {
+        return hash;
+    }
+
+    /**
      * Gets the hash as a byte array in little-endian order.
      *
      * @return the hash byte array in little-endian order.
      */
-    @Override
-    public byte[] toArray() {
-        return super.toArray();
+    public byte[] toLittleEndianArray() {
+        return reverseArray(hash);
     }
 
     /**
@@ -97,7 +109,7 @@ public class Hash256 extends NeoSerializable implements Comparable<Hash256> {
      * @return the hash as hex string in big-endian order.
      */
     public String toString() {
-        return Numeric.toHexStringNoPrefix(ArrayUtils.reverseArray(hash));
+        return toHexStringNoPrefix(hash);
     }
 
     private void checkAndThrowHashLength(byte[] hash) {
@@ -109,8 +121,8 @@ public class Hash256 extends NeoSerializable implements Comparable<Hash256> {
 
     @Override
     public int compareTo(Hash256 o) {
-        return new BigInteger(1, ArrayUtils.reverseArray(hash))
-                .compareTo(new BigInteger(1, ArrayUtils.reverseArray(o.toArray())));
+        return new BigInteger(1, hash)
+                .compareTo(new BigInteger(1, o.toArray()));
     }
 
     @Override

--- a/core/src/main/java/io/neow3j/contract/Hash256.java
+++ b/core/src/main/java/io/neow3j/contract/Hash256.java
@@ -5,6 +5,7 @@ import static io.neow3j.utils.Numeric.hexStringToByteArray;
 import static io.neow3j.utils.Numeric.isValidHexString;
 import static io.neow3j.utils.Numeric.toHexStringNoPrefix;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import io.neow3j.constants.NeoConstants;
 import io.neow3j.io.BinaryReader;
 import io.neow3j.io.BinaryWriter;
@@ -108,6 +109,7 @@ public class Hash256 extends NeoSerializable implements Comparable<Hash256> {
      *
      * @return the hash as hex string in big-endian order.
      */
+    @JsonValue
     public String toString() {
         return toHexStringNoPrefix(hash);
     }

--- a/core/src/main/java/io/neow3j/contract/ScriptBuilder.java
+++ b/core/src/main/java/io/neow3j/contract/ScriptBuilder.java
@@ -89,7 +89,7 @@ public class ScriptBuilder {
         }
         pushInteger(callFlags.getValue());
         pushData(method);
-        pushData(hash160.toArray());
+        pushData(hash160.toLittleEndianArray());
         sysCall(InteropServiceCode.SYSTEM_CONTRACT_CALL);
         return this;
     }
@@ -147,7 +147,7 @@ public class ScriptBuilder {
                 pushInteger((BigInteger) value);
                 break;
             case HASH160:
-                pushData(((Hash160) value).toArray());
+                pushData(((Hash160) value).toLittleEndianArray());
                 break;
             case HASH256:
                 pushData(((Hash256) value).toArray());

--- a/core/src/main/java/io/neow3j/contract/ScriptBuilder.java
+++ b/core/src/main/java/io/neow3j/contract/ScriptBuilder.java
@@ -150,7 +150,7 @@ public class ScriptBuilder {
                 pushData(((Hash160) value).toLittleEndianArray());
                 break;
             case HASH256:
-                pushData(((Hash256) value).toArray());
+                pushData(((Hash256) value).toLittleEndianArray());
                 break;
             case STRING:
                 pushData((String) value);

--- a/core/src/main/java/io/neow3j/crypto/Hash.java
+++ b/core/src/main/java/io/neow3j/crypto/Hash.java
@@ -1,9 +1,11 @@
 package io.neow3j.crypto;
 
 import io.neow3j.utils.Numeric;
+
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+
 import org.bouncycastle.crypto.digests.SHA512Digest;
 import org.bouncycastle.crypto.macs.HMac;
 import org.bouncycastle.crypto.params.KeyParameter;
@@ -174,7 +176,7 @@ public class Hash {
      * <p>
      * Neo uses the name {@code hash256} for hashes created in this way.
      *
-     * @param input The input to hash.
+     * @param input  The input to hash.
      * @param offset The offset at which the slice starts.
      * @param length The length of the slice to hash.
      * @return the hash value.

--- a/core/src/main/java/io/neow3j/protocol/core/JsonRpc2_0Neow3j.java
+++ b/core/src/main/java/io/neow3j/protocol/core/JsonRpc2_0Neow3j.java
@@ -1,6 +1,5 @@
 package io.neow3j.protocol.core;
 
-import static io.neow3j.utils.Strings.isEmpty;
 import static java.util.Arrays.asList;
 import static java.util.Arrays.stream;
 import static java.util.Collections.emptyList;
@@ -162,7 +161,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
         if (returnFullTransactionObjects) {
             return new Request<>(
                     "getblock",
-                    asList(blockHash.toString(), 1),
+                    asList(blockHash, 1),
                     neow3jService,
                     NeoGetBlock.class);
         } else {
@@ -181,7 +180,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoGetRawBlock> getRawBlock(Hash256 blockHash) {
         return new Request<>(
                 "getblock",
-                asList(blockHash.toString(), 0),
+                asList(blockHash, 0),
                 neow3jService,
                 NeoGetRawBlock.class);
     }
@@ -276,7 +275,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoGetBlock> getBlockHeader(Hash256 hash) {
         return new Request<>(
                 "getblockheader",
-                asList(hash.toString(), 1),
+                asList(hash, 1),
                 neow3jService,
                 NeoGetBlock.class);
     }
@@ -320,7 +319,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoGetRawBlock> getRawBlockHeader(Hash256 hash) {
         return new Request<>(
                 "getblockheader",
-                asList(hash.toString(), 0),
+                asList(hash, 0),
                 neow3jService,
                 NeoGetRawBlock.class);
     }
@@ -378,7 +377,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoGetContractState> getContractState(Hash160 hash160) {
         return new Request<>(
                 "getcontractstate",
-                singletonList(hash160.toString()),
+                singletonList(hash160),
                 neow3jService,
                 NeoGetContractState.class);
     }
@@ -449,7 +448,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoGetTransaction> getTransaction(Hash256 txId) {
         return new Request<>(
                 "getrawtransaction",
-                asList(txId.toString(), 1),
+                asList(txId, 1),
                 neow3jService,
                 NeoGetTransaction.class);
     }
@@ -477,7 +476,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoGetRawTransaction> getRawTransaction(Hash256 txId) {
         return new Request<>(
                 "getrawtransaction",
-                asList(txId.toString(), 0),
+                asList(txId, 0),
                 neow3jService,
                 NeoGetRawTransaction.class);
     }
@@ -497,15 +496,15 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     /**
      * Gets the stored value according to the contract script hash and the key.
      *
-     * @param contractAddress the contract hash.
-     * @param keyHexString    the key to look up in storage as a hexadecimal string.
+     * @param contractScriptHash the contract hash.
+     * @param keyHexString       the key to look up in storage as a hexadecimal string.
      * @return the request object.
      */
     @Override
-    public Request<?, NeoGetStorage> getStorage(Hash160 contractAddress, String keyHexString) {
+    public Request<?, NeoGetStorage> getStorage(Hash160 contractScriptHash, String keyHexString) {
         return new Request<>(
                 "getstorage",
-                asList(contractAddress.toString(), Base64.encode(keyHexString)),
+                asList(contractScriptHash, Base64.encode(keyHexString)),
                 neow3jService,
                 NeoGetStorage.class);
     }
@@ -531,7 +530,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoGetTransactionHeight> getTransactionHeight(Hash256 txId) {
         return new Request<>(
                 "gettransactionheight",
-                singletonList(txId.toString()),
+                singletonList(txId),
                 neow3jService,
                 NeoGetTransactionHeight.class);
     }
@@ -700,8 +699,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
      */
     @Override
     public Request<?, NeoInvokeFunction> invokeFunction(Hash160 contractScriptHash,
-            String functionName, List<ContractParameter> contractParams,
-            Signer... signers) {
+            String functionName, List<ContractParameter> contractParams, Signer... signers) {
 
         if (contractParams == null) {
             contractParams = new ArrayList<>();
@@ -710,9 +708,9 @@ public class JsonRpc2_0Neow3j extends Neow3j {
                 .collect(Collectors.toList());
         List<?> params;
         if (txSigners.size() > 0) {
-            params = asList(contractScriptHash.toString(), functionName, contractParams, txSigners);
+            params = asList(contractScriptHash, functionName, contractParams, txSigners);
         } else {
-            params = asList(contractScriptHash.toString(), functionName, contractParams);
+            params = asList(contractScriptHash, functionName, contractParams);
         }
         return new Request<>(
                 "invokefunction",
@@ -782,7 +780,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
         }
         List<TransactionSigner> txSigners = stream(signers)
                 .map(TransactionSigner::new).collect(Collectors.toList());
-        List<?> params = asList(scriptHash.toString(), methodParams, txSigners);
+        List<?> params = asList(scriptHash, methodParams, txSigners);
         return new Request<>(
                 "invokecontractverify",
                 params.stream().filter(Objects::nonNull).collect(Collectors.toList()),
@@ -888,7 +886,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoGetWalletBalance> getWalletBalance(Hash160 assetId) {
         return new Request<>(
                 "getwalletbalance",
-                singletonList(assetId.toString()),
+                singletonList(assetId),
                 neow3jService,
                 NeoGetWalletBalance.class);
     }
@@ -993,6 +991,21 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     @Override
     public Request<?, NeoSendFrom> sendFrom(String fromAddress, String assetId,
             String toAddress, String value) {
+        return sendFrom(fromAddress, new Hash160(assetId), toAddress, value);
+    }
+
+    /**
+     * Transfers an amount of an asset from an address to another address.
+     *
+     * @param fromAddress the transferring address.
+     * @param assetId     the script hash of the NEP17 contract.
+     * @param toAddress   the destination address.
+     * @param value       the transfer amount.
+     * @return the request object.
+     */
+    @Override
+    public Request<?, NeoSendFrom> sendFrom(String fromAddress, Hash160 assetId,
+            String toAddress, String value) {
         return new Request<>(
                 "sendfrom",
                 asList(assetId, fromAddress, toAddress, value),
@@ -1028,7 +1041,9 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoSendMany> sendMany(List<TransactionSendAsset> txSendAsset) {
         return new Request<>(
                 "sendmany",
-                asList(txSendAsset.stream().filter(Objects::nonNull).collect(Collectors.toList())),
+                singletonList(txSendAsset.stream()
+                        .filter(Objects::nonNull)
+                        .collect(Collectors.toList())),
                 neow3jService,
                 NeoSendMany.class);
     }
@@ -1038,7 +1053,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
      * address in a transaction.
      *
      * @param fromAddress the transferring address.
-     * @param txSendAsset a list of {@code TransactoinSendAsset} objects, that
+     * @param txSendAsset a list of {@code TransactionSendAsset} objects, that
      *                    each contains the asset, destination address and
      *                    transfer amount.
      * @return the request object.
@@ -1066,10 +1081,24 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     @Override
     public Request<?, NeoSendToAddress> sendToAddress(String assetId, String toAddress,
             String value) {
+        return sendToAddress(new Hash160(assetId), toAddress, value);
+    }
+
+    /**
+     * Transfers an amount of an asset to another address.
+     *
+     * @param assetId   the script hash of the NEP17 contract.
+     * @param toAddress the destination address.
+     * @param value     the transfer amount.
+     * @return the request object.
+     */
+    @Override
+    public Request<?, NeoSendToAddress> sendToAddress(Hash160 assetId, String toAddress,
+            String value) {
         return new Request<>(
                 "sendtoaddress",
                 Stream.of(assetId, toAddress, value)
-                        .filter((param) -> (param != null && !isEmpty(param)))
+                        .filter(Objects::nonNull)
                         .collect(Collectors.toList()),
                 neow3jService,
                 NeoSendToAddress.class);
@@ -1112,7 +1141,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoGetApplicationLog> getApplicationLog(Hash256 txId) {
         return new Request<>(
                 "getapplicationlog",
-                singletonList(txId.toString()),
+                singletonList(txId),
                 neow3jService,
                 NeoGetApplicationLog.class);
     }
@@ -1216,7 +1245,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
             String storageKeyHex) {
         return new Request<>(
                 "getproof",
-                asList(rootHash.toString(), contractScriptHash.toString(),
+                asList(rootHash, contractScriptHash,
                         Base64.encode(storageKeyHex)),
                 neow3jService,
                 NeoGetProof.class);
@@ -1233,7 +1262,7 @@ public class JsonRpc2_0Neow3j extends Neow3j {
     public Request<?, NeoVerifyProof> verifyProof(Hash256 rootHash, String proofDataHex) {
         return new Request<>(
                 "verifyproof",
-                asList(rootHash.toString(), Base64.encode(proofDataHex)),
+                asList(rootHash, Base64.encode(proofDataHex)),
                 neow3jService,
                 NeoVerifyProof.class);
     }

--- a/core/src/main/java/io/neow3j/protocol/core/Neo.java
+++ b/core/src/main/java/io/neow3j/protocol/core/Neo.java
@@ -199,6 +199,9 @@ public interface Neo {
     Request<?, NeoSendFrom> sendFrom(String fromAddress, String assetId, String toAddress,
             String value);
 
+    Request<?, NeoSendFrom> sendFrom(String fromAddress, Hash160 assetId, String toAddress,
+            String value);
+
     Request<?, NeoSendFrom> sendFrom(String fromAddress, TransactionSendAsset txSendAsset);
 
     Request<?, NeoSendMany> sendMany(List<TransactionSendAsset> txSendAsset);
@@ -206,6 +209,8 @@ public interface Neo {
     Request<?, NeoSendMany> sendMany(String fromAddress, List<TransactionSendAsset> txSendAsset);
 
     Request<?, NeoSendToAddress> sendToAddress(String assetId, String toAddress, String value);
+
+    Request<?, NeoSendToAddress> sendToAddress(Hash160 assetId, String toAddress, String value);
 
     Request<?, NeoSendToAddress> sendToAddress(TransactionSendAsset txSendAsset);
 

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/ByteArrayStackItem.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/ByteArrayStackItem.java
@@ -11,6 +11,7 @@ import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Objects;
 
+import static io.neow3j.utils.ArrayUtils.reverseArray;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 /**
@@ -55,7 +56,7 @@ abstract class ByteArrayStackItem extends StackItem {
     public String getAddress() {
         nullCheck();
         try {
-            return new Hash160(value).toAddress();
+            return new Hash160(reverseArray(value)).toAddress();
         } catch (IllegalArgumentException e) {
             throw new StackItemCastException(e);
         }

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/TransactionSendAsset.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/TransactionSendAsset.java
@@ -2,6 +2,7 @@ package io.neow3j.protocol.core.methods.response;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.neow3j.contract.Hash160;
 
 import java.util.Objects;
 
@@ -9,7 +10,7 @@ import java.util.Objects;
 public class TransactionSendAsset {
 
     @JsonProperty("asset")
-    private String asset;
+    private Hash160 asset;
 
     @JsonProperty("value")
     private String value;
@@ -20,13 +21,13 @@ public class TransactionSendAsset {
     public TransactionSendAsset() {
     }
 
-    public TransactionSendAsset(String asset, String value, String address) {
+    public TransactionSendAsset(Hash160 asset, String value, String address) {
         this.asset = asset;
         this.value = value;
         this.address = address;
     }
 
-    public String getAsset() {
+    public Hash160 getAsset() {
         return asset;
     }
 

--- a/core/src/main/java/io/neow3j/protocol/core/methods/response/TransactionSigner.java
+++ b/core/src/main/java/io/neow3j/protocol/core/methods/response/TransactionSigner.java
@@ -19,7 +19,7 @@ import java.util.stream.Collectors;
 public class TransactionSigner {
 
     @JsonProperty(value = "account", required = true)
-    private String account;
+    private Hash160 account;
 
     @JsonProperty(value = "scopes", required = true)
     @JsonFormat(with = JsonFormat.Feature.ACCEPT_SINGLE_VALUE_AS_ARRAY)
@@ -37,7 +37,7 @@ public class TransactionSigner {
     }
 
     public TransactionSigner(Signer signer) {
-        this.account = signer.getScriptHash().toString();
+        this.account = signer.getScriptHash();
         this.scopes = signer.getScopes();
         this.allowedContracts = signer.getAllowedContracts().stream()
                 .map(Hash160::toString)
@@ -47,7 +47,7 @@ public class TransactionSigner {
                 .collect(Collectors.toList());
     }
 
-    public TransactionSigner(String account, List<WitnessScope> scopes,
+    public TransactionSigner(Hash160 account, List<WitnessScope> scopes,
             List<String> allowedContracts, List<String> allowedGroups) {
         this.account = account;
         this.scopes = scopes;
@@ -55,11 +55,11 @@ public class TransactionSigner {
         this.allowedGroups = allowedGroups;
     }
 
-    public TransactionSigner(String account, List<WitnessScope> scopes) {
+    public TransactionSigner(Hash160 account, List<WitnessScope> scopes) {
         this(account, scopes, new ArrayList<>(), new ArrayList<>());
     }
 
-    public String getAccount() {
+    public Hash160 getAccount() {
         return account;
     }
 

--- a/core/src/main/java/io/neow3j/transaction/Signer.java
+++ b/core/src/main/java/io/neow3j/transaction/Signer.java
@@ -158,22 +158,22 @@ public class Signer extends NeoSerializable {
     @Override
     public void deserialize(BinaryReader reader) throws DeserializationException {
         try {
-            this.account = reader.readSerializable(Hash160.class);
-            this.scopes = WitnessScope.extractCombinedScopes(reader.readByte());
-            if (this.scopes.contains(WitnessScope.CUSTOM_CONTRACTS)) {
-                this.allowedContracts = reader.readSerializableList(Hash160.class);
-                if (this.allowedContracts.size() > NeoConstants.MAX_SIGNER_SUBITEMS) {
+            account = reader.readSerializable(Hash160.class);
+            scopes = WitnessScope.extractCombinedScopes(reader.readByte());
+            if (scopes.contains(WitnessScope.CUSTOM_CONTRACTS)) {
+                allowedContracts = reader.readSerializableList(Hash160.class);
+                if (allowedContracts.size() > NeoConstants.MAX_SIGNER_SUBITEMS) {
                     throw new DeserializationException("A signer's scope can only contain "
                             + NeoConstants.MAX_SIGNER_SUBITEMS + " contracts. The input data "
-                            + "contained " + this.allowedContracts.size() + " contracts.");
+                            + "contained " + allowedContracts.size() + " contracts.");
                 }
             }
-            if (this.scopes.contains(WitnessScope.CUSTOM_GROUPS)) {
-                this.allowedGroups = reader.readSerializableList(ECKeyPair.ECPublicKey.class);
-                if (this.allowedGroups.size() > NeoConstants.MAX_SIGNER_SUBITEMS) {
+            if (scopes.contains(WitnessScope.CUSTOM_GROUPS)) {
+                allowedGroups = reader.readSerializableList(ECKeyPair.ECPublicKey.class);
+                if (allowedGroups.size() > NeoConstants.MAX_SIGNER_SUBITEMS) {
                     throw new DeserializationException("A signer's scope can only contain "
                             + NeoConstants.MAX_SIGNER_SUBITEMS + " groups. The input data "
-                            + "contained " + this.allowedGroups.size() + " groups.");
+                            + "contained " + allowedGroups.size() + " groups.");
                 }
             }
         } catch (IOException e) {
@@ -183,13 +183,13 @@ public class Signer extends NeoSerializable {
 
     @Override
     public void serialize(BinaryWriter writer) throws IOException {
-        writer.writeSerializableFixed(this.account);
-        writer.writeByte(WitnessScope.combineScopes(this.scopes));
+        writer.writeSerializableFixed(account);
+        writer.writeByte(WitnessScope.combineScopes(scopes));
         if (scopes.contains(WitnessScope.CUSTOM_CONTRACTS)) {
-            writer.writeSerializableVariable(this.allowedContracts);
+            writer.writeSerializableVariable(allowedContracts);
         }
         if (scopes.contains(WitnessScope.CUSTOM_GROUPS)) {
-            writer.writeSerializableVariable(this.allowedGroups);
+            writer.writeSerializableVariable(allowedGroups);
         }
     }
 

--- a/core/src/main/java/io/neow3j/transaction/Transaction.java
+++ b/core/src/main/java/io/neow3j/transaction/Transaction.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static io.neow3j.crypto.Hash.sha256;
+import static io.neow3j.utils.ArrayUtils.reverseArray;
 
 public class Transaction extends NeoSerializable {
 
@@ -157,7 +158,7 @@ public class Transaction extends NeoSerializable {
      * @return the transaction ID.
      */
     public Hash256 getTxId() {
-        return new Hash256(sha256(toArrayWithoutWitnesses()));
+        return new Hash256(reverseArray(sha256(toArrayWithoutWitnesses())));
     }
 
     /**

--- a/core/src/test-integration/java/io/neow3j/protocol/Neow3jReadOnlyIntegrationTest.java
+++ b/core/src/test-integration/java/io/neow3j/protocol/Neow3jReadOnlyIntegrationTest.java
@@ -150,7 +150,7 @@ public class Neow3jReadOnlyIntegrationTest {
 
     private static Hash256 transferNeo(String toAddress, String amount) throws IOException {
         NeoSendToAddress send = getNeow3j()
-                .sendToAddress(neoTokenHash(), toAddress, amount)
+                .sendToAddress(NEO_HASH, toAddress, amount)
                 .send();
         Hash256 txHash = send.getSendToAddress().getHash();
         // ensure that the transaction is sent
@@ -160,7 +160,7 @@ public class Neow3jReadOnlyIntegrationTest {
 
     private static Hash256 transferGas(String toAddress, String amount) throws IOException {
         NeoSendToAddress send = getNeow3j()
-                .sendToAddress(gasTokenHash(), toAddress, amount)
+                .sendToAddress(GAS_HASH, toAddress, amount)
                 .send();
         Hash256 txHash = send.getSendToAddress().getHash();
         // ensure that the transaction is sent

--- a/core/src/test-integration/java/io/neow3j/protocol/Neow3jWriteIntegrationTest.java
+++ b/core/src/test-integration/java/io/neow3j/protocol/Neow3jWriteIntegrationTest.java
@@ -24,7 +24,6 @@ import java.io.IOException;
 import static io.neow3j.NeoTestContainer.getNodeUrl;
 import static io.neow3j.TestProperties.committeeAccountAddress;
 import static io.neow3j.TestProperties.defaultAccountAddress;
-import static io.neow3j.TestProperties.neoTokenHash;
 import static io.neow3j.contract.ContractParameter.hash160;
 import static io.neow3j.protocol.IntegrationTestHelper.NEO_HASH;
 import static io.neow3j.protocol.IntegrationTestHelper.NODE_WALLET_PASSWORD;
@@ -60,7 +59,7 @@ public class Neow3jWriteIntegrationTest {
         // open the wallet for JSON-RPC calls
         getNeow3j().openWallet(NODE_WALLET_PATH, NODE_WALLET_PASSWORD).send();
         // ensure that the wallet with NEO/GAS is initialized for the tests
-        Await.waitUntilOpenWalletHasBalanceGreaterThanOrEqualTo("1", new Hash160(neoTokenHash()),
+        Await.waitUntilOpenWalletHasBalanceGreaterThanOrEqualTo("1", NEO_HASH,
                 getNeow3j());
     }
 
@@ -106,7 +105,7 @@ public class Neow3jWriteIntegrationTest {
     @Test
     public void testSendFrom() throws IOException {
         NeoSendFrom sendFrom = getNeow3j()
-                .sendFrom(committeeAccountAddress(), neoTokenHash(), defaultAccountAddress(), "10")
+                .sendFrom(committeeAccountAddress(), NEO_HASH, defaultAccountAddress(), "10")
                 .send();
 
         Transaction tx = sendFrom.getSendFrom();
@@ -119,7 +118,8 @@ public class Neow3jWriteIntegrationTest {
     @Test
     public void testSendFrom_TransactionSendAsset() throws IOException {
         TransactionSendAsset txSendAsset =
-                new TransactionSendAsset(neoTokenHash(), "10", defaultAccountAddress());
+                new TransactionSendAsset(NEO_HASH, "10",
+                        defaultAccountAddress());
         NeoSendFrom sendFrom = getNeow3j()
                 .sendFrom(committeeAccountAddress(), txSendAsset)
                 .send();
@@ -135,8 +135,8 @@ public class Neow3jWriteIntegrationTest {
     public void testSendMany() throws IOException {
         NeoSendMany sendMany = getNeow3j()
                 .sendMany(asList(
-                        new TransactionSendAsset(neoTokenHash(), "100", defaultAccountAddress()),
-                        new TransactionSendAsset(neoTokenHash(), "10", RECIPIENT)))
+                        new TransactionSendAsset(NEO_HASH, "100", defaultAccountAddress()),
+                        new TransactionSendAsset(NEO_HASH, "10", RECIPIENT)))
                 .send();
 
         assertNotNull(sendMany.getSendMany());
@@ -152,8 +152,8 @@ public class Neow3jWriteIntegrationTest {
     public void testSendManyWithFrom() throws IOException {
         NeoSendMany response = getNeow3j()
                 .sendMany(committeeAccountAddress(), asList(
-                        new TransactionSendAsset(neoTokenHash(), "100", defaultAccountAddress()),
-                        new TransactionSendAsset(neoTokenHash(), "10", RECIPIENT)))
+                        new TransactionSendAsset(NEO_HASH, "100", defaultAccountAddress()),
+                        new TransactionSendAsset(NEO_HASH, "10", RECIPIENT)))
                 .send();
 
         assertNotNull(response.getSendMany());
@@ -187,7 +187,7 @@ public class Neow3jWriteIntegrationTest {
     @Test
     public void testSendToAddress() throws IOException {
         NeoSendToAddress sendToAddress = getNeow3j()
-                .sendToAddress(neoTokenHash(), defaultAccountAddress(), "10")
+                .sendToAddress(NEO_HASH, defaultAccountAddress(), "10")
                 .send();
 
         Transaction tx = sendToAddress.getSendToAddress();
@@ -197,7 +197,7 @@ public class Neow3jWriteIntegrationTest {
 
     @Test
     public void testSendToAddress_TransactionSendAsset() throws IOException {
-        TransactionSendAsset transactionSendAsset = new TransactionSendAsset(neoTokenHash(), "10",
+        TransactionSendAsset transactionSendAsset = new TransactionSendAsset(NEO_HASH, "10",
                 defaultAccountAddress());
         NeoSendToAddress sendToAddress = getNeow3j()
                 .sendToAddress(transactionSendAsset)

--- a/core/src/test/java/io/neow3j/contract/Hash160Test.java
+++ b/core/src/test/java/io/neow3j/contract/Hash160Test.java
@@ -3,7 +3,11 @@ package io.neow3j.contract;
 import static io.neow3j.TestProperties.committeeAccountScriptHash;
 import static io.neow3j.TestProperties.defaultAccountAddress;
 import static io.neow3j.TestProperties.defaultAccountPublicKey;
-import static io.neow3j.TestProperties.defaultAccountScriptHash;
+import static io.neow3j.crypto.Hash.sha256AndThenRipemd160;
+import static io.neow3j.utils.ArrayUtils.reverseArray;
+import static io.neow3j.utils.Numeric.hexStringToByteArray;
+import static io.neow3j.utils.Numeric.toHexStringNoPrefix;
+import static java.util.Collections.singletonList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
@@ -12,16 +16,12 @@ import static org.junit.Assert.assertNotEquals;
 
 import io.neow3j.constants.InteropServiceCode;
 import io.neow3j.constants.OpCode;
-import io.neow3j.crypto.Hash;
 import io.neow3j.io.BinaryWriter;
 import io.neow3j.io.NeoSerializableInterface;
 import io.neow3j.io.exceptions.DeserializationException;
-import io.neow3j.utils.ArrayUtils;
-import io.neow3j.utils.Numeric;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
 
 import org.junit.Rule;
 import org.junit.Test;
@@ -72,9 +72,9 @@ public class Hash160Test {
     @Test
     public void toArray() {
         Hash160 hash = new Hash160("23ba2703c53263e8d6e522dc32203339dcd8eee9");
-        byte[] expected = ArrayUtils.reverseArray(Numeric.hexStringToByteArray(
+        byte[] expected = reverseArray(hexStringToByteArray(
                 "23ba2703c53263e8d6e522dc32203339dcd8eee9"));
-        assertArrayEquals(expected, hash.toArray());
+        assertArrayEquals(expected, hash.toLittleEndianArray());
     }
 
     @Test
@@ -83,14 +83,14 @@ public class Hash160Test {
         BinaryWriter writer = new BinaryWriter(outStream);
         new Hash160("23ba2703c53263e8d6e522dc32203339dcd8eee9").serialize(writer);
         byte[] actual = outStream.toByteArray();
-        byte[] expected = ArrayUtils.reverseArray(Numeric.hexStringToByteArray(
+        byte[] expected = reverseArray(hexStringToByteArray(
                 "23ba2703c53263e8d6e522dc32203339dcd8eee9"));
         assertArrayEquals(expected, actual);
     }
 
     @Test
     public void deserialize() throws DeserializationException {
-        byte[] data = ArrayUtils.reverseArray(Numeric.hexStringToByteArray(
+        byte[] data = reverseArray(hexStringToByteArray(
                 "23ba2703c53263e8d6e522dc32203339dcd8eee9"));
         Hash160 hash = NeoSerializableInterface.from(data, Hash160.class);
         assertThat(hash.toString(), is("23ba2703c53263e8d6e522dc32203339dcd8eee9"));
@@ -99,9 +99,9 @@ public class Hash160Test {
     @Test
     public void equals() {
         // first message has script hash 159759880646822985762674987218710759559479736571 (as integer)
-        byte[] m1 = Numeric.hexStringToByteArray("01a402d8");
+        byte[] m1 = hexStringToByteArray("01a402d8");
         // first message has script hash 776468865644545852461964229176363821261390671687 (as integer)
-        byte[] m2 = Numeric.hexStringToByteArray("d802a401");
+        byte[] m2 = hexStringToByteArray("d802a401");
         Hash160 hash1 = Hash160.fromScript(m1);
         Hash160 hash2 = Hash160.fromScript(m2);
         assertNotEquals(hash1, hash2);
@@ -112,9 +112,8 @@ public class Hash160Test {
     @Test
     public void fromValidAddress() {
         Hash160 hash = Hash160.fromAddress("NLnyLtep7jwyq1qhNPkwXbJpurC4jUT8ke");
-        byte[] expectedHash = Numeric.hexStringToByteArray(
-                "09a55874c2da4b86e5d49ff530a1b153eb12c7d6");
-        assertThat(hash.toArray(), is(expectedHash));
+        byte[] expectedHash = hexStringToByteArray("09a55874c2da4b86e5d49ff530a1b153eb12c7d6");
+        assertThat(hash.toLittleEndianArray(), is(expectedHash));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -125,21 +124,21 @@ public class Hash160Test {
     @Test
     public void fromPublicKeyByteArray() {
         final String key = "035fdb1d1f06759547020891ae97c729327853aeb1256b6fe0473bc2e9fa42ff50";
-        byte[] script = Numeric.hexStringToByteArray(""
+        byte[] script = hexStringToByteArray(""
                 + OpCode.PUSHDATA1.toString() + "21"  // PUSHDATA 33 bytes
                 + key // public key
                 + OpCode.SYSCALL.toString()
                 + InteropServiceCode.NEO_CRYPTO_CHECKSIG.getHash()
         );
 
-        Hash160 hash = Hash160.fromPublicKey(Numeric.hexStringToByteArray(key));
-        assertThat(hash.toArray(), is(Hash.sha256AndThenRipemd160(script)));
+        Hash160 hash = Hash160.fromPublicKey(hexStringToByteArray(key));
+        assertThat(hash.toLittleEndianArray(), is(sha256AndThenRipemd160(script)));
     }
 
     @Test
     public void fromPublicKeyByteArrays() {
         Hash160 hash = Hash160.fromPublicKeys(
-                Arrays.asList(Numeric.hexStringToByteArray(defaultAccountPublicKey())), 1);
+                singletonList(hexStringToByteArray(defaultAccountPublicKey())), 1);
         assertThat(hash.toString(), is(committeeAccountScriptHash()));
     }
 
@@ -150,7 +149,7 @@ public class Hash160Test {
 
         String bigEndian = hash.toString();
         assertThat(bigEndian, is("afaed076854454449770763a628f379721ea9808"));
-        String littleEndian = Numeric.toHexStringNoPrefix(hash.toArray());
+        String littleEndian = toHexStringNoPrefix(hash.toLittleEndianArray());
         assertThat(littleEndian, is("0898ea2197378f623a7670974454448576d0aeaf"));
     }
 
@@ -158,18 +157,18 @@ public class Hash160Test {
     public void toAddress() {
         final String key = "031ccaaa46df7c494f442698c8c17c09311e3615c2dc042cbd3afeaba60fa40740";
         // Address generated from the above key, with address version 0x35.
-        Hash160 sh = Hash160.fromPublicKey(Numeric.hexStringToByteArray(defaultAccountPublicKey()));
+        Hash160 sh = Hash160.fromPublicKey(hexStringToByteArray(defaultAccountPublicKey()));
         assertThat(sh.toAddress(), is(defaultAccountAddress()));
     }
 
     @Test
     public void compareTo() {
         // first message has script hash 159759880646822985762674987218710759559479736571 (as integer)
-        byte[] m1 = Numeric.hexStringToByteArray("01a402d8");
+        byte[] m1 = hexStringToByteArray("01a402d8");
         // first message has script hash 776468865644545852461964229176363821261390671687 (as integer)
-        byte[] m2 = Numeric.hexStringToByteArray("d802a401");
+        byte[] m2 = hexStringToByteArray("d802a401");
         // first message has script hash 226912894221247444770625744046962264064050576762 (as integer)
-        byte[] m3 = Numeric.hexStringToByteArray("a7b3a191");
+        byte[] m3 = hexStringToByteArray("a7b3a191");
         Hash160 hash1 = Hash160.fromScript(m1);
         Hash160 hash2 = Hash160.fromScript(m2);
         Hash160 hash3 = Hash160.fromScript(m3);

--- a/core/src/test/java/io/neow3j/contract/Hash256Test.java
+++ b/core/src/test/java/io/neow3j/contract/Hash256Test.java
@@ -2,7 +2,6 @@ package io.neow3j.contract;
 
 import static io.neow3j.utils.ArrayUtils.reverseArray;
 import static io.neow3j.utils.Numeric.hexStringToByteArray;
-import static io.neow3j.utils.Numeric.reverseHexString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;

--- a/core/src/test/java/io/neow3j/contract/Hash256Test.java
+++ b/core/src/test/java/io/neow3j/contract/Hash256Test.java
@@ -1,6 +1,8 @@
 package io.neow3j.contract;
 
 import static io.neow3j.utils.ArrayUtils.reverseArray;
+import static io.neow3j.utils.Numeric.hexStringToByteArray;
+import static io.neow3j.utils.Numeric.reverseHexString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
@@ -10,8 +12,6 @@ import static org.junit.Assert.assertNotEquals;
 import io.neow3j.io.BinaryWriter;
 import io.neow3j.io.NeoSerializableInterface;
 import io.neow3j.io.exceptions.DeserializationException;
-import io.neow3j.utils.ArrayUtils;
-import io.neow3j.utils.Numeric;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -67,8 +67,8 @@ public class Hash256Test {
 
     @Test
     public void hashFromByteArray() {
-        byte[] b = Numeric.hexStringToByteArray(Numeric.reverseHexString(
-                "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
+        byte[] b = hexStringToByteArray(
+                "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a");
         Hash256 hash = new Hash256(b);
         assertThat(hash.toString(),
                 is("b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
@@ -78,9 +78,9 @@ public class Hash256Test {
     public void toArray() {
         Hash256 hash =
                 new Hash256("b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a");
-        byte[] expected = reverseArray(Numeric.hexStringToByteArray(
+        byte[] expected = reverseArray(hexStringToByteArray(
                 "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
-        assertArrayEquals(expected, hash.toArray());
+        assertArrayEquals(expected, hash.toLittleEndianArray());
     }
 
     @Test
@@ -90,14 +90,14 @@ public class Hash256Test {
         new Hash256("b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a")
                 .serialize(writer);
         byte[] actual = outStream.toByteArray();
-        byte[] expected = reverseArray(Numeric.hexStringToByteArray(
+        byte[] expected = reverseArray(hexStringToByteArray(
                 "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
         assertArrayEquals(expected, actual);
     }
 
     @Test
     public void deserialize() throws DeserializationException {
-        byte[] data = reverseArray(Numeric.hexStringToByteArray(
+        byte[] data = reverseArray(hexStringToByteArray(
                 "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
         Hash256 hash = NeoSerializableInterface.from(data, Hash256.class);
         assertThat(hash.toString(),
@@ -108,14 +108,12 @@ public class Hash256Test {
     public void equals() {
         // first message has script hash 159759880646822985762674987218710759559479736571 (as
         // integer)
-        byte[] bytes1 = Numeric
-                .hexStringToByteArray(
-                        "1aa274391ab7127ca6d6b917d413919000ebee2b14974e67b49ac62082a904b8");
+        byte[] bytes1 = reverseArray(hexStringToByteArray(
+                "1aa274391ab7127ca6d6b917d413919000ebee2b14974e67b49ac62082a904b8"));
         // first message has script hash 776468865644545852461964229176363821261390671687 (as
         // integer)
-        byte[] bytes2 =
-                Numeric.hexStringToByteArray(
-                        "b43034ab680d646f8b6ca71647aa6ba167b2eb0b3757e545f6c2715787b13272");
+        byte[] bytes2 = reverseArray(hexStringToByteArray(
+                "b43034ab680d646f8b6ca71647aa6ba167b2eb0b3757e545f6c2715787b13272"));
         Hash256 hash1 = new Hash256(bytes1);
         Hash256 hash2 = new Hash256(bytes2);
         Hash256 hash3 =
@@ -129,12 +127,10 @@ public class Hash256Test {
 
     @Test
     public void compareTo() {
-        byte[] bytes1 = Numeric
-                .hexStringToByteArray(
-                        "1aa274391ab7127ca6d6b917d413919000ebee2b14974e67b49ac62082a904b8");
-        byte[] bytes2 =
-                Numeric.hexStringToByteArray(
-                        "b43034ab680d646f8b6ca71647aa6ba167b2eb0b3757e545f6c2715787b13272");
+        byte[] bytes1 = reverseArray(hexStringToByteArray(
+                "1aa274391ab7127ca6d6b917d413919000ebee2b14974e67b49ac62082a904b8"));
+        byte[] bytes2 = reverseArray(hexStringToByteArray(
+                "b43034ab680d646f8b6ca71647aa6ba167b2eb0b3757e545f6c2715787b13272"));
         Hash256 hash1 = new Hash256(bytes1);
         Hash256 hash2 = new Hash256(bytes2);
         Hash256 hash3 =

--- a/core/src/test/java/io/neow3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/RequestTest.java
@@ -664,7 +664,7 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
-    public void testSendFrom() throws Exception {
+    public void testSendFrom_assetIdAsString() throws Exception {
         neow3j.sendFrom(
                 "AHE5cLhX5NjGB5R2PcdUvGudUoGUBDeHX4",
                 "0xde5f57d430d3dece511cf975a8d37848cb9e0525",
@@ -674,7 +674,26 @@ public class RequestTest extends RequestTester {
 
         verifyResult("{\"jsonrpc\":\"2.0\"," +
                 "\"method\":\"sendfrom\"," +
-                "\"params\":[\"0xde5f57d430d3dece511cf975a8d37848cb9e0525\"," +
+                "\"params\":[\"de5f57d430d3dece511cf975a8d37848cb9e0525\"," +
+                "\"AHE5cLhX5NjGB5R2PcdUvGudUoGUBDeHX4\"," +
+                "\"AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb\"," +
+                "\"10.0\"" +
+                "]," +
+                "\"id\":1}");
+    }
+
+    @Test
+    public void testSendFrom() throws Exception {
+        neow3j.sendFrom(
+                "AHE5cLhX5NjGB5R2PcdUvGudUoGUBDeHX4",
+                new Hash160("0xde5f57d430d3dece511cf975a8d37848cb9e0525"),
+                "AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb",
+                "10.0"
+        ).send();
+
+        verifyResult("{\"jsonrpc\":\"2.0\"," +
+                "\"method\":\"sendfrom\"," +
+                "\"params\":[\"de5f57d430d3dece511cf975a8d37848cb9e0525\"," +
                 "\"AHE5cLhX5NjGB5R2PcdUvGudUoGUBDeHX4\"," +
                 "\"AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb\"," +
                 "\"10.0\"" +
@@ -687,7 +706,7 @@ public class RequestTest extends RequestTester {
         neow3j.sendFrom(
                 "AHE5cLhX5NjGB5R2PcdUvGudUoGUBDeHX4",
                 new TransactionSendAsset(
-                        "0xde5f57d430d3dece511cf975a8d37848cb9e0525",
+                        new Hash160("0xde5f57d430d3dece511cf975a8d37848cb9e0525"),
                         "10.0",
                         "AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb"
                 )
@@ -695,7 +714,7 @@ public class RequestTest extends RequestTester {
 
         verifyResult("{\"jsonrpc\":\"2.0\"," +
                 "\"method\":\"sendfrom\"," +
-                "\"params\":[\"0xde5f57d430d3dece511cf975a8d37848cb9e0525\"," +
+                "\"params\":[\"de5f57d430d3dece511cf975a8d37848cb9e0525\"," +
                 "\"AHE5cLhX5NjGB5R2PcdUvGudUoGUBDeHX4\"," +
                 "\"AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb\"," +
                 "\"10.0\"" +
@@ -708,11 +727,11 @@ public class RequestTest extends RequestTester {
         neow3j.sendMany(
                 asList(
                         new TransactionSendAsset(
-                                "0xde5f57d430d3dece511cf975a8d37848cb9e0525",
+                                new Hash160("0xde5f57d430d3dece511cf975a8d37848cb9e0525"),
                                 "100",
                                 "AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb"),
                         new TransactionSendAsset(
-                                "0xde5f57d430d3dece511cf975a8d37848cb9e0525",
+                                new Hash160("0xde5f57d430d3dece511cf975a8d37848cb9e0525"),
                                 "10",
                                 "AHE5cLhX5NjGB5R2PcdUvGudUoGUBDeHX4")
                 )
@@ -721,8 +740,8 @@ public class RequestTest extends RequestTester {
         verifyResult("{\"jsonrpc\":\"2.0\"," +
                 "\"method\":\"sendmany\"," +
                 "\"params\":[" +
-                "[{\"asset\":\"0xde5f57d430d3dece511cf975a8d37848cb9e0525\",\"value\":\"100\",\"address\":\"AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb\"}," +
-                "{\"asset\":\"0xde5f57d430d3dece511cf975a8d37848cb9e0525\",\"value\":\"10\",\"address\":\"AHE5cLhX5NjGB5R2PcdUvGudUoGUBDeHX4\"}]" +
+                "[{\"asset\":\"de5f57d430d3dece511cf975a8d37848cb9e0525\",\"value\":\"100\",\"address\":\"AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb\"}," +
+                "{\"asset\":\"de5f57d430d3dece511cf975a8d37848cb9e0525\",\"value\":\"10\",\"address\":\"AHE5cLhX5NjGB5R2PcdUvGudUoGUBDeHX4\"}]" +
                 "]," +
                 "\"id\":1}");
     }
@@ -743,11 +762,11 @@ public class RequestTest extends RequestTester {
                 "AGZLEiwUyCC4wiL5sRZA3LbxWPs9WrZeyN",
                 asList(
                         new TransactionSendAsset(
-                                "0xde5f57d430d3dece511cf975a8d37848cb9e0525",
+                                new Hash160("0xde5f57d430d3dece511cf975a8d37848cb9e0525"),
                                 "100",
                                 "AbRTHXb9zqdqn5sVh4EYpQHGZ536FgwCx2"),
                         new TransactionSendAsset(
-                                "0xde5f57d430d3dece511cf975a8d37848cb9e0525",
+                                new Hash160("0xde5f57d430d3dece511cf975a8d37848cb9e0525"),
                                 "10",
                                 "AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y")
                 )
@@ -760,12 +779,12 @@ public class RequestTest extends RequestTester {
                      "  \"params\": [\"AGZLEiwUyCC4wiL5sRZA3LbxWPs9WrZeyN\"," +
                      "  [" +
                      "     {" +
-                     "         \"asset\": \"0xde5f57d430d3dece511cf975a8d37848cb9e0525\", " +
+                     "         \"asset\": \"de5f57d430d3dece511cf975a8d37848cb9e0525\", " +
                      "         \"value\": \"100\"," +
                      "         \"address\": \"AbRTHXb9zqdqn5sVh4EYpQHGZ536FgwCx2\"" +
                      "     }," +
                      "     {" +
-                     "         \"asset\": \"0xde5f57d430d3dece511cf975a8d37848cb9e0525\", " +
+                     "         \"asset\": \"de5f57d430d3dece511cf975a8d37848cb9e0525\", " +
                      "         \"value\": \"10\"," +
                      "         \"address\": \"AK2nJJpJr6o664CWJKi1QRXjqeic2zRp8y\"}" +
                      "     ]" +
@@ -775,7 +794,7 @@ public class RequestTest extends RequestTester {
     }
 
     @Test
-    public void testSendToAddress() throws Exception {
+    public void testSendToAddress_assetIdAsString() throws Exception {
         neow3j.sendToAddress(
                 "0xde5f57d430d3dece511cf975a8d37848cb9e0525",
                 "AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb",
@@ -784,7 +803,24 @@ public class RequestTest extends RequestTester {
 
         verifyResult("{\"jsonrpc\":\"2.0\"," +
                 "\"method\":\"sendtoaddress\"," +
-                "\"params\":[\"0xde5f57d430d3dece511cf975a8d37848cb9e0525\"," +
+                "\"params\":[\"de5f57d430d3dece511cf975a8d37848cb9e0525\"," +
+                "\"AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb\"," +
+                "\"10.0\"" +
+                "]," +
+                "\"id\":1}");
+    }
+
+    @Test
+    public void testSendToAddress() throws Exception {
+        neow3j.sendToAddress(
+                new Hash160("0xde5f57d430d3dece511cf975a8d37848cb9e0525"),
+                "AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb",
+                "10.0"
+        ).send();
+
+        verifyResult("{\"jsonrpc\":\"2.0\"," +
+                "\"method\":\"sendtoaddress\"," +
+                "\"params\":[\"de5f57d430d3dece511cf975a8d37848cb9e0525\"," +
                 "\"AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb\"," +
                 "\"10.0\"" +
                 "]," +
@@ -795,14 +831,14 @@ public class RequestTest extends RequestTester {
     public void testSendToAddress_TransactionSendAsset() throws Exception {
         neow3j.sendToAddress(
                 new TransactionSendAsset(
-                        "0xde5f57d430d3dece511cf975a8d37848cb9e0525",
+                        new Hash160("0xde5f57d430d3dece511cf975a8d37848cb9e0525"),
                         "10.0",
                         "AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb")
         ).send();
 
         verifyResult("{\"jsonrpc\":\"2.0\"," +
                 "\"method\":\"sendtoaddress\"," +
-                "\"params\":[\"0xde5f57d430d3dece511cf975a8d37848cb9e0525\"," +
+                "\"params\":[\"de5f57d430d3dece511cf975a8d37848cb9e0525\"," +
                 "\"AcozGpiGDpp9Vt9RMyokWNyu7hh341T2bb\"," +
                 "\"10.0\"" +
                 "]," +

--- a/core/src/test/java/io/neow3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/ResponseTest.java
@@ -295,7 +295,7 @@ public class ResponseTest extends ResponseTester {
                                 "0",
                                 2107425L,
                                 singletonList(new TransactionSigner(
-                                        "0xf68f181731a47036a99f04dad90043a744edec0f",
+                                        new Hash160("0xf68f181731a47036a99f04dad90043a744edec0f"),
                                         singletonList(WitnessScope.CALLED_BY_ENTRY))
                                 ),
                                 emptyList(),
@@ -316,7 +316,7 @@ public class ResponseTest extends ResponseTester {
                                 "0",
                                 2107425L,
                                 singletonList(new TransactionSigner(
-                                        "0xf68f181731a47036a99f04dad90043a744edec0f",
+                                        new Hash160("0xf68f181731a47036a99f04dad90043a744edec0f"),
                                         singletonList(WitnessScope.CALLED_BY_ENTRY))
                                 ),
                                 emptyList(),
@@ -1126,7 +1126,8 @@ public class ResponseTest extends ResponseTester {
         List<TransactionSigner> signers = transaction.getSigners();
         assertThat(signers, is(notNullValue()));
         assertThat(signers, hasSize(1));
-        assertThat(signers.get(0).getAccount(), is("0xf68f181731a47036a99f04dad90043a744edec0f"));
+        assertThat(signers.get(0).getAccount(),
+                is(new Hash160("0xf68f181731a47036a99f04dad90043a744edec0f")));
         assertThat(signers.get(0).getScopes(), hasSize(1));
         assertThat(signers.get(0).getScopes().get(0), is(WitnessScope.CALLED_BY_ENTRY));
 
@@ -2078,7 +2079,7 @@ public class ResponseTest extends ResponseTester {
         assertThat(sendFrom.getSendFrom().getSigners(), is(notNullValue()));
         assertThat(sendFrom.getSendFrom().getSigners(), hasSize(1));
         assertThat(sendFrom.getSendFrom().getSigners().get(0).getAccount(),
-                is("0xf68f181731a47036a99f04dad90043a744edec0f"));
+                is(new Hash160("0xf68f181731a47036a99f04dad90043a744edec0f")));
         assertThat(sendFrom.getSendFrom().getSigners().get(0).getScopes(), hasSize(1));
         assertThat(sendFrom.getSendFrom().getSigners().get(0).getScopes().get(0), is(WitnessScope.CALLED_BY_ENTRY));
 
@@ -2152,16 +2153,16 @@ public class ResponseTest extends ResponseTester {
         assertThat(sendMany.getSendMany().getSigners(), is(notNullValue()));
         assertThat(sendMany.getSendMany().getSigners(), hasSize(2));
         assertThat(sendMany.getSendMany().getSigners().get(0).getAccount(),
-                is("0xbe175fb771d5782282b7598b56c26a2f5ebf2d24"));
+                is(new Hash160("0xbe175fb771d5782282b7598b56c26a2f5ebf2d24")));
         assertThat(sendMany.getSendMany().getSigners().get(0).getScopes(), hasSize(1));
         assertThat(sendMany.getSendMany().getSigners().get(0).getScopes().get(0), is(WitnessScope.CALLED_BY_ENTRY));
         assertThat(sendMany.getSendMany().getSigners(),
                 containsInAnyOrder(
                         new TransactionSigner(
-                                "0xbe175fb771d5782282b7598b56c26a2f5ebf2d24",
+                                new Hash160("0xbe175fb771d5782282b7598b56c26a2f5ebf2d24"),
                                 singletonList(WitnessScope.CALLED_BY_ENTRY)),
                         new TransactionSigner(
-                                "0xf68f181731a47036a99f04dad90043a744edec0f",
+                                new Hash160("0xf68f181731a47036a99f04dad90043a744edec0f"),
                                 singletonList(WitnessScope.CALLED_BY_ENTRY))
                 ));
 
@@ -2251,7 +2252,7 @@ public class ResponseTest extends ResponseTester {
         assertThat(sendToAddress.getSendToAddress().getSigners(), is(notNullValue()));
         assertThat(sendToAddress.getSendToAddress().getSigners(), hasSize(1));
         assertThat(sendToAddress.getSendToAddress().getSigners().get(0).getAccount(),
-                is("0xf68f181731a47036a99f04dad90043a744edec0f"));
+                is(new Hash160("0xf68f181731a47036a99f04dad90043a744edec0f")));
         assertThat(sendToAddress.getSendToAddress().getSigners().get(0).getScopes(), hasSize(1));
         assertThat(sendToAddress.getSendToAddress().getSigners().get(0).getScopes().get(0),
                 is(WitnessScope.CALLED_BY_ENTRY));

--- a/core/src/test/java/io/neow3j/transaction/TransactionTest.java
+++ b/core/src/test/java/io/neow3j/transaction/TransactionTest.java
@@ -1,6 +1,7 @@
 package io.neow3j.transaction;
 
 import static io.neow3j.crypto.Hash.sha256;
+import static io.neow3j.utils.Numeric.hexStringToByteArray;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
@@ -61,7 +62,7 @@ public class TransactionTest {
                 new ArrayList<>());
 
         byte[] actual = tx.toArray();
-        byte[] expected = Numeric.hexStringToByteArray(""
+        byte[] expected = hexStringToByteArray(""
                 + "00" // version
                 + "04030201"  // nonce
                 + "00e1f50500000000"  // system fee (1 GAS)
@@ -97,7 +98,7 @@ public class TransactionTest {
                 witnesses);
 
         byte[] actual = tx.toArray();
-        byte[] expected = Numeric.hexStringToByteArray(""
+        byte[] expected = hexStringToByteArray(""
                 + "00" // version
                 + "04030201"  // nonce
                 + "00e1f50500000000"  // system fee (1 GAS)
@@ -117,7 +118,7 @@ public class TransactionTest {
 
     @Test
     public void deserialize() throws DeserializationException {
-        byte[] data = Numeric.hexStringToByteArray(""
+        byte[] data = hexStringToByteArray(""
                 + "00" // version
                 + "62bdaa0e"  // nonce
                 + "c272890000000000"  // system fee
@@ -202,7 +203,7 @@ public class TransactionTest {
                 + "01" + OpCode.PUSH1.toString()  // 1-byte script with PUSH1 OpCode
                 + "01" // 1 witness
                 + "01000100"); /* witness*/
-        byte[] txBytes = Numeric.hexStringToByteArray(txString.toString());
+        byte[] txBytes = hexStringToByteArray(txString.toString());
         NeoSerializableInterface.from(txBytes, Transaction.class);
     }
 
@@ -221,7 +222,7 @@ public class TransactionTest {
                 9007990L,
                 1244390L,
                 new ArrayList<>(),
-                Numeric.hexStringToByteArray(
+                hexStringToByteArray(
                         "110c146cd3d4f4f7e35c5ee7d0e725c11dc880cef1e8b10c14c6a1c24a5b87fb8ccd7ac5f7948ffe526d4e01f713c00c087472616e736665720c1425059ecb4878d3a875f91c51ceded330d4575fde41627d5b5238"),
                 new ArrayList<>());
 
@@ -242,11 +243,11 @@ public class TransactionTest {
                 9007990L,
                 1244390L,
                 new ArrayList<>(),
-                Numeric.hexStringToByteArray(
+                hexStringToByteArray(
                         "110c146cd3d4f4f7e35c5ee7d0e725c11dc880cef1e8b10c14c6a1c24a5b87fb8ccd7ac5f7948ffe526d4e01f713c00c087472616e736665720c1425059ecb4878d3a875f91c51ceded330d4575fde41627d5b5238"),
                 new ArrayList<>());
 
-        byte[] expectedUnsignedBytes = Numeric.hexStringToByteArray(
+        byte[] expectedUnsignedBytes = hexStringToByteArray(
                 "00a2f17c0d7673890000000000e6fc120000000000661820000175715e89bbba44a25dc9ca8d4951f104c25c253d010055110c146cd3d4f4f7e35c5ee7d0e725c11dc880cef1e8b10c14c6a1c24a5b87fb8ccd7ac5f7948ffe526d4e01f713c00c087472616e736665720c1425059ecb4878d3a875f91c51ceded330d4575fde41627d5b5238");
         assertThat(tx.toArrayWithoutWitnesses(), is(expectedUnsignedBytes));
     }
@@ -267,7 +268,7 @@ public class TransactionTest {
                 new byte[]{1, 2, 3},
                 new ArrayList<>());
 
-        byte[] txHexWithoutWitness = Numeric.hexStringToByteArray(
+        byte[] txHexWithoutWitness = hexStringToByteArray(
                 "000000000000000000000000000000000000000000000000000193ad1572a4b35c4b925483ce1701b78742dc460f000003010203");
         byte[] expectedData = ArrayUtils.concatenate(neow.getNetworkMagicNumber(),
                 sha256(txHexWithoutWitness));

--- a/core/src/test/java/io/neow3j/transaction/WitnessTest.java
+++ b/core/src/test/java/io/neow3j/transaction/WitnessTest.java
@@ -5,12 +5,9 @@ import io.neow3j.constants.OpCode;
 import io.neow3j.contract.Hash160;
 import io.neow3j.crypto.ECKeyPair;
 import io.neow3j.crypto.ECKeyPair.ECPublicKey;
-import io.neow3j.crypto.Hash;
-import io.neow3j.crypto.Sign;
 import io.neow3j.crypto.Sign.SignatureData;
 import io.neow3j.io.NeoSerializableInterface;
 import io.neow3j.io.exceptions.DeserializationException;
-import io.neow3j.utils.Numeric;
 import org.junit.Test;
 
 import java.math.BigInteger;
@@ -24,7 +21,13 @@ import java.util.List;
 import static io.neow3j.constants.OpCode.PUSH2;
 import static io.neow3j.constants.OpCode.PUSHDATA1;
 import static io.neow3j.constants.OpCode.SYSCALL;
+import static io.neow3j.crypto.ECKeyPair.createEcKeyPair;
+import static io.neow3j.crypto.Hash.sha256AndThenRipemd160;
+import static io.neow3j.crypto.Sign.signMessage;
+import static io.neow3j.transaction.Witness.createMultiSigWitness;
 import static io.neow3j.utils.ArrayUtils.concatenate;
+import static io.neow3j.utils.Numeric.hexStringToByteArray;
+import static io.neow3j.utils.Numeric.toHexStringNoPrefix;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 
@@ -36,28 +39,28 @@ public class WitnessTest {
 
         byte[] message = new byte[10];
         Arrays.fill(message, (byte) 10);
-        ECKeyPair keyPair = ECKeyPair.createEcKeyPair();
+        ECKeyPair keyPair = createEcKeyPair();
         Witness witness = Witness.create(message, keyPair);
 
         // Test invocation script
-        SignatureData expectedSig = Sign.signMessage(message, keyPair);
+        SignatureData expectedSig = signMessage(message, keyPair);
         String expected = "" +
                 PUSHDATA1.toString() + "40" + // 64 bytes of signature data
-                Numeric.toHexStringNoPrefix(expectedSig.getConcatenated()); // signature
+                toHexStringNoPrefix(expectedSig.getConcatenated()); // signature
 
         assertArrayEquals(
-                Numeric.hexStringToByteArray(expected),
+                hexStringToByteArray(expected),
                 witness.getInvocationScript().getScript());
 
         // Test verification script
         expected = "" +
                 PUSHDATA1.toString() + "21" + // 33 bytes of public key
-                Numeric.toHexStringNoPrefix(keyPair.getPublicKey().getEncoded(true)) + // pubKey
+                toHexStringNoPrefix(keyPair.getPublicKey().getEncoded(true)) + // pubKey
                 SYSCALL.toString() + // syscall to...
                 InteropServiceCode.NEO_CRYPTO_CHECKSIG.getHash(); // ...signature verification
 
         assertArrayEquals(
-                Numeric.hexStringToByteArray(expected),
+                hexStringToByteArray(expected),
                 witness.getVerificationScript().getScript());
     }
 
@@ -68,7 +71,7 @@ public class WitnessTest {
 
         byte[] message = new byte[10];
         Arrays.fill(message, (byte) 10);
-        ECKeyPair keyPair = ECKeyPair.createEcKeyPair();
+        ECKeyPair keyPair = createEcKeyPair();
         Witness witness = Witness.create(message, keyPair);
 
         byte[] invScript = InvocationScript.fromMessageAndKeyPair(message, keyPair).getScript();
@@ -93,36 +96,36 @@ public class WitnessTest {
         List<ECPublicKey> publicKeys = new ArrayList<>();
 
         for (int i = 0; i < 3; i++) {
-            ECKeyPair keyPair = ECKeyPair.createEcKeyPair();
-            signatures.add(Sign.signMessage(message, keyPair));
+            ECKeyPair keyPair = createEcKeyPair();
+            signatures.add(signMessage(message, keyPair));
             publicKeys.add(keyPair.getPublicKey());
         }
 
         String expected = ""
                 + "84" // 132 bytes follow as invocation script
                 + PUSHDATA1.toString() + "40" // PUSHDATA 64 bytes
-                + Numeric.toHexStringNoPrefix(signatures.get(0).getConcatenated()) // key 1 sig
+                + toHexStringNoPrefix(signatures.get(0).getConcatenated()) // key 1 sig
                 + PUSHDATA1.toString() + "40" // PUSHDATA 64 bytes
-                + Numeric.toHexStringNoPrefix(signatures.get(1).getConcatenated()) // key 2 sig
+                + toHexStringNoPrefix(signatures.get(1).getConcatenated()) // key 2 sig
                 + "70" // 113 bytes follow as verification script
                 + PUSH2.toString() // signing threshold
                 + PUSHDATA1 + "21" // PUSHDATA 33 bytes
-                + Numeric.toHexStringNoPrefix(publicKeys.get(0).getEncoded(true)) // public key 1
+                + toHexStringNoPrefix(publicKeys.get(0).getEncoded(true)) // public key 1
                 + PUSHDATA1 + "21" // PUSHDATA 33 bytes
-                + Numeric.toHexStringNoPrefix(publicKeys.get(1).getEncoded(true)) // public key 2
+                + toHexStringNoPrefix(publicKeys.get(1).getEncoded(true)) // public key 2
                 + PUSHDATA1 + "21" // PUSHDATA 33 bytes
-                + Numeric.toHexStringNoPrefix(publicKeys.get(2).getEncoded(true)) // public key 3
+                + toHexStringNoPrefix(publicKeys.get(2).getEncoded(true)) // public key 3
                 + OpCode.PUSH3.toString() // m = 3, number of keys
                 + OpCode.SYSCALL.toString()
                 + InteropServiceCode.NEO_CRYPTO_CHECKMULTISIG.getHash();
 
         // Test create from BigIntegers
-        Witness script = Witness.createMultiSigWitness(signingThreshold, signatures, publicKeys);
-        assertArrayEquals(Numeric.hexStringToByteArray(expected), script.toArray());
+        Witness script = createMultiSigWitness(signingThreshold, signatures, publicKeys);
+        assertArrayEquals(hexStringToByteArray(expected), script.toArray());
 
         // Test create from byte arrays.
-        script = Witness.createMultiSigWitness(signingThreshold, signatures, publicKeys);
-        assertArrayEquals(Numeric.hexStringToByteArray(expected), script.toArray());
+        script = createMultiSigWitness(signingThreshold, signatures, publicKeys);
+        assertArrayEquals(hexStringToByteArray(expected), script.toArray());
     }
 
     @Test
@@ -142,17 +145,17 @@ public class WitnessTest {
         int messageSize = 10;
         byte[] message = new byte[messageSize];
         Arrays.fill(message, (byte) 1);
-        ECKeyPair keyPair = ECKeyPair.createEcKeyPair();
+        ECKeyPair keyPair = createEcKeyPair();
 
-        byte[] sig = Sign.signMessage(message, keyPair).getConcatenated();
+        byte[] sig = signMessage(message, keyPair).getConcatenated();
 
         String invocationScript = ""
                 + PUSHDATA1.toString() + "40" // 64 bytes of signature
-                + Numeric.toHexStringNoPrefix(sig); // signature
+                + toHexStringNoPrefix(sig); // signature
 
         String verificationScript = ""
                 + PUSHDATA1.toString() + "21" // 33 bytes of public key
-                + Numeric.toHexStringNoPrefix(keyPair.getPublicKey().getEncoded(true)) // pubKey
+                + toHexStringNoPrefix(keyPair.getPublicKey().getEncoded(true)) // pubKey
                 + SYSCALL.toString() // syscall to...
                 + InteropServiceCode.NEO_CRYPTO_CHECKSIG.getHash(); // ...signature verification
 
@@ -163,13 +166,13 @@ public class WitnessTest {
                 + verificationScript;
 
         Witness witness = NeoSerializableInterface
-                .from(Numeric.hexStringToByteArray(serializedWitness), Witness.class);
+                .from(hexStringToByteArray(serializedWitness), Witness.class);
 
         assertArrayEquals(
-                Numeric.hexStringToByteArray(invocationScript),
+                hexStringToByteArray(invocationScript),
                 witness.getInvocationScript().getScript());
         assertArrayEquals(
-                Numeric.hexStringToByteArray(verificationScript),
+                hexStringToByteArray(verificationScript),
                 witness.getVerificationScript().getScript());
     }
 
@@ -177,7 +180,7 @@ public class WitnessTest {
     public void getScriptHashFromWitness1() {
         String sk = "9117f4bf9be717c9a90994326897f4243503accd06712162267e77f18b49c3a3";
         String pk = "0265bf906bf385fbf3f777832e55a87991bcfbe19b097fb7c5ca2e4025a4d5e5d6";
-        ECKeyPair keyPair = ECKeyPair.create(Numeric.hexStringToByteArray(sk));
+        ECKeyPair keyPair = ECKeyPair.create(hexStringToByteArray(sk));
         byte[] message = new byte[10];
         Arrays.fill(message, (byte) 1);
         Witness script = Witness.create(message, keyPair);
@@ -188,35 +191,35 @@ public class WitnessTest {
                 + SYSCALL.toString() // syscall to...
                 + InteropServiceCode.NEO_CRYPTO_CHECKSIG.getHash(); // ...signature verification
 
-        byte[] expectedHash = Hash.sha256AndThenRipemd160(
-                Numeric.hexStringToByteArray(expectedVerificationScript));
+        byte[] expectedHash = sha256AndThenRipemd160(
+                hexStringToByteArray(expectedVerificationScript));
 
-        assertArrayEquals(expectedHash, script.getScriptHash().toArray());
+        assertArrayEquals(expectedHash, script.getScriptHash().toLittleEndianArray());
     }
 
     @Test
     public void getScriptHashFromWitness2() {
         // Test with script hash generated by neon-js.
-        byte[] invocationScript = Numeric.hexStringToByteArray(
+        byte[] invocationScript = hexStringToByteArray(
                 "4051c2e6e2993c6feb43383131ed2091f4953747d3e16ecad752cdd90203a992dea0273e98c8cd09e9bfcf2dab22ce843429cdf0fcb9ba4ac93ef1aeef40b20783");
-        byte[] verificationScript = Numeric.hexStringToByteArray(
+        byte[] verificationScript = hexStringToByteArray(
                 "21031d8e1630ce640966967bc6d95223d21f44304133003140c3b52004dc981349c9ac");
         Witness witness = new Witness(invocationScript, verificationScript);
         assertArrayEquals(
-                Numeric.hexStringToByteArray("35b20010db73bf86371075ddfba4e6596f1ff35d"),
-                witness.getScriptHash().toArray()
+                hexStringToByteArray("35b20010db73bf86371075ddfba4e6596f1ff35d"),
+                witness.getScriptHash().toLittleEndianArray()
         );
     }
 
     @Test
     public void createWithoutVerificationScript() {
-        byte[] invocationScript = Numeric.hexStringToByteArray("0000");
+        byte[] invocationScript = hexStringToByteArray("0000");
         Hash160 hash = new Hash160("1a70eac53f5882e40dd90f55463cce31a9f72cd4");
         Witness witness = new Witness(invocationScript, hash);
         // 02: two bytes of invocation script;
         // 0000: invocation script;
         // 00: zero bytes of verification script
-        assertEquals("02000000", Numeric.toHexStringNoPrefix(witness.toArray()));
+        assertEquals("02000000", toHexStringNoPrefix(witness.toArray()));
     }
 
 }


### PR DESCRIPTION
The hashes in the classes `Hash160` and `Hash256` are now stored in big-endian format and its constructors now all take big-endian formats as parameter. This way the hashes are uniformly handled in big-endian format.

Resolves #442.