### PR TITLE
Hash and ECPoint improvements

### DIFF
--- a/compiler/src/test-integration/java/io/neow3j/compiler/ByteStringIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ByteStringIntegrationTest.java
@@ -47,6 +47,12 @@ public class ByteStringIntegrationTest {
     }
 
     @Test
+    public void createByteStringFromInteger() throws IOException {
+        InvocationResult res = ct.callInvokeFunction(testName).getInvocationResult();
+        assertThat(res.getStack().get(0).getByteArray(), is(new byte[]{0x64, 0x1b, 0x40}));
+    }
+
+    @Test
     public void getElementsOfByteString() throws IOException {
         ContractParameter byteString = byteArray("00010203");
         InvocationResult res = ct.callInvokeFunction(testName, byteString, integer(0))
@@ -194,6 +200,10 @@ public class ByteStringIntegrationTest {
 
         public static ByteString createByteStringFromByteArray() {
             return new ByteString(new byte[]{0x00, 0x01, 0x02, 0x03});
+        }
+
+        public static ByteString createByteStringFromInteger() {
+            return new ByteString(4201316);
         }
 
         public static byte getElementsOfByteString(ByteString s, int index) {

--- a/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
@@ -99,13 +99,13 @@ public class ECPointIntegrationTest {
             return new ECPoint(s);
         }
 
-        public static boolean[] isObjectValidECPoint(Object validHash, Object invalidHash,
+        public static boolean[] isObjectValidECPoint(Object validECPoint, Object invalidECPoint,
                 Object integer) {
             boolean[] b = new boolean[4];
-            b[0] = ECPoint.isValid(validHash);
-            b[1] = ECPoint.isValid(invalidHash);
+            b[0] = ECPoint.isValid(validECPoint);
+            b[1] = ECPoint.isValid(invalidECPoint);
             b[2] = ECPoint.isValid(integer);
-            byte[] buffer = ((ByteString) validHash).toByteArray();
+            byte[] buffer = ((ByteString) validECPoint).toByteArray();
             b[3] = ECPoint.isValid(buffer);
             return b;
         }

--- a/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
@@ -102,11 +102,11 @@ public class ECPointIntegrationTest {
         public static boolean[] isObjectValidECPoint(Object validHash, Object invalidHash,
                 Object integer) {
             boolean[] b = new boolean[4];
-            b[0] = io.neow3j.devpack.ECPoint.isValid(validHash);
-            b[1] = io.neow3j.devpack.ECPoint.isValid(invalidHash);
-            b[2] = io.neow3j.devpack.ECPoint.isValid(integer);
+            b[0] = ECPoint.isValid(validHash);
+            b[1] = ECPoint.isValid(invalidHash);
+            b[2] = ECPoint.isValid(integer);
             byte[] buffer = ((ByteString) validHash).toByteArray();
-            b[3] = io.neow3j.devpack.ECPoint.isValid(buffer);
+            b[3] = ECPoint.isValid(buffer);
             return b;
         }
 

--- a/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
@@ -1,10 +1,8 @@
 package io.neow3j.compiler;
 
-import io.neow3j.types.ContractParameter;
+import io.neow3j.protocol.core.stackitem.StackItem;
 import io.neow3j.devpack.ByteString;
 import io.neow3j.devpack.ECPoint;
-import io.neow3j.devpack.StringLiteralHelper;
-import io.neow3j.types.NeoVMStateType;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
@@ -13,10 +11,16 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 
 import java.io.IOException;
+import java.util.List;
 
+import static io.neow3j.devpack.StringLiteralHelper.hexToBytes;
 import static io.neow3j.types.ContractParameter.byteArray;
+import static io.neow3j.types.ContractParameter.integer;
+import static io.neow3j.types.ContractParameter.publicKey;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class ECPointIntegrationTest {
 
@@ -28,7 +32,7 @@ public class ECPointIntegrationTest {
             ECPointIntegrationTestContract.class.getName());
 
     @Test
-    public void createEcPointFromValidByteArray() throws IOException {
+    public void createECPointFromByteArray() throws IOException {
         String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(publicKey));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
@@ -36,15 +40,7 @@ public class ECPointIntegrationTest {
     }
 
     @Test
-    public void createEcPointFromInvalidByteArray() throws IOException {
-        // Public key byte array is one byte too short
-        String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e1368";
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(publicKey));
-        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
-    }
-
-    @Test
-    public void createEcPointFromValidString() throws IOException {
+    public void createECPointFromString() throws IOException {
         String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(publicKey));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
@@ -52,18 +48,25 @@ public class ECPointIntegrationTest {
     }
 
     @Test
-    public void createEcPointFromInvalidString() throws IOException {
-        // Public key byte array is one byte too short
-        String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e1368";
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(publicKey));
-        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+    public void isObjectValidECPoint() throws IOException {
+        String validPubKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
+        // One byte too short.
+        String invalidPubKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e1368";
+        int otherValue = 123456;
+
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validPubKey),
+                byteArray(invalidPubKey), integer(otherValue));
+        List<StackItem> array = response.getInvocationResult().getStack().get(0).getList();
+        assertTrue(array.get(0).getBoolean());
+        assertFalse(array.get(1).getBoolean());
+        assertFalse(array.get(2).getBoolean());
+        assertTrue(array.get(3).getBoolean());
     }
 
     @Test
     public void ecPointToByteArray() throws IOException {
         String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
-        NeoInvokeFunction response = ct.callInvokeFunction(testName,
-                ContractParameter.publicKey(publicKey));
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, publicKey(publicKey));
         assertThat(response.getInvocationResult().getStack().get(0).getByteArray(),
                 is(Numeric.hexStringToByteArray(publicKey)));
     }
@@ -71,8 +74,7 @@ public class ECPointIntegrationTest {
     @Test
     public void ecPointAsByteString() throws IOException {
         String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
-        NeoInvokeFunction response = ct.callInvokeFunction(testName,
-                ContractParameter.publicKey(publicKey));
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, publicKey(publicKey));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
                 is(publicKey));
     }
@@ -87,30 +89,39 @@ public class ECPointIntegrationTest {
 
     static class ECPointIntegrationTestContract {
 
-        public static ECPoint createEcPointFromValidByteArray(byte[] b) {
-            return new ECPoint(b);
+        public static ECPoint createECPointFromByteArray(ByteString b) {
+            byte[] buffer = b.toByteArray();
+            assert buffer instanceof byte[] : "Value is not of type buffer.";
+            return new ECPoint(buffer);
         }
 
-        public static ECPoint createEcPointFromInvalidByteArray(byte[] b) {
-            return new ECPoint(b);
-        }
-
-        public static ECPoint createEcPointFromValidString(ByteString s) {
+        public static ECPoint createECPointFromString(ByteString s) {
             return new ECPoint(s);
         }
 
-        public static ECPoint createEcPointFromInvalidString(ByteString s) {
-            return new ECPoint(s);
+        public static boolean[] isObjectValidECPoint(Object validHash, Object invalidHash,
+                Object integer) {
+            boolean[] b = new boolean[4];
+            b[0] = io.neow3j.devpack.ECPoint.isValid(validHash);
+            b[1] = io.neow3j.devpack.ECPoint.isValid(invalidHash);
+            b[2] = io.neow3j.devpack.ECPoint.isValid(integer);
+            byte[] buffer = ((ByteString) validHash).toByteArray();
+            b[3] = io.neow3j.devpack.ECPoint.isValid(buffer);
+            return b;
         }
 
         public static byte[] ecPointToByteArrayFromStringLiteral() {
-            ECPoint point = new ECPoint(StringLiteralHelper.hexToBytes(
+            ECPoint point = new ECPoint(hexToBytes(
                     "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816"));
-            return point.toByteArray();
+            byte[] pointBuffer = point.toByteArray();
+            assert pointBuffer instanceof byte[] : "Value is not of type buffer.";
+            return pointBuffer;
         }
 
         public static byte[] ecPointToByteArray(ECPoint ecPoint) {
-            return ecPoint.toByteArray();
+            byte[] pointBuffer = ecPoint.toByteArray();
+            assert pointBuffer instanceof byte[] : "Value is not of type buffer.";
+            return pointBuffer;
         }
 
         public static ByteString ecPointAsByteString(ECPoint ecPoint) {

--- a/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
@@ -67,7 +67,7 @@ public class HashIntegrationTest {
     }
 
     @Test
-    public void createHash160FromValidByteArray() throws IOException {
+    public void createHash160FromByteArray() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
@@ -75,7 +75,7 @@ public class HashIntegrationTest {
     }
 
     @Test
-    public void createHash160FromValidString() throws IOException {
+    public void createHash160FromString() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
@@ -133,7 +133,7 @@ public class HashIntegrationTest {
     }
 
     @Test
-    public void createHash256FromValidByteArray() throws IOException {
+    public void createHash256FromByteArray() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
@@ -141,7 +141,7 @@ public class HashIntegrationTest {
     }
 
     @Test
-    public void createHash256FromValidString() throws IOException {
+    public void createHash256FromString() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
@@ -203,13 +203,13 @@ public class HashIntegrationTest {
             return b;
         }
 
-        public static io.neow3j.devpack.Hash160 createHash160FromValidByteArray(ByteString b) {
+        public static io.neow3j.devpack.Hash160 createHash160FromByteArray(ByteString b) {
             byte[] buffer = b.toByteArray();
             assert buffer instanceof byte[] : "Value is not of type buffer.";
             return new io.neow3j.devpack.Hash160(buffer);
         }
 
-        public static io.neow3j.devpack.Hash160 createHash160FromValidString(ByteString s) {
+        public static io.neow3j.devpack.Hash160 createHash160FromString(ByteString s) {
             return new io.neow3j.devpack.Hash160(s);
         }
 
@@ -243,13 +243,13 @@ public class HashIntegrationTest {
             return b;
         }
 
-        public static Hash256 createHash256FromValidByteArray(ByteString b) {
+        public static Hash256 createHash256FromByteArray(ByteString b) {
             byte[] buffer = b.toByteArray();
             assert buffer instanceof byte[] : "Value is not of type buffer.";
             return new Hash256(buffer);
         }
 
-        public static Hash256 createHash256FromValidString(ByteString s) {
+        public static Hash256 createHash256FromString(ByteString s) {
             return new Hash256(s);
         }
 

--- a/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
@@ -4,7 +4,6 @@ import io.neow3j.types.Hash160;
 import io.neow3j.devpack.ByteString;
 import io.neow3j.devpack.Hash256;
 import io.neow3j.devpack.StringLiteralHelper;
-import io.neow3j.types.NeoVMStateType;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.stackitem.StackItem;
 import io.neow3j.utils.Numeric;
@@ -142,27 +141,11 @@ public class HashIntegrationTest {
     }
 
     @Test
-    public void createHash256FromInvalidByteArray() throws IOException {
-        // Too long hash.
-        String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b00000000000000000000000000";
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
-        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
-    }
-
-    @Test
     public void createHash256FromValidString() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
                 is(hash));
-    }
-
-    @Test
-    public void createHash256FromInvalidString() throws IOException {
-        // Too long hash.
-        String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b00000000000000000000000000";
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
-        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
     }
 
     @Test
@@ -226,12 +209,6 @@ public class HashIntegrationTest {
             return new io.neow3j.devpack.Hash160(buffer);
         }
 
-        public static io.neow3j.devpack.Hash160 createHash160FromInvalidByteArray(ByteString b) {
-            byte[] buffer = b.toByteArray();
-            assert buffer instanceof byte[] : "Value is not of type buffer.";
-            return new io.neow3j.devpack.Hash160(buffer);
-        }
-
         public static io.neow3j.devpack.Hash160 createHash160FromValidString(ByteString s) {
             return new io.neow3j.devpack.Hash160(s);
         }
@@ -266,19 +243,13 @@ public class HashIntegrationTest {
             return b;
         }
 
-        public static Hash256 createHash256FromValidByteArray(byte[] b) {
-            return new Hash256(b);
-        }
-
-        public static Hash256 createHash256FromInvalidByteArray(byte[] b) {
-            return new Hash256(b);
+        public static Hash256 createHash256FromValidByteArray(ByteString b) {
+            byte[] buffer = b.toByteArray();
+            assert buffer instanceof byte[] : "Value is not of type buffer.";
+            return new Hash256(buffer);
         }
 
         public static Hash256 createHash256FromValidString(ByteString s) {
-            return new Hash256(s);
-        }
-
-        public static Hash256 createHash256FromInvalidString(ByteString s) {
             return new Hash256(s);
         }
 

--- a/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
@@ -20,7 +20,6 @@ import static io.neow3j.types.ContractParameter.byteArray;
 import static io.neow3j.types.ContractParameter.hash160;
 import static io.neow3j.types.ContractParameter.hash256;
 import static io.neow3j.types.ContractParameter.integer;
-import static io.neow3j.types.ContractParameter.string;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -77,25 +76,11 @@ public class HashIntegrationTest {
     }
 
     @Test
-    public void createHash160FromInvalidByteArray() throws IOException {
-        String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b7b"; // One byte to long.
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
-        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
-    }
-
-    @Test
     public void createHash160FromValidString() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
                 is(hash));
-    }
-
-    @Test
-    public void createHash160FromInvalidString() throws IOException {
-        String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b7b"; // One byte to long.
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, string(hash));
-        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
     }
 
     @Test
@@ -136,7 +121,7 @@ public class HashIntegrationTest {
     @Test
     public void isObjectValidHash256() throws IOException {
         String validHash = "0000000000000000000000000000000000000000000000000000000000000001";
-        // One byte to short.
+        // One byte too short.
         String invalidHash = "00000000000000000000000000000000000000000000000000000000000001";
         int otherValue = 10;
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validHash),
@@ -158,7 +143,7 @@ public class HashIntegrationTest {
 
     @Test
     public void createHash256FromInvalidByteArray() throws IOException {
-        // One byte to long.
+        // Too long hash.
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b00000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
         assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
@@ -174,7 +159,7 @@ public class HashIntegrationTest {
 
     @Test
     public void createHash256FromInvalidString() throws IOException {
-        // One byte to long.
+        // Too long hash.
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b00000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
         assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
@@ -235,19 +220,19 @@ public class HashIntegrationTest {
             return b;
         }
 
-        public static io.neow3j.devpack.Hash160 createHash160FromValidByteArray(byte[] b) {
-            return new io.neow3j.devpack.Hash160(b);
+        public static io.neow3j.devpack.Hash160 createHash160FromValidByteArray(ByteString b) {
+            byte[] buffer = b.toByteArray();
+            assert buffer instanceof byte[] : "Value is not of type buffer.";
+            return new io.neow3j.devpack.Hash160(buffer);
         }
 
-        public static io.neow3j.devpack.Hash160 createHash160FromInvalidByteArray(byte[] b) {
-            return new io.neow3j.devpack.Hash160(b);
+        public static io.neow3j.devpack.Hash160 createHash160FromInvalidByteArray(ByteString b) {
+            byte[] buffer = b.toByteArray();
+            assert buffer instanceof byte[] : "Value is not of type buffer.";
+            return new io.neow3j.devpack.Hash160(buffer);
         }
 
         public static io.neow3j.devpack.Hash160 createHash160FromValidString(ByteString s) {
-            return new io.neow3j.devpack.Hash160(s);
-        }
-
-        public static io.neow3j.devpack.Hash160 createHash160FromInvalidString(ByteString s) {
             return new io.neow3j.devpack.Hash160(s);
         }
 

--- a/compiler/src/test/java/io/neow3j/compiler/ManifestExtraTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/ManifestExtraTest.java
@@ -1,0 +1,85 @@
+package io.neow3j.compiler;
+
+import io.neow3j.devpack.annotations.ManifestExtra;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("unchecked")
+public class ManifestExtraTest {
+
+    @Test
+    public void singleExtraAnnotation() throws IOException {
+        CompilationUnit unit = new Compiler()
+                .compile(SingleExtraManifestTestContract.class.getName());
+        Object extra = unit.getManifest().getExtra();
+        assertTrue(extra instanceof Map);
+        Map extras = (Map<String, String>) extra;
+        assertThat(extras.size(), is(1));
+        assertThat((String) (extras.get("Author")), is("AxLabs"));
+    }
+
+    @ManifestExtra(key = "Author", value = "AxLabs")
+    static class SingleExtraManifestTestContract {
+
+        public static void main() {
+        }
+
+    }
+
+    @Test
+    public void multipleExtraAnnotations() throws IOException {
+        CompilationUnit unit = new Compiler()
+                .compile(MultipleSingleExtraManifestTestContract.class.getName());
+        Object extra = unit.getManifest().getExtra();
+        assertTrue(extra instanceof Map);
+        Map extras = (Map<String, String>) extra;
+        assertThat(extras.size(), is(3));
+        assertThat((String) (extras.get("k")), is("val"));
+        assertThat((String) (extras.get("Cool Cat")), is("neow3j"));
+        assertThat((String) (extras.get("author")), is("axlabs"));
+    }
+
+    @ManifestExtra(key = "k", value = "val")
+    @ManifestExtra(key = "author", value = "axlabs")
+    @ManifestExtra(key = "Cool Cat", value = "neow3j")
+    static class MultipleSingleExtraManifestTestContract {
+
+        public static void main() {
+        }
+
+    }
+
+    @Test
+    public void extrasAnnotation() throws IOException {
+        CompilationUnit unit = new Compiler()
+                .compile(ExtrasManifestTestContract.class.getName());
+        Object extra = unit.getManifest().getExtra();
+        assertTrue(extra instanceof Map);
+        Map extras = (Map<String, String>) extra;
+        assertThat(extras.size(), is(4));
+        assertThat((String) (extras.get("k")), is("val"));
+        assertThat((String) (extras.get("Cool cat")), is("Neoooow3j"));
+        assertThat((String) (extras.get("author")), is("axlabs"));
+        assertThat((String) (extras.get("key")), is("value"));
+    }
+
+    @ManifestExtra.ManifestExtras({
+            @ManifestExtra(key = "Cool cat", value = "Neoooow3j"),
+            @ManifestExtra(key = "k", value = "val"),
+            @ManifestExtra(key = "key", value = "value"),
+            @ManifestExtra(key = "author", value = "axlabs")
+    })
+    static class ExtrasManifestTestContract {
+
+        public static void main() {
+        }
+
+    }
+
+}

--- a/core/src/main/java/io/neow3j/script/OpCode.java
+++ b/core/src/main/java/io/neow3j/script/OpCode.java
@@ -375,7 +375,7 @@ public enum OpCode {
 
     /**
      * End finally, If no exception happen or be catched, vm will jump to the target instruction of
-     * ENDTRY/ENDTRY_L. Otherwise vm will rethrow the exception to upper layer.
+     * ENDTRY/ENDTRY_L. Otherwise, vm will rethrow the exception to upper layer.
      */
     ENDFINALLY(0x3F, 1 << 2),
 
@@ -881,17 +881,17 @@ public enum OpCode {
     SHR(0xA9, 1 << 3),
 
     /**
-     * If the input is 0 or 1, it is flipped. Otherwise the output will be 0.
+     * If the input is 0 or 1, it is flipped. Otherwise, the output will be 0.
      */
     NOT(0xAA, 1 << 2),
 
     /**
-     * If both a and b are not 0, the output is 1. Otherwise 0.
+     * If both a and b are not 0, the output is 1. Otherwise, 0.
      */
     BOOLAND(0xAB, 1 << 3),
 
     /**
-     * If a or b is not 0, the output is 1. Otherwise 0.
+     * If a or b is not 0, the output is 1. Otherwise, 0.
      */
     BOOLOR(0xAC, 1 << 3),
 
@@ -1159,4 +1159,5 @@ public enum OpCode {
             return null;
         }
     }
+
 }

--- a/devpack/src/main/java/io/neow3j/devpack/ByteString.java
+++ b/devpack/src/main/java/io/neow3j/devpack/ByteString.java
@@ -22,9 +22,8 @@ public class ByteString {
      *
      * @param str The string.
      */
-    @Instruction()
+    @Instruction
     public ByteString(String str) {
-
     }
 
     /**
@@ -35,7 +34,6 @@ public class ByteString {
      */
     @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
     public ByteString(byte[] buffer) {
-
     }
 
     /**
@@ -46,7 +44,6 @@ public class ByteString {
      */
     @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
     public ByteString(int integer) {
-
     }
 
 
@@ -74,7 +71,7 @@ public class ByteString {
      * @return the string.
      */
     @Override
-    @Instruction()
+    @Instruction
     public native String toString();
 
     /**

--- a/devpack/src/main/java/io/neow3j/devpack/ByteString.java
+++ b/devpack/src/main/java/io/neow3j/devpack/ByteString.java
@@ -39,6 +39,18 @@ public class ByteString {
     }
 
     /**
+     * Constructs a new {@code ByteString} from the given integer. This incurs the GAS cost of
+     * converting the integer to a {@code ByteString}.
+     *
+     * @param integer The integer.
+     */
+    @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
+    public ByteString(int integer) {
+
+    }
+
+
+    /**
      * Gets the item at the given index in this {@code ByteString}. If the index is out of bounds
      * the NeoVM will throw an exception that needs to be catched. Otherwise, the NeoVM will FAULT.
      *

--- a/devpack/src/main/java/io/neow3j/devpack/ECPoint.java
+++ b/devpack/src/main/java/io/neow3j/devpack/ECPoint.java
@@ -10,36 +10,53 @@ import io.neow3j.types.StackItemType;
  */
 public class ECPoint {
 
+    private static final byte LENGTH = 0x21; // 33 bytes
+
     /**
      * Constructs an {@code ECPoint} from the given byte array. Checks if the argument has the
      * appropriate size of 33 bytes for an EC point.
+     * <p>
+     * Does NOT check if the value has the appropriate size for an EC Point. Use {@code ECPoint
+     * .isValid()} in order to verify the correct format.
      *
-     * @param value The EC point as a byte array.
+     * @param buffer The EC point as a byte array.
      */
     @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
-    @Instruction(opcode = OpCode.DUP)
-    @Instruction(opcode = OpCode.SIZE)
-    @Instruction(opcode = OpCode.PUSHINT8, operand = 0x21) // 33 bytes expected array size
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    @Instruction(opcode = OpCode.ASSERT)
-    public ECPoint(byte[] value) {
+    public ECPoint(byte[] buffer) {
 
     }
 
     /**
-     * Constructs an {@code ECPoint} from the given byte string. Checks if the argument has the
-     * appropriate size of 33 bytes for an EC point.
+     * Constructs an {@code ECPoint} from the given byte string.
+     * <p>
+     * Does NOT check if the value is a valid EC point. Use {@code ECPoint.isValid()} in order to
+     * verify the correct format.
      *
      * @param value The EC point as a hex string.
      */
-    @Instruction(opcode = OpCode.DUP)
-    @Instruction(opcode = OpCode.SIZE)
-    @Instruction(opcode = OpCode.PUSHINT8, operand = 0x21) // 33 bytes expected array size
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    @Instruction(opcode = OpCode.ASSERT)
+    @Instruction
     public ECPoint(ByteString value) {
-
     }
+
+    /**
+     * Checks if the given object is a valid EC point, i.e., if it is either a ByteString or Buffer
+     * and 33 bytes long.
+     *
+     * @param data The object to check.
+     * @return true if the given object is a valid EC point. False, otherwise.
+     */
+    @Instruction(opcode = OpCode.DUP)
+    @Instruction(opcode = OpCode.DUP)
+    @Instruction(opcode = OpCode.ISTYPE, operand = StackItemType.BYTE_STRING_CODE)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.ISTYPE, operand = StackItemType.BUFFER_CODE)
+    @Instruction(opcode = OpCode.BOOLOR)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.SIZE)
+    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 33 bytes expected array size
+    @Instruction(opcode = OpCode.NUMEQUAL)
+    @Instruction(opcode = OpCode.BOOLAND)
+    public static native boolean isValid(Object data);
 
     /**
      * Returns this {@code ECPoint} as a byte array.
@@ -68,5 +85,5 @@ public class ECPoint {
     @Override
     @Instruction(opcode = OpCode.EQUAL)
     public native boolean equals(Object other);
-}
 
+}

--- a/devpack/src/main/java/io/neow3j/devpack/ECPoint.java
+++ b/devpack/src/main/java/io/neow3j/devpack/ECPoint.java
@@ -13,8 +13,7 @@ public class ECPoint {
     private static final byte LENGTH = 0x21; // 33 bytes
 
     /**
-     * Constructs an {@code ECPoint} from the given byte array. Checks if the argument has the
-     * appropriate size of 33 bytes for an EC point.
+     * Constructs an {@code ECPoint} from the given byte array.
      * <p>
      * Does NOT check if the value has the appropriate size for an EC Point. Use {@code ECPoint
      * .isValid()} in order to verify the correct format.

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -20,7 +20,8 @@ public class Hash160 {
     /**
      * Creates a {@code Hash160} from the given byte array.
      * <p>
-     * Checks if the value is a valid hash. Fails if it is not.
+     * Does NOT check if the value is a valid hash. Use {@code Hash160.isValid()} in order to
+     * verify the correct format.
      *
      * @param value The hash as a byte array.
      */
@@ -31,7 +32,8 @@ public class Hash160 {
     /**
      * Creates a {@code Hash160} from the given bytes.
      * <p>
-     * Checks if the value is a valid hash. Fails if it is not.
+     * Does NOT check if the value is a valid hash. Use {@code Hash160.isValid()} in order to
+     * verify the correct format.
      *
      * @param value The hash as a byte string.
      */

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -23,10 +23,10 @@ public class Hash160 {
      * Does NOT check if the value is a valid hash. Use {@code Hash160.isValid()} in order to
      * verify the correct format.
      *
-     * @param value The hash as a byte array.
+     * @param buffer The hash as a byte array.
      */
     @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
-    public Hash160(byte[] value) {
+    public Hash160(byte[] buffer) {
     }
 
     /**

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -15,7 +15,7 @@ import io.neow3j.types.StackItemType;
  */
 public class Hash160 {
 
-    private static final byte LENGTH = 0x14;
+    private static final byte LENGTH = 0x14; // 20 bytes
 
     /**
      * Creates a {@code Hash160} from the given byte array.
@@ -64,7 +64,7 @@ public class Hash160 {
      * and 20 bytes long.
      *
      * @param data The object to check.
-     * @return true if this the given object is a valid Hash160. False, otherwise.
+     * @return true if the given object is a valid Hash160. False, otherwise.
      */
     @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.DUP)

--- a/devpack/src/main/java/io/neow3j/devpack/Hash160.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash160.java
@@ -25,11 +25,6 @@ public class Hash160 {
      * @param value The hash as a byte array.
      */
     @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
-    @Instruction(opcode = OpCode.DUP)
-    @Instruction(opcode = OpCode.SIZE)
-    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 20 bytes expected array size
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    @Instruction(opcode = OpCode.ASSERT)
     public Hash160(byte[] value) {
     }
 
@@ -40,11 +35,7 @@ public class Hash160 {
      *
      * @param value The hash as a byte string.
      */
-    @Instruction(opcode = OpCode.DUP)
-    @Instruction(opcode = OpCode.SIZE)
-    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 20 bytes expected array size
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    @Instruction(opcode = OpCode.ASSERT)
+    @Instruction
     public Hash160(ByteString value) {
     }
 
@@ -113,4 +104,5 @@ public class Hash160 {
     @Override
     @Instruction(opcode = OpCode.EQUAL)
     public native boolean equals(Object other);
+
 }

--- a/devpack/src/main/java/io/neow3j/devpack/Hash256.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash256.java
@@ -15,7 +15,7 @@ import io.neow3j.types.StackItemType;
  */
 public class Hash256 {
 
-    private static final byte LENGTH = 0x20;
+    private static final byte LENGTH = 0x20; // 32 bytes
 
     /**
      * Creates a {@code Hash256} from the given byte array.
@@ -64,7 +64,7 @@ public class Hash256 {
      * and 32 bytes long.
      *
      * @param data The object to check.
-     * @return true if this the given object is a valid Hash256. False, otherwise.
+     * @return true if the given object is a valid Hash256. False, otherwise.
      */
     @Instruction(opcode = OpCode.DUP)
     @Instruction(opcode = OpCode.DUP)

--- a/devpack/src/main/java/io/neow3j/devpack/Hash256.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Hash256.java
@@ -20,31 +20,24 @@ public class Hash256 {
     /**
      * Creates a {@code Hash256} from the given byte array.
      * <p>
-     * Checks if the value is a valid hash. Fails if it is not.
+     * Does NOT check if the value is a valid hash. Use {@code Hash256.isValid()} in order to
+     * verify the correct format.
      *
-     * @param value The hash as a byte array.
+     * @param buffer The hash as a byte array.
      */
     @Instruction(opcode = OpCode.CONVERT, operand = StackItemType.BYTE_STRING_CODE)
-    @Instruction(opcode = OpCode.DUP)
-    @Instruction(opcode = OpCode.SIZE)
-    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 32 bytes expected array size
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    @Instruction(opcode = OpCode.ASSERT)
-    public Hash256(byte[] value) {
+    public Hash256(byte[] buffer) {
     }
 
     /**
      * Creates a {@code Hash256} from the given bytes.
      * <p>
-     * Checks if the value is a valid hash. Fails if it is not.
+     * Does NOT check if the value is a valid hash. Use {@code Hash256.isValid()} in order to
+     * verify the correct format.
      *
      * @param value The hash as a byte string.
      */
-    @Instruction(opcode = OpCode.DUP)
-    @Instruction(opcode = OpCode.SIZE)
-    @Instruction(opcode = OpCode.PUSHINT8, operand = LENGTH) // 32 bytes expected array size
-    @Instruction(opcode = OpCode.NUMEQUAL)
-    @Instruction(opcode = OpCode.ASSERT)
+    @Instruction
     public Hash256(ByteString value) {
     }
 


### PR DESCRIPTION
- Removed size checks from constructors in `Hash160`, `Hash256` and `ECPoint` classes. 
- Added `ECPoint.isValid()` method.
- Added ByteString constructor from integer value.

Closes #699 #703