### PR TITLE
Standardize the formatting of the devpack's constant names

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -5,6 +5,7 @@ on:
     inputs:
       snapshot:
         description: 'Publish snapshot?'
+        required: false
         default: 'false'
   push:
 
@@ -23,6 +24,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 1.8
+      - name: Compile
+        run: ./gradlew compileJava compileTestJava compileIntegrationTestJava
       - name: Build with Unit Tests
         run: ./gradlew --info --warning-mode=all check jacocoRootTestReport
       - name: Test Results to CodeCov

--- a/compiler/src/test-integration/java/io/neow3j/compiler/CryptoLibIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/CryptoLibIntegrationTest.java
@@ -53,12 +53,12 @@ public class CryptoLibIntegrationTest {
         String signature =
                 "a30ded6e19be5573a6f6a5ff37c35d4ae76ff35ab4bee03b5b5bfbbef371f812ff70b5b480462807948a2ffb24dd8771484d9ca5a90333f9e6db69a6c8802a63";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(message),
-                publicKey(pubKey), byteArray(signature), integer(NamedCurve.SECP256R1));
+                publicKey(pubKey), byteArray(signature), integer(NamedCurve.secp256r1));
         assertTrue(response.getInvocationResult().getStack().get(0).getBoolean());
 
         message = "0102030406"; // small change in message.
         response = ct.callInvokeFunction(testName, byteArray(message), publicKey(pubKey),
-                byteArray(signature), integer(NamedCurve.SECP256R1));
+                byteArray(signature), integer(NamedCurve.secp256r1));
         assertFalse(response.getInvocationResult().getStack().get(0).getBoolean());
     }
 

--- a/compiler/src/test-integration/java/io/neow3j/compiler/CryptoLibIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/CryptoLibIntegrationTest.java
@@ -58,7 +58,7 @@ public class CryptoLibIntegrationTest {
 
         message = "0102030406"; // small change in message.
         response = ct.callInvokeFunction(testName, byteArray(message), publicKey(pubKey),
-                byteArray(signature), integer(NamedCurve.secp256r1));
+                byteArray(signature), integer(NamedCurve.Secp256r1));
         assertFalse(response.getInvocationResult().getStack().get(0).getBoolean());
     }
 

--- a/compiler/src/test-integration/java/io/neow3j/compiler/CryptoLibIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/CryptoLibIntegrationTest.java
@@ -53,7 +53,7 @@ public class CryptoLibIntegrationTest {
         String signature =
                 "a30ded6e19be5573a6f6a5ff37c35d4ae76ff35ab4bee03b5b5bfbbef371f812ff70b5b480462807948a2ffb24dd8771484d9ca5a90333f9e6db69a6c8802a63";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(message),
-                publicKey(pubKey), byteArray(signature), integer(NamedCurve.secp256r1));
+                publicKey(pubKey), byteArray(signature), integer(NamedCurve.Secp256r1));
         assertTrue(response.getInvocationResult().getStack().get(0).getBoolean());
 
         message = "0102030406"; // small change in message.

--- a/compiler/src/test-integration/java/io/neow3j/compiler/RoleManagementTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/RoleManagementTest.java
@@ -48,7 +48,7 @@ public class RoleManagementTest {
         ct.signWithCommitteeAccount();
 
         Hash256 txHash = ct.invokeFunctionAndAwaitExecution("designateAsRole",
-                integer(Role.STATE_VALIDATOR), array(publicKey(pubKey)));
+                integer(Role.StateValidator), array(publicKey(pubKey)));
         int blockIndex = ct.getNeow3j().getTransactionHeight(txHash).send().getHeight().intValue();
 
         // Check if the role has been successfully assigned.
@@ -59,7 +59,7 @@ public class RoleManagementTest {
 
         // Test if the designate can be fetched via a smart contract call.
         NeoInvokeFunction response = ct.callInvokeFunction("getDesignatedByRole",
-                integer(Role.STATE_VALIDATOR), integer(blockIndex + 1));
+                integer(Role.StateValidator), integer(blockIndex + 1));
         List<StackItem> pubKeysItem = response.getInvocationResult().getStack().get(0).getList();
         assertThat(pubKeysItem.get(0).getByteArray(), is(pubKey));
     }

--- a/devpack/src/main/java/io/neow3j/devpack/Block.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Block.java
@@ -10,7 +10,7 @@ import io.neow3j.script.OpCode;
 public class Block {
 
     /**
-     * The hash of this block.
+     * The hash of this block in little-endian order.
      */
     public final Hash256 hash;
 

--- a/devpack/src/main/java/io/neow3j/devpack/Contract.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Contract.java
@@ -25,7 +25,7 @@ public class Contract {
     public final int updateCounter;
 
     /**
-     * The contract's hash.
+     * The contract's hash in little-endian order.
      */
     public final Hash160 hash;
 

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -36,9 +36,9 @@ public class Hash160 {
      * Checks if this {@code Hash160} is valid, i.e. is 20 bytes long.
      * <p>
      * This method is useful when a contract method takes a {@code Hash160} as a parameter and
-     * you want to make sure that the underlying value really is a valid hash. The contract does
-     * not include or enforce this check automatically, because that would consume extra GAS even
-     * if you don't require that check.
+     * you want to make sure that the underlying value really is a valid hash. The compiler and
+     * NeoVM don't include or enforce this check automatically, because that would consume extra
+     * GAS even if you don't require that check.
      *
      * @return true if this {@code Hash160} is valid. False, otherwise.
      */

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -7,6 +7,8 @@ import io.neow3j.types.StackItemType;
 /**
  * Represents a hash with 160 bit length that was produced by first applying SHA-256 and then
  * RIPEMD-160. Use this class when working with script hashes, i.e., accounts and contracts.
+ * <p>
+ * The underlying bytes of a {@code Hash160} are always handled in little-endian order.
  */
 public class Hash160 {
 
@@ -32,6 +34,11 @@ public class Hash160 {
 
     /**
      * Checks if this {@code Hash160} is valid, i.e. is 20 bytes long.
+     * <p>
+     * This method is useful when a contract method takes a {@code Hash160} as a parameter and
+     * you want to make sure that the underlying value really is a valid hash. The contract does
+     * not include or enforce this check automatically, because that would consume extra GAS even
+     * if you don't require that check.
      *
      * @return true if this {@code Hash160} is valid. False, otherwise.
      */
@@ -45,10 +52,13 @@ public class Hash160 {
     public native boolean isValid();
 
     /**
-     * Creates a {@code Hash160} from the given byte array. Checks if it is valid and fails if it is
-     * not.
+     * Creates a {@code Hash160} from the given byte array.
+     * <p>
+     * Checks if the value is a valid hash. Fails if it is not.
+     * <p>
+     * The hash has to be passed in little-endian order.
      *
-     * @param value The hash byte array.
+     * @param value The hash as a byte array.
      */
     @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
     @Instruction(opcode = OpCode.DUP)
@@ -60,9 +70,13 @@ public class Hash160 {
     }
 
     /**
-     * Creates a {@code Hash160} from the given bytes. Checks if it is valid and fails if it is not.
+     * Creates a {@code Hash160} from the given bytes.
+     * <p>
+     * Checks if the value is a valid hash. Fails if it is not.
+     * <p>
+     * The hash has to be passed in little-endian order.
      *
-     * @param value The hash string.
+     * @param value The hash as a byte string.
      */
     @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.SIZE)

--- a/devpack/src/main/java/io/neow3j/devpack/Hash256.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash256.java
@@ -7,6 +7,8 @@ import io.neow3j.types.StackItemType;
 /**
  * Represents a hash with length of 256 bit that was created by applying SHA-256 twice. Use this
  * class when working with transaction and block hashes.
+ *
+ * The underlying bytes of a {@code Hash256} are always handled in little-endian order.
  */
 public class Hash256 {
 
@@ -32,6 +34,11 @@ public class Hash256 {
 
     /**
      * Checks if this {@code Hash256} is valid, i.e. is 32 bytes long.
+     * <p>
+     * This method is useful when a contract method takes a {@code Hash256} as a parameter and
+     * you want to make sure that the underlying value really is a valid hash. The compiler and
+     * NeoVM don't include or enforce this check automatically, because that would consume extra
+     * GAS even if you don't require that check.
      *
      * @return true if this {@code Hash256} is valid. False, otherwise.
      */
@@ -45,10 +52,13 @@ public class Hash256 {
     public native boolean isValid();
 
     /**
-     * Creates a {@code Hash256} from the given byte array. Checks if it is valid and fails if it is
-     * not.
+     * Creates a {@code Hash256} from the given byte array.
+     * <p>
+     * Checks if the value is a valid hash. Fails if it is not.
+     * <p>
+     * The hash has to be passed in little-endian order.
      *
-     * @param value The hash byte array.
+     * @param value The hash as a byte array.
      */
     @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
     @Instruction(opcode = OpCode.DUP)
@@ -60,9 +70,13 @@ public class Hash256 {
     }
 
     /**
-     * Creates a {@code Hash256} from the given bytes. Checks if it is valid and fails if it is not.
+     * Creates a {@code Hash256} from the given bytes.
+     * <p>
+     * Checks if the value is a valid hash. Fails if it is not.
+     * <p>
+     * The hash has to be passed in little-endian order.
      *
-     * @param value The hash string.
+     * @param value The hash as a byte string.
      */
     @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.SIZE)

--- a/devpack/src/main/java/io/neow3j/devpack/Transaction.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Transaction.java
@@ -10,7 +10,7 @@ import io.neow3j.devpack.annotations.Instruction;
 public class Transaction {
 
     /**
-     * The hash of the transaction.
+     * The hash of this transaction in little-endian order.
      */
     public final Hash256 hash;
 

--- a/devpack/src/main/java/io/neow3j/devpack/constants/NamedCurve.java
+++ b/devpack/src/main/java/io/neow3j/devpack/constants/NamedCurve.java
@@ -8,11 +8,11 @@ public class NamedCurve {
     /**
      * The secp256k1 curve.
      */
-    public final static byte SECP256K1 = 22;
+    public final static byte Secp256k1 = 22;
 
     /**
      * The secp256r1 curve, which is known as prime256v1 or nistP-256.
      */
-    public final static byte SECP256R1 = 23;
+    public final static byte Secp256r1 = 23;
 
 }

--- a/devpack/src/main/java/io/neow3j/devpack/constants/OracleResponseCode.java
+++ b/devpack/src/main/java/io/neow3j/devpack/constants/OracleResponseCode.java
@@ -5,22 +5,22 @@ package io.neow3j.devpack.constants;
  */
 public class OracleResponseCode {
 
-    public static final byte SUCCESS = 0;
+    public static final byte Success = 0;
 
-    public static final byte PROTOCOL_NOT_SUPPORTED = 0x10;
+    public static final byte ProtocolNotSupported = 0x10;
 
-    public static final byte CONSENSUS_UNREACHABLE = 0x12;
+    public static final byte ConsensusUnreachable = 0x12;
 
-    public static final byte NOT_FOUND = 0x14;
+    public static final byte NotFound = 0x14;
 
-    public static final byte TIMEOUT = 0x16;
+    public static final byte Timeout = 0x16;
 
-    public static final byte FORBIDDEN = 0x18;
+    public static final byte Forbidden = 0x18;
 
-    public static final byte RESPONSE_TOO_LARGE = 0x1a;
+    public static final byte ResponseTooLarge = 0x1a;
 
-    public static final byte INSUFFICIENT_FUNDS = 0x1c;
+    public static final byte InsufficientFunds = 0x1c;
 
-    public static final byte ERROR = (byte) 0xff;
+    public static final byte Error = (byte) 0xff;
 
 }

--- a/devpack/src/main/java/io/neow3j/devpack/constants/Role.java
+++ b/devpack/src/main/java/io/neow3j/devpack/constants/Role.java
@@ -8,16 +8,16 @@ public class Role {
     /**
      * The validators of the state. Used to generate and sign the state root.
      */
-    public static final byte STATE_VALIDATOR = 1 << 2;
+    public static final byte StateValidator = 1 << 2;
 
     /**
      * The nodes used to process Oracle requests.
      */
-    public static final byte ORACLE = 1 << 3;
+    public static final byte Oracle = 1 << 3;
 
     /**
      * The NeoFS Alphabet nodes.
      */
-    public static final byte NEO_FS_ALPHABET_NODE = 1 << 4;
+    public static final byte NeoFSAlphabetNode = 1 << 4;
 
 }

--- a/devpack/src/main/java/io/neow3j/devpack/contracts/OracleContract.java
+++ b/devpack/src/main/java/io/neow3j/devpack/contracts/OracleContract.java
@@ -8,27 +8,27 @@ public class OracleContract extends ContractInterface {
     /**
      * The minimum GAS fee necessary on an oracle request to pay for the response.
      */
-    public static final int MIN_RESPONSE_FEE = 10000000;
+    public static final int MinResponseFee = 10000000;
 
     /**
      * The maximum byte length of the url.
      */
-    public static final int MAX_URL_LENGTH = 1 << 8;
+    public static final int MaxUrlLength = 1 << 8;
 
     /**
      * The maximum byte length of the filter.
      */
-    public static final int MAX_FILTER_LENGTH = 1 << 7;
+    public static final int MaxFilterLength = 1 << 7;
 
     /**
      * The maximum byte length of the callback function.
      */
-    public static final int MAX_CALLBACK_LENGTH = 1 << 5;
+    public static final int MaxCallbackLength = 1 << 5;
 
     /**
      * The maximum byte length of the user data.
      */
-    public static final int MAX_USER_DATA_LENGTH = 1 << 9;
+    public static final int MaxUserDataLength = 1 << 9;
 
     /**
      * Does a request to the oracle service with the given request data. The given callback function

--- a/devpack/src/main/java/io/neow3j/devpack/contracts/PolicyContract.java
+++ b/devpack/src/main/java/io/neow3j/devpack/contracts/PolicyContract.java
@@ -9,12 +9,12 @@ public class PolicyContract extends ContractInterface {
     /**
      * The maximum execution fee factor that the committee can set.
      */
-    public static final int MAX_EXEC_FEE_FACTOR = 1000;
+    public static final int MaxExecFeeFactor = 1000;
 
     /**
      * The maximum storage price that the committee can set.
      */
-    public static final int MAX_STORAGE_PRICE = 1000;
+    public static final int MaxStoragePrice = 1000;
 
     /**
      * Gets the GAS cost per transaction byte, i.e. the fee per byte.

--- a/devpack/src/main/java/io/neow3j/devpack/contracts/StdLib.java
+++ b/devpack/src/main/java/io/neow3j/devpack/contracts/StdLib.java
@@ -9,7 +9,7 @@ public class StdLib extends ContractInterface {
     /**
      * The maximum byte length for input values.
      */
-    public static final int MAX_INPUT_LENGTH = 1024;
+    public static final int MaxInputLength = 1024;
 
     /**
      * Serialize the given object to a byte string.


### PR DESCRIPTION
I know that java's standard for constants is all upper case, but since the devpack is anyway not used for writting standard code and because i think that the camelcase format has better readability, I wanted to have all of them in camelcase with the first letter being upper case.

Some of the constants where already camelcase. This PR standardizes this throughout the whole devpack.

The javadoc changes are not related but I snuck them into this PR anyway since it's not actual code changes.