### PR TITLE
Make Hash160/256.isValid() a static class method

### DIFF
--- a/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import static io.neow3j.types.ContractParameter.byteArray;
 import static io.neow3j.types.ContractParameter.hash160;
 import static io.neow3j.types.ContractParameter.hash256;
+import static io.neow3j.types.ContractParameter.integer;
 import static io.neow3j.types.ContractParameter.string;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -54,14 +55,17 @@ public class HashIntegrationTest {
     }
 
     @Test
-    public void isHash160Valid() throws IOException {
+    public void isObjectValidHash160() throws IOException {
         String validHash = "0000000000000000000000000000000000000001";
         String invalidHash = "00000000000000000000000000000000000001"; // One byte short.
+        int otherValue = 10;
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validHash),
-                byteArray(invalidHash));
+                byteArray(invalidHash), integer(otherValue));
         List<StackItem> array = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(array.get(0).getBoolean());
         assertFalse(array.get(1).getBoolean());
+        assertFalse(array.get(2).getBoolean());
+        assertTrue(array.get(3).getBoolean());
     }
 
     @Test
@@ -203,7 +207,6 @@ public class HashIntegrationTest {
                 is("03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000"));
     }
 
-
     static class HashIntegrationTestContract {
 
         public static io.neow3j.devpack.Hash160 getZeroHash160() {
@@ -218,11 +221,14 @@ public class HashIntegrationTest {
             return b;
         }
 
-        public static boolean[] isHash160Valid(io.neow3j.devpack.Hash160 h1,
-                io.neow3j.devpack.Hash160 h2) {
-            boolean[] b = new boolean[2];
-            b[0] = h1.isValid();
-            b[1] = h2.isValid();
+        public static boolean[] isObjectValidHash160(Object validHash, Object invalidHash,
+                Object integer) {
+            boolean[] b = new boolean[4];
+            b[0] = io.neow3j.devpack.Hash160.isValid(validHash);
+            b[1] = io.neow3j.devpack.Hash160.isValid(invalidHash);
+            b[2] = io.neow3j.devpack.Hash160.isValid(integer);
+            byte[] buffer = ((ByteString) validHash).toByteArray();
+            b[3] = io.neow3j.devpack.Hash160.isValid(buffer);
             return b;
         }
 

--- a/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
@@ -134,15 +134,18 @@ public class HashIntegrationTest {
     }
 
     @Test
-    public void isHash256Valid() throws IOException {
+    public void isObjectValidHash256() throws IOException {
         String validHash = "0000000000000000000000000000000000000000000000000000000000000001";
         // One byte to short.
         String invalidHash = "00000000000000000000000000000000000000000000000000000000000001";
-        NeoInvokeFunction response =
-                ct.callInvokeFunction(testName, hash256(validHash), byteArray(invalidHash));
+        int otherValue = 10;
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validHash),
+                byteArray(invalidHash), integer(otherValue));
         List<StackItem> array = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(array.get(0).getBoolean());
         assertFalse(array.get(1).getBoolean());
+        assertFalse(array.get(2).getBoolean());
+        assertTrue(array.get(3).getBoolean());
     }
 
     @Test
@@ -267,10 +270,14 @@ public class HashIntegrationTest {
             return b;
         }
 
-        public static boolean[] isHash256Valid(Hash256 hash256_1, Hash256 hash256_2) {
-            boolean[] b = new boolean[2];
-            b[0] = hash256_1.isValid();
-            b[1] = hash256_2.isValid();
+        public static boolean[] isObjectValidHash256(Object validHash, Object invalidHash,
+                Object integer) {
+            boolean[] b = new boolean[4];
+            b[0] = io.neow3j.devpack.Hash256.isValid(validHash);
+            b[1] = io.neow3j.devpack.Hash256.isValid(invalidHash);
+            b[2] = io.neow3j.devpack.Hash256.isValid(integer);
+            byte[] buffer = ((ByteString) validHash).toByteArray();
+            b[3] = io.neow3j.devpack.Hash256.isValid(buffer);
             return b;
         }
 

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -70,7 +70,7 @@ public class Hash160 {
      * Checks if the given object is a valid Hash160, i.e., if it is either a ByteString or Buffer
      * and 20 bytes long.
      *
-     * @return true if this {@code Hash160} is valid. False, otherwise.
+     * @return true if this the given object is a valid Hash160. False, otherwise.
      */
     @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.DUP)

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -18,43 +18,6 @@ public class Hash160 {
     private static final byte LENGTH = 0x14;
 
     /**
-     * Provides a zero-valued {@code Hash160}.
-     *
-     * @return the zero-valued {@code Hash160}.
-     */
-    @Instruction(opcode = OpCode.PUSHDATA1, operandPrefix = LENGTH, operand = {0, 0, 0, 0, 0, 0, 0,
-            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
-    public static native Hash160 zero();
-
-    /**
-     * Checks if this {@code Hash160} is zero-valued.
-     *
-     * @return true if this {@code Hash160} is zero-valued. False, otherwise.
-     */
-    @Instruction(opcode = OpCode.PUSH0)
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    public native boolean isZero();
-
-    /**
-     * Checks if this {@code Hash160} is valid, i.e. is 20 bytes long.
-     * <p>
-     * This method is useful when a contract method takes a {@code Hash160} as a parameter and
-     * you want to make sure that the underlying value really is a valid hash. The compiler and
-     * NeoVM don't include or enforce this check automatically, because that would consume extra
-     * GAS even if you don't require that check.
-     *
-     * @return true if this {@code Hash160} is valid. False, otherwise.
-     */
-    @Instruction(opcode = OpCode.DUP)
-    @Instruction(opcode = OpCode.ISTYPE, operand = StackItemType.BYTE_STRING_CODE)
-    @Instruction(opcode = OpCode.SWAP)
-    @Instruction(opcode = OpCode.SIZE)
-    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 20 bytes expected array size
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    @Instruction(opcode = OpCode.BOOLAND)
-    public native boolean isValid();
-
-    /**
      * Creates a {@code Hash160} from the given byte array.
      * <p>
      * Checks if the value is a valid hash. Fails if it is not.
@@ -84,6 +47,43 @@ public class Hash160 {
     @Instruction(opcode = OpCode.ASSERT)
     public Hash160(ByteString value) {
     }
+
+    /**
+     * Provides a zero-valued {@code Hash160}.
+     *
+     * @return the zero-valued {@code Hash160}.
+     */
+    @Instruction(opcode = OpCode.PUSHDATA1, operandPrefix = LENGTH, operand = {0, 0, 0, 0, 0, 0, 0,
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0})
+    public static native Hash160 zero();
+
+    /**
+     * Checks if this {@code Hash160} is zero-valued.
+     *
+     * @return true if this {@code Hash160} is zero-valued. False, otherwise.
+     */
+    @Instruction(opcode = OpCode.PUSH0)
+    @Instruction(opcode = OpCode.NUMEQUAL)
+    public native boolean isZero();
+
+    /**
+     * Checks if the given object is a valid Hash160, i.e., if it is either a ByteString or Buffer
+     * and 20 bytes long.
+     *
+     * @return true if this {@code Hash160} is valid. False, otherwise.
+     */
+    @Instruction(opcode = OpCode.DUP)
+    @Instruction(opcode = OpCode.DUP)
+    @Instruction(opcode = OpCode.ISTYPE, operand = StackItemType.BYTE_STRING_CODE)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.ISTYPE, operand = StackItemType.BUFFER_CODE)
+    @Instruction(opcode = OpCode.BOOLOR)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.SIZE)
+    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 20 bytes expected array size
+    @Instruction(opcode = OpCode.NUMEQUAL)
+    @Instruction(opcode = OpCode.BOOLAND)
+    public static native boolean isValid(Object data);
 
     /**
      * Returns this {@code Hash160} as a byte array.

--- a/devpack/src/main/java/io/neow3j/devpack/Hash256.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash256.java
@@ -76,14 +76,19 @@ public class Hash256 {
      *
      * @return true if this {@code Hash256} is valid. False, otherwise.
      */
+
+    @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.ISTYPE, operand = StackItemType.BYTE_STRING_CODE)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.ISTYPE, operand = StackItemType.BUFFER_CODE)
+    @Instruction(opcode = OpCode.BOOLOR)
     @Instruction(opcode = OpCode.SWAP)
     @Instruction(opcode = OpCode.SIZE)
     @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 32 bytes expected array size
     @Instruction(opcode = OpCode.NUMEQUAL)
     @Instruction(opcode = OpCode.BOOLAND)
-    public native boolean isValid();
+    public static native boolean isValid(Object data);
 
     /**
      * Returns this {@code Hash256} as a byte array.

--- a/devpack/src/main/java/io/neow3j/devpack/Hash256.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash256.java
@@ -67,16 +67,11 @@ public class Hash256 {
     public native boolean isZero();
 
     /**
-     * Checks if this {@code Hash256} is valid, i.e. is 32 bytes long.
-     * <p>
-     * This method is useful when a contract method takes a {@code Hash256} as a parameter and
-     * you want to make sure that the underlying value really is a valid hash. The compiler and
-     * NeoVM don't include or enforce this check automatically, because that would consume extra
-     * GAS even if you don't require that check.
+     * Checks if the given object is a valid Hash256, i.e., if it is either a ByteString or Buffer
+     * and 32 bytes long.
      *
-     * @return true if this {@code Hash256} is valid. False, otherwise.
+     * @return true if this the given object is a valid Hash256. False, otherwise.
      */
-
     @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.ISTYPE, operand = StackItemType.BYTE_STRING_CODE)

--- a/devpack/src/main/java/io/neow3j/devpack/Hash256.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash256.java
@@ -18,6 +18,37 @@ public class Hash256 {
     private static final byte LENGTH = 0x20;
 
     /**
+     * Creates a {@code Hash256} from the given byte array.
+     * <p>
+     * Checks if the value is a valid hash. Fails if it is not.
+     *
+     * @param value The hash as a byte array.
+     */
+    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
+    @Instruction(opcode = OpCode.DUP)
+    @Instruction(opcode = OpCode.SIZE)
+    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 32 bytes expected array size
+    @Instruction(opcode = OpCode.NUMEQUAL)
+    @Instruction(opcode = OpCode.ASSERT)
+    public Hash256(byte[] value) {
+    }
+
+    /**
+     * Creates a {@code Hash256} from the given bytes.
+     * <p>
+     * Checks if the value is a valid hash. Fails if it is not.
+     *
+     * @param value The hash as a byte string.
+     */
+    @Instruction(opcode = OpCode.DUP)
+    @Instruction(opcode = OpCode.SIZE)
+    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 32 bytes expected array size
+    @Instruction(opcode = OpCode.NUMEQUAL)
+    @Instruction(opcode = OpCode.ASSERT)
+    public Hash256(ByteString value) {
+    }
+
+    /**
      * Provides a zero-valued {@code Hash256}.
      *
      * @return the zero-valued {@code Hash256}.
@@ -53,37 +84,6 @@ public class Hash256 {
     @Instruction(opcode = OpCode.NUMEQUAL)
     @Instruction(opcode = OpCode.BOOLAND)
     public native boolean isValid();
-
-    /**
-     * Creates a {@code Hash256} from the given byte array.
-     * <p>
-     * Checks if the value is a valid hash. Fails if it is not.
-     *
-     * @param value The hash as a byte array.
-     */
-    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
-    @Instruction(opcode = OpCode.DUP)
-    @Instruction(opcode = OpCode.SIZE)
-    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 32 bytes expected array size
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    @Instruction(opcode = OpCode.ASSERT)
-    public Hash256(byte[] value) {
-    }
-
-    /**
-     * Creates a {@code Hash256} from the given bytes.
-     * <p>
-     * Checks if the value is a valid hash. Fails if it is not.
-     *
-     * @param value The hash as a byte string.
-     */
-    @Instruction(opcode = OpCode.DUP)
-    @Instruction(opcode = OpCode.SIZE)
-    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 32 bytes expected array size
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    @Instruction(opcode = OpCode.ASSERT)
-    public Hash256(ByteString value) {
-    }
 
     /**
      * Returns this {@code Hash256} as a byte array.


### PR DESCRIPTION
When working on the governance contracts i realized that a static 'isValid' method on the hash classes would be more convenient than the instance methods that we provide at the moment. This new 'isValid(Object data)' checks if the hash is either a Buffer or ByteString and has the right length. Note, that the constructors also do the size check, i.e., there is a bit of redundancy.