### PR TITLE
More on trusts and permissions

### DIFF
--- a/compiler/src/main/java/io/neow3j/compiler/ManifestBuilder.java
+++ b/compiler/src/main/java/io/neow3j/compiler/ManifestBuilder.java
@@ -151,13 +151,7 @@ public class ManifestBuilder {
         int i = ann.values.indexOf("contract");
         String hashOrPubKey = (String) ann.values.get(i + 1);
         throwIfNotValidContractHashOrPubKey(hashOrPubKey);
-
-        // Contract hashes need a '0x' prefix. Public keys must be without '0x' prefix.
-        if (hashOrPubKey.length() == 2 * NeoConstants.HASH160_SIZE) {
-            hashOrPubKey = Numeric.prependHexPrefix(hashOrPubKey);
-        } else if (hashOrPubKey.length() == 2 * NeoConstants.PUBLIC_KEY_SIZE) {
-            hashOrPubKey = Numeric.cleanHexPrefix(hashOrPubKey);
-        }
+        hashOrPubKey = addOrClearHexPrefix(hashOrPubKey);
 
         i = ann.values.indexOf("methods");
         List<String> methods = new ArrayList<>();
@@ -173,6 +167,16 @@ public class ManifestBuilder {
         }
 
         return new ContractPermission(hashOrPubKey, methods);
+    }
+
+    private static String addOrClearHexPrefix(String hashOrPubKey) {
+        // Contract hashes need a '0x' prefix. Public keys must be without '0x' prefix.
+        if (hashOrPubKey.length() == 2 * NeoConstants.HASH160_SIZE) {
+            hashOrPubKey = Numeric.prependHexPrefix(hashOrPubKey);
+        } else if (hashOrPubKey.length() == 2 * NeoConstants.PUBLIC_KEY_SIZE + 2) {
+            hashOrPubKey = Numeric.cleanHexPrefix(hashOrPubKey);
+        }
+        return hashOrPubKey;
     }
 
     private static ContractGroup getContractGroup(AnnotationNode ann) {
@@ -246,7 +250,7 @@ public class ManifestBuilder {
         int i = ann.values.indexOf("value");
         String trust = (String) ann.values.get(i + 1);
         throwIfNotValidContractHashOrPubKey(trust);
-        return trust;
+        return addOrClearHexPrefix(trust);
     }
 
     private static List<AnnotationNode> checkForSingleOrMultipleAnnotations(ClassNode asmClass,

--- a/compiler/src/test/java/io/neow3j/compiler/TrustManifestTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/TrustManifestTest.java
@@ -16,10 +16,10 @@ import org.junit.rules.ExpectedException;
 
 public class TrustManifestTest {
 
-    private static final String CONTRACT_HASH_1 = "0f46dc4287b70117ce8354924b5cb3a47215ad93";
+    private static final String CONTRACT_HASH_1 = "0x0f46dc4287b70117ce8354924b5cb3a47215ad93";
     private static final String GROUP_PUBKEY_1 =
             "02163946a133e3d2e0d987fb90cb01b060ed1780f1718e2da28edf13b965fd2b60";
-    private static final String CONTRACT_HASH_2 = "d6c712eb53b1a130f59fd4e5864bdac27458a509";
+    private static final String CONTRACT_HASH_2 = "0xd6c712eb53b1a130f59fd4e5864bdac27458a509";
 
     @Rule
     public ExpectedException exceptionRule = ExpectedException.none();


### PR DESCRIPTION
In blockchain we trust... The same handling of '0x' that applied to permission contract hashes and public keys is needed for trusts.  