### PR TITLE
Changed method name from 'as' to 'to'

### DIFF
--- a/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
@@ -114,7 +114,7 @@ public class ECPointIntegrationTest {
         }
 
         public static ByteString ecPointAsByteString(ECPoint ecPoint) {
-            return ecPoint.asByteString();
+            return ecPoint.toByteString();
         }
     }
 

--- a/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
@@ -247,7 +247,7 @@ public class HashIntegrationTest {
         }
 
         public static ByteString hash160ToString(io.neow3j.devpack.Hash160 hash160) {
-            return hash160.asByteString();
+            return hash160.toByteString();
         }
 
         public static Hash256 getZeroHash256() {
@@ -289,7 +289,7 @@ public class HashIntegrationTest {
         }
 
         public static ByteString hash256ToString(Hash256 hash256) {
-            return hash256.asByteString();
+            return hash256.toByteString();
         }
 
         public static io.neow3j.devpack.Hash160 hash160FromStringLiteral() {

--- a/compiler/src/test-integration/java/io/neow3j/compiler/SwitchCaseIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/SwitchCaseIntegrationTest.java
@@ -171,7 +171,7 @@ public class SwitchCaseIntegrationTest {
                                 case 100:
                                     localInt = 100;
                                     localString = "is" + "Hello" +
-                                            Runtime.getCallingScriptHash().asByteString().toString();
+                                            Runtime.getCallingScriptHash().toByteString().toString();
                                     break;
                                 default:
                                     throw new Exception();

--- a/devpack/src/main/java/io/neow3j/devpack/Block.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Block.java
@@ -1,7 +1,7 @@
 package io.neow3j.devpack;
 
-import io.neow3j.script.OpCode;
 import io.neow3j.devpack.annotations.Instruction;
+import io.neow3j.script.OpCode;
 
 /**
  * Represents a block and provides block-related information. It is returned for example when

--- a/devpack/src/main/java/io/neow3j/devpack/ECPoint.java
+++ b/devpack/src/main/java/io/neow3j/devpack/ECPoint.java
@@ -55,7 +55,7 @@ public class ECPoint {
      * @return the byte string.
      */
     @Instruction
-    public native ByteString asByteString();
+    public native ByteString toByteString();
 
     /**
      * Compares this EC point to the given object. The comparison happens first by reference and

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -86,7 +86,7 @@ public class Hash160 {
      * @return the byte string.
      */
     @Instruction
-    public native ByteString asByteString();
+    public native ByteString toByteString();
 
     /**
      * Compares this hash to the given object. The comparison happens first by reference and then by

--- a/devpack/src/main/java/io/neow3j/devpack/Hash256.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash256.java
@@ -87,7 +87,7 @@ public class Hash256 {
      * @return the byte string.
      */
     @Instruction
-    public native ByteString asByteString();
+    public native ByteString toByteString();
 
     /**
      * Compares this hash to the given object. The comparison happens first by reference and then by

--- a/devpack/src/main/java/io/neow3j/devpack/StringLiteralHelper.java
+++ b/devpack/src/main/java/io/neow3j/devpack/StringLiteralHelper.java
@@ -26,10 +26,10 @@ public class StringLiteralHelper {
     /**
      * Converts the given hex string to a byte array.
      * <p>
-     * This method can only be applied to constant string literals.
+     * If you use this for an account or contract hash, make sure to pass the hex string in
+     * little-endian order.
      * <p>
-     * Example: hexToBytes("0102030405060708090a0b0c0d0e0faabbccddee") generates the corresponding
-     * byte array.
+     * This method can only be applied to constant string literals.
      *
      * @param hex The hex string to convert to bytes.
      * @return the byte array.

--- a/devpack/src/main/java/io/neow3j/devpack/annotations/OnNEP17Payment.java
+++ b/devpack/src/main/java/io/neow3j/devpack/annotations/OnNEP17Payment.java
@@ -5,8 +5,8 @@ import io.neow3j.devpack.Hash160;
 /**
  * Marks a smart contract method as the method to be called when the contract receives tokens from a
  * NEP-17 contract. The annotated method can have any name but is required to have the signature
- * "{@code void methodName(Hash160, int, Object)}". The method will appear under the name
- * "onNEP17Payment" in the contract manifest.
+ * "{@code void methodName(Hash160 sender, int amount, Object data)}". The method will appear under
+ * the name "onNEP17Payment" in the contract manifest.
  * <p>
  * If a contract does not have this method, it cannot receive NEP-17 tokens.
  */


### PR DESCRIPTION
I think it is more appropriate to always use 'to' for such conversion methods.