### PR TITLE
Changed the the Map.Entry to Iterator.Struct

### DIFF
--- a/compiler/src/test-integration/java/io/neow3j/compiler/IteratorTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/IteratorTest.java
@@ -2,7 +2,7 @@ package io.neow3j.compiler;
 
 import io.neow3j.devpack.Iterator;
 import io.neow3j.devpack.Map;
-import io.neow3j.devpack.Map.Entry;
+import io.neow3j.devpack.Iterator.Struct;
 import io.neow3j.protocol.core.methods.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.methods.response.StackItem;
 import org.junit.ClassRule;
@@ -72,7 +72,7 @@ public class IteratorTest {
             for (int i = 0; i < ints1.length; i++) {
                 map.put(ints1[i], ints2[i]);
             }
-            Iterator<Entry<Integer, Integer>> it = Iterator.create(map);
+            Iterator<Struct<Integer, Integer>> it = Iterator.create(map);
 
             int[] keysAndValues = new int[ints1.length * 2];
             int i = 0;

--- a/compiler/src/test-integration/java/io/neow3j/compiler/StorageIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/StorageIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.neow3j.compiler;
 
+import io.neow3j.devpack.Iterator.Struct;
 import io.neow3j.contract.ContractParameter;
 import io.neow3j.devpack.ByteString;
 import io.neow3j.devpack.FindOptions;
@@ -384,11 +385,11 @@ public class StorageIntegrationTest {
         public static io.neow3j.devpack.Map<ByteString, ByteString> findWithFindOptionDeserializeValues() {
             Storage.put(ctx, hexToBytes("0102"), hexToBytes("102030"));
             byte findOption = FindOptions.DeserializeValues & FindOptions.PickField0;
-            Iterator<io.neow3j.devpack.Map.Entry<ByteString, ByteString>> it = Storage.find(ctx,
+            Iterator<Struct<ByteString, ByteString>> it = Storage.find(ctx,
                     hexToBytes("01"), findOption);
             io.neow3j.devpack.Map<ByteString, ByteString> map = new io.neow3j.devpack.Map<>();
             it.next();
-            io.neow3j.devpack.Map.Entry<ByteString, ByteString> entry = it.get();
+            Struct<ByteString, ByteString> entry = it.get();
             map.put(entry.key, entry.value);
             it.next();
             entry = it.get();

--- a/devpack/src/main/java/io/neow3j/devpack/Iterator.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Iterator.java
@@ -1,6 +1,5 @@
 package io.neow3j.devpack;
 
-import io.neow3j.devpack.Map.Entry;
 import io.neow3j.devpack.annotations.Syscall;
 
 import static io.neow3j.constants.InteropServiceCode.SYSTEM_ITERATOR_CREATE;
@@ -30,21 +29,22 @@ public class Iterator<V> implements InteropInterface {
      * Creates an {@code Iterator} over the entries of the given array.
      *
      * @param entries The elements to iterator over.
-     * @param <V> The type of the iterator's entries.
+     * @param <V>     The type of the iterator's entries.
      * @return the iterator.
      */
     @Syscall(SYSTEM_ITERATOR_CREATE)
     public static native <V> Iterator<V> create(V[] entries);
 
     /**
-     * Creates a {@code Iterator} over the entries of the given map.
+     * Creates an {@code Iterator} over the entries of the given map.
+     *
      * @param map The map to iterate over.
      * @param <K> The type of the keys.
      * @param <V> The type of the values.
      * @return the iterator.
      */
     @Syscall(SYSTEM_ITERATOR_CREATE)
-    public static native <K, V> Iterator<Entry<K, V>> create(Map<K, V> map);
+    public static native <K, V> Iterator<Struct<K, V>> create(Map<K, V> map);
 
     /**
      * Moves this {@code Iterator}'s position to the next element.
@@ -55,12 +55,23 @@ public class Iterator<V> implements InteropInterface {
     public native boolean next();
 
     /**
-     * Gets the the element at the current {@code Iterator} position.
+     * Gets the element at the current {@code Iterator} position.
      *
      * @return the value.
      */
     @Syscall(SYSTEM_ITERATOR_VALUE)
     public native V get();
+
+    /**
+     * Represents a two element struct that the neo-vm uses when iterating over a map.
+     *
+     * @param <K> type of the first element of the struct.
+     * @param <V> type of the second element of the struct.
+     */
+    public static class Struct<K, V> {
+        public K key;
+        public V value;
+    }
 
 }
 

--- a/devpack/src/main/java/io/neow3j/devpack/Map.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Map.java
@@ -71,9 +71,4 @@ public class Map<K, V> {
     @Instruction(opcode = OpCode.REMOVE)
     public native void remove(K key);
 
-    public static class Entry<K, V> {
-        public K key;
-        public V value;
-    }
-
 }

--- a/devpack/src/main/java/io/neow3j/devpack/Storage.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Storage.java
@@ -1,9 +1,9 @@
 package io.neow3j.devpack;
 
 import io.neow3j.constants.OpCode;
-import io.neow3j.devpack.Map.Entry;
 import io.neow3j.devpack.annotations.Instruction;
 import io.neow3j.devpack.annotations.Syscall;
+import io.neow3j.model.types.StackItemType;
 
 import static io.neow3j.constants.InteropServiceCode.SYSTEM_STORAGE_DELETE;
 import static io.neow3j.constants.InteropServiceCode.SYSTEM_STORAGE_FIND;
@@ -53,6 +53,15 @@ public class Storage {
      */
     @Syscall(SYSTEM_STORAGE_GET)
     public static native ByteString get(StorageContext context, String key);
+
+    @Instruction(opcode = OpCode.DUP)
+    @Instruction(opcode = OpCode.ISNULL)
+    @Instruction(opcode = OpCode.JMPIFNOT, operand = 0x05)
+    @Instruction(opcode = OpCode.PUSH0)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.DROP)
+    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.INTEGER_CODE)
+    public static native int getInt(StorageContext context, String key);
 
     /**
      * Returns the value corresponding to the given key.
@@ -217,8 +226,8 @@ public class Storage {
      * The types that the {@code Iterator} contains are dependent on the find options used.
      * <ul>
      *     <li>
-     *         With {@link FindOptions#None} an {@code Iterator<Map.Entry<ByteString, ByteString>>}
-     *         will be returned, where each {@code Map.Entry} is a key-value pair found under the
+     *         With {@link FindOptions#None} an {@code Iterator<Struct<ByteString, ByteString>>}
+     *         will be returned, where each {@code Struct} is a key-value pair found under the
      *         given prefix. The prefix is part of the key.
      *     </li>
      *     <li>
@@ -228,7 +237,7 @@ public class Storage {
      *     </li>
      *     <li>
      *          With {@link FindOptions#RemovePrefix} the results will be an
-     *          {@code Iterator<Map.Entry<ByteString, ByteString>>}, where each {@code Map.Entry}
+     *          {@code Iterator<Struct<ByteString, ByteString>>}, where each {@code Struct}
      *          is a key-value pair found under the given prefix but the prefix is removed from
      *          the key.
      *     </li>
@@ -239,7 +248,7 @@ public class Storage {
      *     </li>
      * </ul>
      *
-     * @param context     The storage context to get the values from.
+     * @param context     The storage context to use.
      * @param prefix      The key prefix.
      * @param findOptions Controls the kind of iterator to return. Use the values of
      *                    {@link FindOptions}.
@@ -254,8 +263,8 @@ public class Storage {
      * The types that the {@code Iterator} contains are dependent on the find options used.
      * <ul>
      *     <li>
-     *         With {@link FindOptions#None} an {@code Iterator<Map.Entry<ByteString, ByteString>>}
-     *         will be returned, where each {@code Map.Entry} is a key-value pair found under the
+     *         With {@link FindOptions#None} an {@code Iterator<Struct<ByteString, ByteString>>}
+     *         will be returned, where each {@code Struct} is a key-value pair found under the
      *         given prefix. The prefix is part of the key.
      *     </li>
      *     <li>
@@ -265,7 +274,7 @@ public class Storage {
      *     </li>
      *     <li>
      *          With {@link FindOptions#RemovePrefix} the results will be an
-     *          {@code Iterator<Map.Entry<ByteString, ByteString>>}, where each {@code Map.Entry}
+     *          {@code Iterator<Struct<ByteString, ByteString>>}, where each {@code Struct}
      *          is a key-value pair found under the given prefix but the prefix is removed from
      *          the key.
      *     </li>
@@ -276,11 +285,11 @@ public class Storage {
      *     </li>
      * </ul>
      *
-     * @param context     The storage context to get the values from.
+     * @param context     The storage context to use.
      * @param prefix      The key prefix.
      * @param findOptions Controls the kind of iterator to return. Use the values of
      *                    {@link FindOptions}.
-     * @return an iterator over key, values or key-value pairs found under the given prefix.
+     * @return an iterator over key, values, or key-value pairs found under the given prefix.
      */
     @Syscall(SYSTEM_STORAGE_FIND)
     public static native Iterator find(StorageContext context, ByteString prefix, byte findOptions);
@@ -291,8 +300,8 @@ public class Storage {
      * The types that the {@code Iterator} contains are dependent on the find options used.
      * <ul>
      *     <li>
-     *         With {@link FindOptions#None} an {@code Iterator<Map.Entry<ByteString, ByteString>>}
-     *         will be returned, where each {@code Map.Entry} is a key-value pair found under the
+     *         With {@link FindOptions#None} an {@code Iterator<Struct<ByteString, ByteString>>}
+     *         will be returned, where each {@code Struct} is a key-value pair found under the
      *         given prefix. The prefix is part of the key.
      *     </li>
      *     <li>
@@ -302,7 +311,7 @@ public class Storage {
      *     </li>
      *     <li>
      *          With {@link FindOptions#RemovePrefix} the results will be an
-     *          {@code Iterator<Map.Entry<ByteString, ByteString>>}, where each {@code Map.Entry}
+     *          {@code Iterator<Struct<ByteString, ByteString>>}, where each {@code Struct}
      *          is a key-value pair found under the given prefix but the prefix is removed from
      *          the key.
      *     </li>
@@ -313,7 +322,7 @@ public class Storage {
      *     </li>
      * </ul>
      *
-     * @param context     The storage context to get the values from.
+     * @param context     The storage context to use.
      * @param prefix      The key prefix.
      * @param findOptions Controls the kind of iterator to return. Use the values of
      *                    {@link FindOptions}.


### PR DESCRIPTION
Since the neo-vm returns a StructStackItem when iterating over map entries, I changed the Map.Entry type to Iterator.Struct.