### PR TITLE
Make getHash of Contract Interfaces return little-endian hash

### DIFF
--- a/compiler/src/test-integration/java/io/neow3j/compiler/ContractInterfacesIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ContractInterfacesIntegrationTest.java
@@ -4,6 +4,7 @@ import io.neow3j.devpack.ContractInterface;
 import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.annotations.ContractHash;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
+import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -34,7 +35,7 @@ public class ContractInterfacesIntegrationTest {
     public void getScriptHashOfCustomNeoContractInterface() throws IOException {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(neoTokenHash()));
+                is(Numeric.reverseHexString(neoTokenHash())));
     }
 
     static class ContractInterfacesIntegrationTestContract {

--- a/compiler/src/test-integration/java/io/neow3j/compiler/ContractInterfacesIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ContractInterfacesIntegrationTest.java
@@ -15,14 +15,14 @@ import static io.neow3j.test.TestProperties.neoTokenHash;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 
-public class ContractInterfacesTest {
+public class ContractInterfacesIntegrationTest {
 
     @Rule
     public TestName testName = new TestName();
 
     @ClassRule
     public static ContractTestRule ct = new ContractTestRule(
-            ContractInterfacesTestContract.class.getName());
+            ContractInterfacesIntegrationTestContract.class.getName());
 
     @Test
     public void callSymbolMethodOfCustomNeoContractInterface() throws IOException {
@@ -37,7 +37,7 @@ public class ContractInterfacesTest {
                 is(neoTokenHash()));
     }
 
-    static class ContractInterfacesTestContract {
+    static class ContractInterfacesIntegrationTestContract {
 
         public static String callSymbolMethodOfCustomNeoContractInterface() {
             return CustomNeoToken.symbol();

--- a/compiler/src/test-integration/java/io/neow3j/compiler/ContractManagementIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ContractManagementIntegrationTest.java
@@ -1,5 +1,6 @@
 package io.neow3j.compiler;
 
+import io.neow3j.test.TestProperties;
 import io.neow3j.types.Hash160;
 import io.neow3j.types.Hash256;
 import io.neow3j.contract.NeoToken;
@@ -235,7 +236,7 @@ public class ContractManagementIntegrationTest {
     public void getHash() throws Throwable {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(io.neow3j.contract.ContractManagement.SCRIPT_HASH.toString()));
+                is(Numeric.reverseHexString(TestProperties.contractManagementHash())));
     }
 
     static class ContractManagementIntegrationTestContract {

--- a/compiler/src/test-integration/java/io/neow3j/compiler/CryptoLibIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/CryptoLibIntegrationTest.java
@@ -6,6 +6,7 @@ import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.NamedCurve;
 import io.neow3j.devpack.contracts.CryptoLib;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
+import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -65,7 +66,7 @@ public class CryptoLibIntegrationTest {
     public void getHash() throws Throwable {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(cryptoLibHash()));
+                is(Numeric.reverseHexString(cryptoLibHash())));
     }
 
     static class CryptoLibIntegrationTestContract {

--- a/compiler/src/test-integration/java/io/neow3j/compiler/FungibleTokenTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/FungibleTokenTest.java
@@ -5,6 +5,7 @@ import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.annotations.ContractHash;
 import io.neow3j.devpack.contracts.FungibleToken;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
+import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -12,6 +13,7 @@ import org.junit.rules.TestName;
 
 import java.io.IOException;
 
+import static io.neow3j.test.TestProperties.neoTokenHash;
 import static io.neow3j.types.ContractParameter.hash160;
 import static io.neow3j.types.ContractParameter.integer;
 import static org.hamcrest.Matchers.greaterThan;
@@ -71,10 +73,10 @@ public class FungibleTokenTest {
     public void getScriptHashOfFungibleToken() throws IOException {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(NeoToken.SCRIPT_HASH.toString()));
+                is(Numeric.reverseHexString(neoTokenHash())));
     }
 
-    static class FungibleTokenTestContract extends FungibleToken {
+    static class FungibleTokenTestContract {
 
         public static String callSymbolMethodOfFungibleToken() {
             return CustomNeoToken.symbol();

--- a/compiler/src/test-integration/java/io/neow3j/compiler/GasTokenIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/GasTokenIntegrationTest.java
@@ -10,6 +10,7 @@ import io.neow3j.protocol.core.response.InvocationResult;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.stackitem.StackItem;
 import io.neow3j.utils.Await;
+import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -18,6 +19,7 @@ import org.junit.rules.TestName;
 import java.math.BigInteger;
 import java.util.List;
 
+import static io.neow3j.test.TestProperties.gasTokenHash;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -35,7 +37,7 @@ public class GasTokenIntegrationTest {
     public void getHash() throws Throwable {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(io.neow3j.contract.GasToken.SCRIPT_HASH.toString()));
+                is(Numeric.reverseHexString(gasTokenHash())));
     }
 
     @Test

--- a/compiler/src/test-integration/java/io/neow3j/compiler/LedgerContractIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/LedgerContractIntegrationTest.java
@@ -177,7 +177,7 @@ public class LedgerContractIntegrationTest {
     public void getHash() throws IOException {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(ledgerContractHash()));
+                is(Numeric.reverseHexString(ledgerContractHash())));
     }
 
     static class LedgerContractIntegrationTestContract {

--- a/compiler/src/test-integration/java/io/neow3j/compiler/NeoTokenIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/NeoTokenIntegrationTest.java
@@ -9,6 +9,7 @@ import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.stackitem.StackItem;
 import io.neow3j.transaction.Signer;
 import io.neow3j.utils.Await;
+import io.neow3j.utils.Numeric;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -134,7 +135,7 @@ public class NeoTokenIntegrationTest {
     public void getHash() throws Throwable {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(neoTokenHash()));
+                is(Numeric.reverseHexString(neoTokenHash())));
     }
 
     @Test

--- a/compiler/src/test-integration/java/io/neow3j/compiler/OracleContractIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/OracleContractIntegrationTest.java
@@ -20,6 +20,7 @@ import io.neow3j.protocol.core.response.Transaction;
 import io.neow3j.transaction.Signer;
 import io.neow3j.transaction.TransactionAttributeType;
 import io.neow3j.utils.Await;
+import io.neow3j.utils.Numeric;
 import io.reactivex.disposables.Disposable;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -63,7 +64,7 @@ public class OracleContractIntegrationTest {
     public void getScriptHash() throws IOException {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(oracleContractHash()));
+                is(Numeric.reverseHexString(oracleContractHash())));
     }
 
     @Test

--- a/compiler/src/test-integration/java/io/neow3j/compiler/PolicyContractIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/PolicyContractIntegrationTest.java
@@ -5,6 +5,7 @@ import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.contracts.PolicyContract;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.stackitem.StackItem;
+import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -102,7 +103,7 @@ public class PolicyContractIntegrationTest {
     public void getHash() throws Throwable {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(policyContractHash()));
+                is(Numeric.reverseHexString(policyContractHash())));
     }
 
     static class PolicyContractIntegrationTestContract {

--- a/compiler/src/test-integration/java/io/neow3j/compiler/RoleManagementTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/RoleManagementTest.java
@@ -8,6 +8,7 @@ import io.neow3j.devpack.contracts.Role;
 import io.neow3j.devpack.contracts.RoleManagement;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.stackitem.StackItem;
+import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,7 +38,7 @@ public class RoleManagementTest {
     public void getHash() throws IOException {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(roleManagementHash()));
+                is(Numeric.reverseHexString(roleManagementHash())));
     }
 
     @Test

--- a/compiler/src/test-integration/java/io/neow3j/compiler/StdLibIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/StdLibIntegrationTest.java
@@ -7,6 +7,7 @@ import io.neow3j.devpack.contracts.StdLib;
 import io.neow3j.types.StackItemType;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.stackitem.StackItem;
+import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -167,7 +168,7 @@ public class StdLibIntegrationTest {
     public void getHash() throws Throwable {
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(stdLibHash()));
+                is(Numeric.reverseHexString(stdLibHash())));
     }
 
     @Test

--- a/compiler/src/test/java/io/neow3j/compiler/CompilerExceptionsTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/CompilerExceptionsTest.java
@@ -1,5 +1,6 @@
 package io.neow3j.compiler;
 
+import io.neow3j.devpack.contracts.FungibleToken;
 import io.neow3j.script.OpCode;
 import io.neow3j.devpack.ContractInterface;
 import io.neow3j.devpack.Hash160;
@@ -174,6 +175,26 @@ public class CompilerExceptionsTest {
         new Compiler().compile(InstanceOfContract.class.getName());
     }
 
+    @Test
+    public void failCallingAContractInterfaceWithoutContractHashAnnotation() throws IOException {
+        exceptionRule.expect(CompilerException.class);
+        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+                "Error trying to call a method on a contract interface",
+                ContractHash.class.getCanonicalName())));
+        new Compiler().compile(ContractInterfaceWithoutHash.class.getName());
+    }
+
+    @Test
+    public void failCallingAContractInterfaceWithoutContractHashAnnotationAndMultipleInheritance()
+            throws IOException {
+
+        exceptionRule.expect(CompilerException.class);
+        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+                "Error trying to call a method on a contract interface",
+                ContractHash.class.getCanonicalName())));
+        new Compiler().compile(ContractInterfaceWithoutHashAndMultipleInheritance.class.getName());
+    }
+
     static class UnsupportedInheritanceInConstructor {
 
         public static void method() {
@@ -320,6 +341,25 @@ public class CompilerExceptionsTest {
             return obj instanceof Hash160;
         }
     }
+
+    static class ContractInterfaceWithoutHash {
+
+        public static String method() {
+            return FungibleToken.symbol();
+        }
+    }
+
+    static class ContractInterfaceWithoutHashAndMultipleInheritance {
+
+        public static String method() {
+            return CustomFungibleToken.symbol();
+        }
+    }
+
+    static class CustomFungibleToken extends FungibleToken {
+
+    }
+
 
 }
 

--- a/devpack/src/main/java/io/neow3j/devpack/ContractInterface.java
+++ b/devpack/src/main/java/io/neow3j/devpack/ContractInterface.java
@@ -13,8 +13,8 @@ import io.neow3j.devpack.contracts.PolicyContract;
 public abstract class ContractInterface {
 
     /**
-     * Gets the contract's script hash. This requires the extending class to use the {@link
-     * ContractHash} annotation.
+     * Gets the contract's script hash in little-endian order. This requires the extending class to
+     * use the {@link ContractHash} annotation.
      *
      * @return the contract's script hash.
      */

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -88,9 +88,6 @@ public class Hash160 {
     @Instruction
     public native ByteString asByteString();
 
-    @Instruction(opcode = OpCode.EQUAL)
-    public native boolean equals();
-
     /**
      * Compares this hash to the given object. The comparison happens first by reference and then by
      * value. I.e., two {@code Hash160} are compared byte by byte.

--- a/devpack/src/main/java/io/neow3j/devpack/Runtime.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Runtime.java
@@ -108,33 +108,33 @@ public class Runtime {
     public static native Object getScriptContainer();
 
     /**
-     * Gets the script hash of the currently executing contract.
+     * Gets the script hash of the currently executing contract in little-endian order.
      *
-     * @return the script hash of the executing contract.
+     * @return the script hash of the executing contract in little-endian order.
      */
     @Syscall(InteropService.SYSTEM_RUNTIME_GETEXECUTINGSCRIPTHASH)
     public static native Hash160 getExecutingScriptHash();
 
     /**
-     * Gets the script hash of the caller of the contract.
+     * Gets the script hash of the caller of the contract in little-endian order.
      * <p>
      * If the contact was invoked directly by a transaction, then this returns the hash of that
      * transaction's script. If the contract is called by another contact as part of an invocation
      * chain, then this returns the script hash of the calling contract.
      *
-     * @return the caller's script hash.
+     * @return the caller's script hash in little-endian order.
      */
     @Syscall(InteropService.SYSTEM_RUNTIME_GETCALLINGSCRIPTHASH)
     public static native Hash160 getCallingScriptHash();
 
     /**
-     * Gets the script hash of the entry context, i.e., the context at the beginning of the
-     * contract invocation chain.
+     * Gets the script hash of the entry context in little-endian order, i.e., the context at the
+     * beginning of the contract invocation chain.
      * <p>
      * In case the invocation was induced by a transaction, the hash of that transaction's script is
      * the entry script hash.
      *
-     * @return the script hash.
+     * @return the script hash in little-endian order.
      */
     @Syscall(InteropService.SYSTEM_RUNTIME_GETENTRYSCRIPTHASH)
     public static native Hash160 getEntryScriptHash();


### PR DESCRIPTION
Also, improved the handling of contract interfaces in the compiler.