### PR TITLE
Replace ExpectedException with Assert.assertThrows

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ buildscript {
 
     // test dependencies
     ext.equalsverifierVersion = '2.1.7'
-    ext.junitVersion = '4.11'
+    ext.junitVersion = '4.13'
     ext.junitBenchmarkVersion = '0.7.2'
     ext.logbackVersion = '1.2.3'
     ext.jetbrainsAnnotationsVersion = '20.1.0'

--- a/compiler/src/test/java/io/neow3j/compiler/CompilerExceptionsTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/CompilerExceptionsTest.java
@@ -262,7 +262,7 @@ public class CompilerExceptionsTest {
 
     @Test
     public void throwOnStaticVariableInNonContractClass() {
-        CompilerException thrown = assertThrows(
+        assertThrows(
                 "Static variables are not allowed outside the main contract class",
                 CompilerException.class,
                 () -> new Compiler().compile(ContractClassWithReferenceToStaticVariable.class.getName())

--- a/compiler/src/test/java/io/neow3j/compiler/CompilerExceptionsTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/CompilerExceptionsTest.java
@@ -12,11 +12,7 @@ import io.neow3j.devpack.contracts.ContractInterface;
 import io.neow3j.devpack.contracts.FungibleToken;
 import io.neow3j.devpack.events.Event1Arg;
 import io.neow3j.script.OpCode;
-import org.hamcrest.core.StringContains;
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.MethodNode;
 
@@ -26,57 +22,61 @@ import java.util.List;
 
 import static io.neow3j.compiler.Compiler.CLASS_VERSION_SUPPORTED;
 import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThrows;
 
 public class CompilerExceptionsTest {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
-    public void throwExceptionIfNonDefaultExceptionInstanceIsUsed() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void throwExceptionIfNonDefaultExceptionInstanceIsUsed() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(UnsupportedException.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 IllegalArgumentException.class.getCanonicalName(),
                 Exception.class.getCanonicalName())));
-        new Compiler().compile(UnsupportedException.class.getName());
     }
 
     @Test
-    public void throwExceptionIfNonDefaultExceptionIsUsedInCatchClause() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList("catch",
+    public void throwExceptionIfNonDefaultExceptionIsUsedInCatchClause() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(UnsupportedExceptionInCatchClause.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList("catch",
                 RuntimeException.class.getCanonicalName(),
                 Exception.class.getCanonicalName())));
-        new Compiler().compile(UnsupportedExceptionInCatchClause.class.getName());
     }
 
     @Test
-    public void throwExceptionIfExceptionWithMoreThanOneArgumentIsUsed() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContains("You provided 2 arguments."));
-        new Compiler().compile(UnsupportedNumberOfExceptionArguments.class.getName());
+    public void throwExceptionIfExceptionWithMoreThanOneArgumentIsUsed() {
+        assertThrows("You provided 2 arguments.", CompilerException.class,
+                () -> new Compiler().compile(UnsupportedNumberOfExceptionArguments.class.getName()));
     }
 
     @Test
-    public void throwExceptionIfExceptionWithANonStringArgumentIsUsed() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContains("You provided a non-string argument."));
-        new Compiler().compile(UnsupportedExceptionArgument.class.getName());
+    public void throwExceptionIfExceptionWithANonStringArgumentIsUsed() {
+        assertThrows("You provided a non-string argument.", CompilerException.class,
+                () -> new Compiler().compile(UnsupportedExceptionArgument.class.getName())
+        );
     }
 
     @Test
-    public void throwExceptionIfTwoEventsAreGivenTheSameName() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList("Two events", "transfer")));
-        new Compiler().compile(DuplicateUseOfEventDisplayName.class.getName());
+    public void throwExceptionIfTwoEventsAreGivenTheSameName() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(DuplicateUseOfEventDisplayName.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList("Two events", "transfer")));
     }
 
     @Test
-    public void throwExceptionIfContractInterfaceClassHasInvalidScriptHash() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList("Script hash", "8",
-                "CustomContractInterface")));
-        new Compiler().compile(InvalidScriptHashContractInterfaceContract.class.getName());
+    public void throwExceptionIfContractInterfaceClassHasInvalidScriptHash() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(InvalidScriptHashContractInterfaceContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList("Script hash", "8", "CustomContractInterface")));
     }
 
     @Test
@@ -88,10 +88,11 @@ public class CompilerExceptionsTest {
         MethodNode method = asmClass.methods.get(1);
         NeoMethod neoMethod = new NeoMethod(method, asmClass);
 
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(
-                new StringContainsInOrder(asList("223344", "3", OpCode.PUSHINT16.name(), "2")));
-        Compiler.processInstructionAnnotations(method, neoMethod);
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> Compiler.processInstructionAnnotations(method, neoMethod)
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList("223344", "3", OpCode.PUSHINT16.name(), "2")));
     }
 
     @Test
@@ -103,10 +104,11 @@ public class CompilerExceptionsTest {
         MethodNode method = asmClass.methods.get(1);
         NeoMethod neoMethod = new NeoMethod(method, asmClass);
 
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> Compiler.processInstructionAnnotations(method, neoMethod)
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList(OpCode.PUSHDATA1.name(), "needs an operand prefix of size", "1", "2")));
-        Compiler.processInstructionAnnotations(method, neoMethod);
     }
 
     @Test
@@ -120,9 +122,10 @@ public class CompilerExceptionsTest {
         MethodNode method = asmClass.methods.get(1);
         NeoMethod neoMethod = new NeoMethod(method, asmClass);
 
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList("Operand prefix", "1", "2")));
-        Compiler.processInstructionAnnotations(method, neoMethod);
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> Compiler.processInstructionAnnotations(method, neoMethod)
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList("Operand prefix", "1", "2")));
     }
 
     @Test
@@ -134,145 +137,159 @@ public class CompilerExceptionsTest {
         MethodNode method = asmClass.methods.get(1);
         NeoMethod neoMethod = new NeoMethod(method, asmClass);
 
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> Compiler.processInstructionAnnotations(method, neoMethod)
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList("1122", OpCode.ASSERT.name(), "doesn't take any operands.")));
-        Compiler.processInstructionAnnotations(method, neoMethod);
     }
 
     @Test
-    public void testNonPublicMethodsMarkedWithSafeAnnotation() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void testNonPublicMethodsMarkedWithSafeAnnotation() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(PrivateMethodMarkedAsSafe.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 this.getClass().getSimpleName() + ".java", // the file name
                 "privateMethod", "safe")));
-        new Compiler().compile(PrivateMethodMarkedAsSafe.class.getName());
 
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+        thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(ProtectedMethodMarkedAsSafe.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 this.getClass().getSimpleName() + ".java", // the file name
                 "protectedMethod", "safe")));
-        new Compiler().compile(ProtectedMethodMarkedAsSafe.class.getName());
 
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+        thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(PackagePrivateMethodMarkedAsSafe.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 this.getClass().getSimpleName() + ".java", // the file name
                 "packagePrivateMethod", "safe")));
     }
 
     @Test
-    public void failIfLocalVariablesAreUsedInStaticConstructor() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void failIfLocalVariablesAreUsedInStaticConstructor() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(LocalVariableInStaticConstructorContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 CompilerExceptionsTest.class.getSimpleName(),
                 "Local variables are not supported in the static constructor")));
-        new Compiler().compile(LocalVariableInStaticConstructorContract.class.getName());
     }
 
     @Test
-    public void failIfInstanceOfIsUsedOnUnsupportedType() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void failIfInstanceOfIsUsedOnUnsupportedType() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(InstanceOfContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 Hash160.class.getName(), "is not supported for the instanceof operation.")));
-        new Compiler().compile(InstanceOfContract.class.getName());
     }
 
     @Test
-    public void failCallingAContractInterfaceWithoutContractHashAnnotation() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList("Contract interface",
+    public void failCallingAContractInterfaceWithoutContractHashAnnotation() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(ContractInterfaceWithoutHash.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList("Contract interface",
                 FungibleToken.class.getSimpleName(),
                 "needs to be annotated with the 'ContractHash' annotation to be usable.")));
-        new Compiler().compile(ContractInterfaceWithoutHash.class.getName());
     }
 
     @Test
-    public void failCallingAContractInterfaceWithoutContractHashAnnotationAndMultipleInheritance()
-            throws IOException {
-
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList("Contract interface",
+    public void failCallingAContractInterfaceWithoutContractHashAnnotationAndMultipleInheritance() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(ContractInterfaceWithoutHashAndMultipleInheritance.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList("Contract interface",
                 CustomFungibleToken.class.getSimpleName(),
                 "needs to be annotated with the 'ContractHash' annotation to be usable.")));
-        new Compiler().compile(ContractInterfaceWithoutHashAndMultipleInheritance.class.getName());
     }
 
     @Test
-    public void failUsingConstructorOnAnEvent() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContains("Events must not be initialized by " +
-                "calling their constructor."));
-        new Compiler().compile(EventConstructorMisuse.class.getName());
+    public void failUsingConstructorOnAnEvent() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(EventConstructorMisuse.class.getName())
+        );
+        assertThat(thrown.getMessage(), containsString("Events must not be initialized by calling" +
+                " their constructor."));
     }
 
     @Test
-    public void throwOnTokenContractInterfaceMissingHashAnnotation() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void throwOnTokenContractInterfaceMissingHashAnnotation() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(TokenContractMissingHashAnnotation.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 TokenContractWithoutHashAnnotation.class.getSimpleName(),
                 ContractHash.class.getSimpleName())));
-        new Compiler().compile(TokenContractMissingHashAnnotation.class.getName());
     }
 
     @Test
-    public void throwOnContractInterfaceMissingHashAnnotation() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void throwOnContractInterfaceMissingHashAnnotation() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(ContractMissingHashAnnotation.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 ContractWithoutHashAnnotation.class.getSimpleName(),
                 ContractHash.class.getSimpleName())));
-        new Compiler().compile(ContractMissingHashAnnotation.class.getName());
     }
 
     @Test
-    public void throwOnContractMissingContractInterface() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void throwOnContractMissingContractInterface() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(ContractMissingContractInterface.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 ContractWithoutContractInterface.class.getSimpleName(),
                 ContractHash.class.getSimpleName(), ContractInterface.class.getSimpleName())));
-        new Compiler().compile(ContractMissingContractInterface.class.getName());
     }
 
     @Test
-    public void throwOnWrongClassCompatibility() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
-                ContractWithWrongClassCompatibility.class.getSimpleName(), "51",
-                Integer.toString(CLASS_VERSION_SUPPORTED))));
+    public void throwOnWrongClassCompatibility() {
         ClassNode c = new ClassNode();
         c.name = ContractWithWrongClassCompatibility.class.getSimpleName();
         c.version = 51;
-        new Compiler().compile(c);
+
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(c)
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
+                ContractWithWrongClassCompatibility.class.getSimpleName(), "51",
+                Integer.toString(CLASS_VERSION_SUPPORTED))));
     }
 
     @Test
-    public void throwOnStaticVariableInNonContractClass() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContains(
-                "Static variables are not allowed outside the main contract class"));
-        new Compiler().compile(ContractClassWithReferenceToStaticVariable.class.getName());
+    public void throwOnStaticVariableInNonContractClass() {
+        CompilerException thrown = assertThrows(
+                "Static variables are not allowed outside the main contract class",
+                CompilerException.class,
+                () -> new Compiler().compile(ContractClassWithReferenceToStaticVariable.class.getName())
+        );
     }
 
     @Test
-    public void throwOnEventDeclarationInNonContractClass() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContains(
-                "Couldn't find triggered event in list of events"));
-        new Compiler().compile(ContractClassWithReferenceToEventInOtherClass.class.getName());
+    public void throwOnEventDeclarationInNonContractClass() {
+        assertThrows("Couldn't find triggered event in list of events", CompilerException.class,
+                () -> new Compiler().compile(ContractClassWithReferenceToEventInOtherClass.class.getName())
+        );
     }
 
     @Test
-    public void throwOnEventFiredInVerifyMethod() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("The verify method is not allowed to fire any event.");
-        new Compiler().compile(VerificationWithEvent.class.getName());
+    public void throwOnEventFiredInVerifyMethod() {
+        assertThrows("The verify method is not allowed to fire any event.",
+                CompilerException.class,
+                () -> new Compiler().compile(VerificationWithEvent.class.getName())
+        );
     }
 
     @Test
-    public void multiDimensionalArraySize() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("Only the first dimension of a multi-dimensional array " +
-                "declaration can be defined");
-        new Compiler().compile(MultiDimensionalArraySize.class.getName());
+    public void multiDimensionalArraySize() {
+        assertThrows("Only the first dimension of a multi-dimensional array " +
+                        "declaration can be defined", CompilerException.class,
+                () -> new Compiler().compile(MultiDimensionalArraySize.class.getName())
+        );
     }
 
     static class UnsupportedInheritanceInConstructor {
@@ -342,8 +359,8 @@ public class CompilerExceptionsTest {
 
         @ContractHash("8")
         static class CustomContractInterface extends ContractInterface {
-
         }
+
     }
 
     static class InstructionAnnotationWithWrongSizeOperandContract {
@@ -437,7 +454,6 @@ public class CompilerExceptionsTest {
     }
 
     static class CustomFungibleToken extends FungibleToken {
-
     }
 
     static class EventConstructorMisuse {
@@ -489,7 +505,6 @@ public class CompilerExceptionsTest {
         public static void method() {
             StorageContext storageContext = NonContractClassWithStaticVariable.ctx.asReadOnly();
         }
-
     }
 
     static class NonContractClassWithStaticVariable {
@@ -501,7 +516,6 @@ public class CompilerExceptionsTest {
         public static void method() {
             NonContractClassWithEventDeclaration.event.fire("Hello, world!");
         }
-
     }
 
     static class NonContractClassWithEventDeclaration {

--- a/compiler/src/test/java/io/neow3j/compiler/DeploymentMethodTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/DeploymentMethodTest.java
@@ -4,25 +4,23 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThrows;
 
 import io.neow3j.devpack.annotations.OnDeployment;
 import io.neow3j.devpack.annotations.OnVerification;
 import io.neow3j.types.ContractParameterType;
 import io.neow3j.protocol.core.response.ContractManifest.ContractABI.ContractMethod;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
+
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class DeploymentMethodTest {
 
     private static final String DEPLOY_METHOD_NAME = "_deploy";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void whenUsingTheOnDeploymentAnnotationTheDeployMethodShouldBeInTheContractManifest()
@@ -38,40 +36,43 @@ public class DeploymentMethodTest {
     }
 
     @Test
-    public void throwExceptionWhenDeployMethodHasIllegalSignature() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+    public void throwExceptionWhenDeployMethodHasIllegalSignature() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(DeploymentMethodIllegalReturnTypeTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList("doDeploy", "Object", "boolean", "void")));
-        new Compiler().compile(DeploymentMethodIllegalReturnTypeTestContract.class.getName());
 
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+        thrown = assertThrows(CompilerException.class, () -> new Compiler().compile(
+                DeploymentMethodIllegalParameterTypeTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList("doDeploy", "Object", "boolean", "void")));
-        new Compiler().compile(
-                DeploymentMethodIllegalParameterTypeTestContract.class.getName());
 
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
-                "doDeploy", "Object", "Boolean", "void")));
-        new Compiler().compile(
-                DeploymentMethodMissingParameterTestContract.class.getName());
+        thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(
+                        DeploymentMethodMissingParameterTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
+                "doDeploy", "Object", "boolean", "void")));
     }
 
     @Test
-    public void throwExceptionWhenMultipleDeployMethodsAreUsed() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+    public void throwExceptionWhenMultipleDeployMethodsAreUsed() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(MultipleDeploymentMethodsTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList("multiple methods", DEPLOY_METHOD_NAME)));
-        new Compiler().compile(MultipleDeploymentMethodsTestContract.class.getName());
     }
 
     @Test
-    public void throwExceptionWhenTwoMethodSignatureAnnotationsAreUsedOnTheSameMethod()
-            throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+    public void throwExceptionWhenTwoMethodSignatureAnnotationsAreUsedOnTheSameMethod() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(MultipleMethodSignatureAnnotationsTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList("annotatedMethod", "multiple annotations", "specific method signature")));
-        new Compiler().compile(MultipleMethodSignatureAnnotationsTestContract.class.getName());
     }
 
     static class DeploymentMethodTestContract {
@@ -87,7 +88,6 @@ public class DeploymentMethodTest {
         public static int doDeploy(Object data, boolean update) {
             return 41;
         }
-
     }
 
     static class DeploymentMethodIllegalParameterTypeTestContract {
@@ -95,7 +95,6 @@ public class DeploymentMethodTest {
         @OnDeployment
         public static void doDeploy(Object data, int wrongParam) {
         }
-
     }
 
     static class DeploymentMethodMissingParameterTestContract {
@@ -103,7 +102,6 @@ public class DeploymentMethodTest {
         @OnDeployment
         public static void doDeploy(boolean update) {
         }
-
     }
 
     static class MultipleDeploymentMethodsTestContract {
@@ -115,7 +113,6 @@ public class DeploymentMethodTest {
         @OnDeployment
         public static void doDeploy2(Object data, boolean update) {
         }
-
     }
 
     static class MultipleMethodSignatureAnnotationsTestContract {
@@ -123,7 +120,6 @@ public class DeploymentMethodTest {
         @OnDeployment
         @OnVerification
         public static void annotatedMethod(Object data, boolean update) {
-
         }
     }
 

--- a/compiler/src/test/java/io/neow3j/compiler/InstanceVariablesTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/InstanceVariablesTest.java
@@ -1,34 +1,31 @@
 package io.neow3j.compiler;
 
-import java.io.IOException;
-import java.util.Arrays;
-
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThrows;
 
 public class InstanceVariablesTest {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
-    public void usageOfInstanceInitializerThrowsCompilerException() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(Arrays.asList(
+    public void usageOfInstanceInitializerThrowsCompilerException() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(IllegalUseOfInstanceInitializer.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 IllegalUseOfInstanceInitializer.class.getSimpleName(),
                 "has an explicit instance constructor")));
-        new Compiler().compile(IllegalUseOfInstanceInitializer.class.getName());
     }
 
     @Test
-    public void usageOfInstanceVariablesThrowsCompilerException() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(Arrays.asList(
-                IllegalUseOfInstanceVariables.class.getSimpleName(),
-                "has non-static fields")));
-        new Compiler().compile(IllegalUseOfInstanceVariables.class.getName());
+    public void usageOfInstanceVariablesThrowsCompilerException() {
+        CompilerException thrown = assertThrows(CompilerException.class, () ->
+                new Compiler().compile(IllegalUseOfInstanceVariables.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
+                IllegalUseOfInstanceVariables.class.getSimpleName(), "has non-static fields")));
     }
 
     static class IllegalUseOfInstanceInitializer {

--- a/compiler/src/test/java/io/neow3j/compiler/ObjectInheritanceTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/ObjectInheritanceTest.java
@@ -1,91 +1,97 @@
 package io.neow3j.compiler;
 
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
+import static org.junit.Assert.assertThrows;
 
 public class ObjectInheritanceTest {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
-    public void testHashCode() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'hashCode'");
-        new Compiler().compile(ObjectHashCode.class.getName());
+    public void testHashCode() {
+        assertThrows("are not supported. Implement the method 'hashCode'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectHashCode.class.getName())
+        );
     }
 
     @Test
-    public void testEquals() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'equals'");
-        new Compiler().compile(ObjectEquals.class.getName());
+    public void testEquals() {
+        assertThrows("are not supported. Implement the method 'equals'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectEquals.class.getName())
+        );
     }
 
     @Test
-    public void testToString() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'toString'");
-        new Compiler().compile(ObjectToString.class.getName());
+    public void testToString() {
+        assertThrows("are not supported. Implement the method 'toString'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectToString.class.getName())
+        );
     }
 
     @Test
-    public void testNotify() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'notify'");
-        new Compiler().compile(ObjectNotify.class.getName());
+    public void testNotify() {
+        assertThrows("are not supported. Implement the method 'notify'",
+                CompilerException.class,
+                () ->new Compiler().compile(ObjectNotify.class.getName())
+        );
     }
 
     @Test
-    public void testNotifyAll() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'notifyAll'");
-        new Compiler().compile(ObjectNotifyAll.class.getName());
+    public void testNotifyAll() {
+        assertThrows("are not supported. Implement the method 'notifyAll'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectNotifyAll.class.getName())
+        );
     }
 
     @Test
-    public void testWaitLong() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'wait'");
-        new Compiler().compile(ObjectWaitLong.class.getName());
+    public void testWaitLong() {
+        assertThrows("are not supported. Implement the method 'wait'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectWaitLong.class.getName())
+        );
     }
 
     @Test
-    public void testWaitLongInt() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'wait'");
-        new Compiler().compile(ObjectWaitLongInt.class.getName());
+    public void testWaitLongInt() {
+        assertThrows("are not supported. Implement the method 'wait'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectWaitLongInt.class.getName())
+        );
     }
 
     @Test
-    public void testWaitNoParams() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'wait'");
-        new Compiler().compile(ObjectWaitNoParams.class.getName());
+    public void testWaitNoParams() {
+        assertThrows("are not supported. Implement the method 'wait'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectWaitNoParams.class.getName())
+        );
     }
 
     @Test
-    public void testGetClass() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'getClass'");
-        new Compiler().compile(ObjectGetClass.class.getName());
+    public void testGetClass() {
+        assertThrows("are not supported. Implement the method 'getClass'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectGetClass.class.getName())
+        );
     }
 
     @Test
-    public void testClone() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'clone'");
-        new Compiler().compile(ObjectClone.class.getName());
+    public void testClone() {
+        assertThrows("are not supported. Implement the method 'clone'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectClone.class.getName())
+        );
     }
 
     @Test
-    public void testFinalize() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("are not supported. Implement the method 'finalize'");
-        new Compiler().compile(ObjectFinalize.class.getName());
+    public void testFinalize() {
+        assertThrows("are not supported. Implement the method 'finalize'",
+                CompilerException.class,
+                () -> new Compiler().compile(ObjectFinalize.class.getName())
+        );
     }
 
     public static class TestClass {

--- a/compiler/src/test/java/io/neow3j/compiler/OnNEP11PaymentMethodTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/OnNEP11PaymentMethodTest.java
@@ -4,6 +4,8 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThrows;
 
 import io.neow3j.devpack.ByteString;
 import io.neow3j.types.ContractParameter;
@@ -16,17 +18,11 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class OnNEP11PaymentMethodTest {
 
     private final static String ONNEP11PAYMENT_METHOD_NAME = "onNEP11Payment";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void whenUsingTheOnNEP11PaymentAnnotationTheCorrectMethodNameShouldAppearInTheManifest()
@@ -47,33 +43,37 @@ public class OnNEP11PaymentMethodTest {
     }
 
     @Test
-    public void OnNep11PaymentMethodIllegalReturnType() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void OnNep11PaymentMethodIllegalReturnType() {
+        CompilerException thrown = assertThrows(CompilerException.class, () ->
+                new Compiler().compile(
+                        OnNep11PaymentMethodIllegalReturnTypeTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 "onPayment", "required to have", Hash160.class.getName(),
                 int.class.getName(), ByteString.class.getName(), Object.class.getName(),
                 void.class.getName())));
-        new Compiler().compile(
-                OnNep11PaymentMethodIllegalReturnTypeTestContract.class.getName());
     }
 
     @Test
-    public void OnNep11PaymentMethodIllegalParameters() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void OnNep11PaymentMethodIllegalParameters() {
+        CompilerException thrown = assertThrows(CompilerException.class, () ->
+                new Compiler().compile(
+                        OnNep11PaymentMethodIllegalParametersTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 "onPayment", "required to have", Hash160.class.getName(),
                 int.class.getName(), ByteString.class.getName(), Object.class.getName(),
                 void.class.getName())));
-        new Compiler().compile(
-                OnNep11PaymentMethodIllegalParametersTestContract.class.getName());
     }
 
     @Test
-    public void throwExceptionWhenMultipleMethodsAreUsed() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                asList("multiple methods", ONNEP11PAYMENT_METHOD_NAME)));
-        new Compiler().compile(MultipleOnNep11PaymentMethodsTestContract.class.getName());
+    public void throwExceptionWhenMultipleMethodsAreUsed() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(MultipleOnNep11PaymentMethodsTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList("multiple methods", ONNEP11PAYMENT_METHOD_NAME))
+        );
     }
 
     static class OnNep11PaymentMethodTestContract {

--- a/compiler/src/test/java/io/neow3j/compiler/OnNEP17PaymentMethodTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/OnNEP17PaymentMethodTest.java
@@ -4,26 +4,24 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThrows;
 
 import io.neow3j.types.ContractParameter;
 import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.annotations.OnNEP17Payment;
 import io.neow3j.types.ContractParameterType;
 import io.neow3j.protocol.core.response.ContractManifest.ContractABI.ContractMethod;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
+
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class OnNEP17PaymentMethodTest {
 
     private final static String ONNEP17PAYMENT_METHOD_NAME = "onNEP17Payment";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void whenUsingTheOnNEP17PaymentAnnotationTheCorrectMethodNameShouldAppearInTheManifest()
@@ -44,31 +42,35 @@ public class OnNEP17PaymentMethodTest {
     }
 
     @Test
-    public void OnNep11PaymentMethodIllegalReturnType() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void OnNep11PaymentMethodIllegalReturnType() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(
+                        OnNep17PaymentMethodIllegalReturnTypeTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 "onPayment", "required to have", Hash160.class.getName(), int.class.getName(),
                 Object.class.getName(), void.class.getName())));
-        new Compiler().compile(
-                OnNep17PaymentMethodIllegalReturnTypeTestContract.class.getName());
     }
 
     @Test
     public void OnNep17PaymentMethodIllegalParameters() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(
+                        OnNep17PaymentMethodIllegalParametersTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 "onPayment", "required to have", Hash160.class.getName(), int.class.getName(),
                 Object.class.getName(), void.class.getName())));
-        new Compiler().compile(
-                OnNep17PaymentMethodIllegalParametersTestContract.class.getName());
     }
 
     @Test
     public void throwExceptionWhenMultipleMethodsAreUsed() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                asList("multiple methods", ONNEP17PAYMENT_METHOD_NAME)));
-        new Compiler().compile(MultipleOnNep17PaymentMethodsTestContract.class.getName());
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(
+                        MultipleOnNep17PaymentMethodsTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(),
+                stringContainsInOrder(asList("multiple methods", ONNEP17PAYMENT_METHOD_NAME)));
     }
 
     static class OnNep17PaymentMethodTestContract {
@@ -76,6 +78,7 @@ public class OnNEP17PaymentMethodTest {
         @OnNEP17Payment
         public static void onPayment(Hash160 hash, int i, Object data) {
         }
+
     }
 
     static class OnNep17PaymentMethodIllegalReturnTypeTestContract {
@@ -99,7 +102,6 @@ public class OnNEP17PaymentMethodTest {
 
         @OnNEP17Payment
         public static void onPayment1(Hash160 hash, int i, Object data) {
-
         }
 
         @OnNEP17Payment
@@ -107,4 +109,5 @@ public class OnNEP17PaymentMethodTest {
         }
 
     }
+
 }

--- a/compiler/src/test/java/io/neow3j/compiler/PermissionManifestTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/PermissionManifestTest.java
@@ -7,10 +7,7 @@ import io.neow3j.devpack.constants.NativeContract;
 import io.neow3j.protocol.ObjectMapperFactory;
 import io.neow3j.protocol.core.response.ContractManifest.ContractPermission;
 import io.neow3j.types.Hash160;
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.List;
@@ -19,7 +16,9 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 
 public class PermissionManifestTest {
 
@@ -29,9 +28,6 @@ public class PermissionManifestTest {
     private static final String CONTRACT_METHOD_1 = "method1";
     private static final String CONTRACT_METHOD_2 = "method2";
     private static final String CONTRACT_HASH_2 = "0xd6c712eb53b1a130f59fd4e5864bdac27458a509";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void withPermissionsAnnotation() throws IOException {
@@ -115,12 +111,13 @@ public class PermissionManifestTest {
     }
 
     @Test
-    public void withPermissionsAnnotationButNotValidContract() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void withPermissionsAnnotationButNotValidContract() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(
+                        PermissionManifestTestContractWithNotValidContractHashNorGroupKey.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 "Invalid contract hash or public key:", "invalidContractHashOrPubKey")));
-        new Compiler().compile(
-                PermissionManifestTestContractWithNotValidContractHashNorGroupKey.class.getName());
     }
 
     @Test
@@ -134,29 +131,27 @@ public class PermissionManifestTest {
     }
 
     @Test
-    public void withBothContractAndNativeContract() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("must either have the attribute 'contract' or " +
-                "'nativeContract' set but not both");
-        new Compiler().compile(
-                PermissionManifestTestContractWithContractAndNativeContract.class.getName());
+    public void withBothContractAndNativeContract() {
+        assertThrows("must either have the attribute 'contract' or 'nativeContract' set but not " +
+                "both", CompilerException.class, () -> new Compiler().compile(
+                PermissionManifestTestContractWithContractAndNativeContract.class.getName())
+        );
     }
 
     @Test
-    public void withoutBothContractAndNativeContract() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("must either have the attribute 'contract' or " +
-                "'nativeContract' set but not both");
-        new Compiler().compile(
-                PermissionManifestTestContractWithoutContract.class.getName());
+    public void withoutBothContractAndNativeContract() {
+        assertThrows("must either have the attribute 'contract' or 'nativeContract' set but not " +
+                "both", CompilerException.class, () -> new Compiler().compile(
+                PermissionManifestTestContractWithoutContract.class.getName())
+        );
     }
 
     @Test
-    public void withNoneNativeContractValue() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("The provided native contract does not exist.");
-        new Compiler().compile(
-                PermissionManifestTestContractWithNoneNativeContractValue.class.getName());
+    public void withNoneNativeContractValue() {
+        assertThrows("The provided native contract does not exist.", CompilerException.class,
+                () -> new Compiler().compile(
+                        PermissionManifestTestContractWithNoneNativeContractValue.class.getName())
+        );
     }
 
     @Test
@@ -167,9 +162,10 @@ public class PermissionManifestTest {
 
     @Test
     public void invalidNativeContract() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("There exists no native contract with ");
-        NativeContract.valueOf(new Hash160("6a3828e0378f9f331c69476f016fe91f5bba8dbd"));
+        assertThrows("There exists no native contract with ", IllegalArgumentException.class,
+                () -> NativeContract.valueOf(
+                        new Hash160("6a3828e0378f9f331c69476f016fe91f5bba8dbd"))
+        );
     }
 
     @Permission(contract = CONTRACT_HASH_1)

--- a/compiler/src/test/java/io/neow3j/compiler/StringLiteralHelperTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/StringLiteralHelperTest.java
@@ -4,50 +4,49 @@ import io.neow3j.devpack.ByteString;
 import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.StringLiteralHelper;
 import io.neow3j.devpack.Runtime;
-
-import java.io.IOException;
-import java.util.Arrays;
-
-import org.hamcrest.core.StringContains;
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
+
+import static java.util.Arrays.asList;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThrows;
 
 public class StringLiteralHelperTest {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
-    public void invalidAddressStringLiteralThrowsCompilerExceptions() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                Arrays.asList("Invalid address", "A0unErzotcQTNWP2qktA7LgkXZVdHea97H")));
-        new Compiler().compile(InvalidAddressVariable.class.getName());
+    public void invalidAddressStringLiteralThrowsCompilerExceptions() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(InvalidAddressVariable.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList("Invalid address", "A0unErzotcQTNWP2qktA7LgkXZVdHea97H")));
     }
 
     @Test
-    public void invalidHexStringLiteralThrowsCompilerExceptions() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                Arrays.asList("Invalid hex string", "0x0h02")));
-        new Compiler().compile(InvalidHexStringVariable.class.getName());
+    public void invalidHexStringLiteralThrowsCompilerExceptions() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(InvalidHexStringVariable.class.getName())
+        );
+        assertThat(thrown.getMessage(),
+                stringContainsInOrder(asList("Invalid hex string", "0x0h02")));
     }
 
     @Test
-    public void invalidIntegerStringLiteralThrowsCompilerExceptions() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                Arrays.asList("Invalid number string", "100e0000000000000000000000000000")));
-        new Compiler().compile(InvalidIntStringVariable.class.getName());
+    public void invalidIntegerStringLiteralThrowsCompilerExceptions() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(InvalidIntStringVariable.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList("Invalid number string", "100e0000000000000000000000000000")));
     }
 
     @Test
-    public void illegalInputToConverterMethodLeadsToCompilerException() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContains("constant string literals"));
-        new Compiler().compile(IllegalInputConverterMethod.class.getName());
+    public void illegalInputToConverterMethodLeadsToCompilerException() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(IllegalInputConverterMethod.class.getName())
+        );
+        assertThat(thrown.getMessage(), containsString("constant string literals"));
     }
 
     static class InvalidAddressVariable {
@@ -58,6 +57,7 @@ public class StringLiteralHelperTest {
         public static Hash160 main() {
             return scriptHash;
         }
+
     }
 
     static class InvalidHexStringVariable {
@@ -67,6 +67,7 @@ public class StringLiteralHelperTest {
         public static ByteString main() {
             return bytes;
         }
+
     }
 
     static class InvalidIntStringVariable {
@@ -77,6 +78,7 @@ public class StringLiteralHelperTest {
         public static int main() {
             return integer;
         }
+
     }
 
     static class IllegalInputConverterMethod {
@@ -91,4 +93,3 @@ public class StringLiteralHelperTest {
     }
 
 }
-

--- a/compiler/src/test/java/io/neow3j/compiler/TrustManifestTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/TrustManifestTest.java
@@ -5,17 +5,17 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThrows;
 
 import io.neow3j.devpack.annotations.Trust;
 import io.neow3j.devpack.annotations.Trust.Trusts;
+
 import java.io.IOException;
 import java.util.List;
 
 import io.neow3j.devpack.constants.NativeContract;
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class TrustManifestTest {
 
@@ -23,9 +23,6 @@ public class TrustManifestTest {
     private static final String GROUP_PUBKEY_1 =
             "02163946a133e3d2e0d987fb90cb01b060ed1780f1718e2da28edf13b965fd2b60";
     private static final String CONTRACT_HASH_2 = "0xd6c712eb53b1a130f59fd4e5864bdac27458a509";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void withTrustsAnnotation() throws IOException {
@@ -63,13 +60,15 @@ public class TrustManifestTest {
     }
 
     @Test
-    public void withTrustsAnnotationButNotValidContracHashNorGroupPubKey() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void withTrustsAnnotationButNotValidContracHashNorGroupPubKey() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler()
+                        .compile(TrustManifestTestContractWithNotValidContractHashNorGroupKey.class
+                                .getName())
+
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 "Invalid contract hash or public key:", "invalidContractHashOrPubKey")));
-        new Compiler()
-                .compile(TrustManifestTestContractWithNotValidContractHashNorGroupKey.class
-                        .getName());
     }
 
     @Test
@@ -82,29 +81,28 @@ public class TrustManifestTest {
     }
 
     @Test
-    public void withBothContractAndNativeContract() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("must either have the attribute 'contract' or " +
-                "'nativeContract' set but not both");
-        new Compiler().compile(
-                TrustManifestTest.TrustManifestTestContractWithContractAndNativeContract.class.getName());
+    public void withBothContractAndNativeContract() {
+        assertThrows("must either have the attribute 'contract' or 'nativeContract' set but not " +
+                        "both",
+                CompilerException.class, () -> new Compiler().compile(
+                        TrustManifestTest.TrustManifestTestContractWithContractAndNativeContract.class.getName())
+        );
     }
 
     @Test
-    public void withoutBothContractAndNativeContract() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("requires either the attribute 'contract' or " +
-                "'nativeContract' to be set.");
-        new Compiler().compile(
-                TrustManifestTest.TrustManifestTestContractWithoutContract.class.getName());
+    public void withoutBothContractAndNativeContract() {
+        assertThrows("requires either the attribute 'contract' or 'nativeContract' to be set.",
+                CompilerException.class, () -> new Compiler().compile(
+                        TrustManifestTest.TrustManifestTestContractWithoutContract.class.getName())
+        );
     }
 
     @Test
-    public void withNoneNativeContractValue() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage("The provided native contract does not exist.");
-        new Compiler().compile(
-                TrustManifestTest.TrustManifestTestContractWithNoneNativeContractValue.class.getName());
+    public void withNoneNativeContractValue() {
+        assertThrows("The provided native contract does not exist.", CompilerException.class,
+                () -> new Compiler().compile(
+                        TrustManifestTest.TrustManifestTestContractWithNoneNativeContractValue.class.getName())
+        );
     }
 
     @Trust(contract = CONTRACT_HASH_1)

--- a/compiler/src/test/java/io/neow3j/compiler/VerificationMethodTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/VerificationMethodTest.java
@@ -18,7 +18,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.hamcrest.text.StringContainsInOrder;
 import org.junit.Test;
 
 public class VerificationMethodTest {

--- a/compiler/src/test/java/io/neow3j/compiler/VerificationMethodTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/VerificationMethodTest.java
@@ -4,6 +4,8 @@ import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.stringContainsInOrder;
+import static org.junit.Assert.assertThrows;
 
 import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.Runtime;
@@ -11,20 +13,17 @@ import io.neow3j.devpack.StringLiteralHelper;
 import io.neow3j.devpack.annotations.OnVerification;
 import io.neow3j.types.ContractParameterType;
 import io.neow3j.protocol.core.response.ContractManifest.ContractABI.ContractMethod;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
+
 import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class VerificationMethodTest {
 
     private static final String VERIFY_METHOD_NAME = "verify";
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void whenUsingTheOnVerificationAnnotationTheVerifyMethodShouldBeInTheContractManifest()
@@ -40,19 +39,21 @@ public class VerificationMethodTest {
     }
 
     @Test
-    public void throwExceptionWhenVerifyMethodHasIllegalSignature() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(asList(
+    public void throwExceptionWhenVerifyMethodHasIllegalSignature() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(VerificationMethodIllegalSignatureTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(asList(
                 "doVerify", "required to have return type", "boolean")));
-        new Compiler().compile(VerificationMethodIllegalSignatureTestContract.class.getName());
     }
 
     @Test
-    public void throwExceptionWhenMultipleVerifyMethodsAreUsed() throws IOException {
-        exceptionRule.expect(CompilerException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+    public void throwExceptionWhenMultipleVerifyMethodsAreUsed() {
+        CompilerException thrown = assertThrows(CompilerException.class,
+                () -> new Compiler().compile(MultipleVerificationMethodsTestContract.class.getName())
+        );
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList("multiple methods", VERIFY_METHOD_NAME)));
-        new Compiler().compile(MultipleVerificationMethodsTestContract.class.getName());
     }
 
     static class VerificationMethodTestContract {

--- a/contract/src/test/java/io/neow3j/contract/ContractManagementTest.java
+++ b/contract/src/test/java/io/neow3j/contract/ContractManagementTest.java
@@ -1,6 +1,5 @@
 package io.neow3j.contract;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.neow3j.protocol.Neow3j;
@@ -17,7 +16,6 @@ import io.neow3j.wallet.Account;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.IOException;
@@ -41,6 +39,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 
 public class ContractManagementTest {
 
@@ -57,9 +56,6 @@ public class ContractManagementTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -169,30 +165,28 @@ public class ContractManagementTest {
     }
 
     @Test
-    public void deploy_NefNull() throws JsonProcessingException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The NEF file cannot be null.");
-        new ContractManagement(neow3j)
-                .deploy(null, null, null);
+    public void deploy_NefNull() {
+        assertThrows("The NEF file cannot be null.", IllegalArgumentException.class,
+                () -> new ContractManagement(neow3j).deploy(null, null, null)
+        );
     }
 
     @Test
     public void deploy_manifestNull() throws IOException, DeserializationException,
             URISyntaxException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The manifest cannot be null.");
+
         File nefFile = new File(this.getClass().getClassLoader()
                 .getResource(TESTCONTRACT_NEF_FILE.toString()).toURI());
         NefFile nef = NefFile.readFromFile(nefFile);
-        new ContractManagement(neow3j)
-                .deploy(nef, null, null);
+
+        assertThrows("The manifest cannot be null.", IllegalArgumentException.class,
+                () -> new ContractManagement(neow3j).deploy(nef, null, null)
+        );
     }
 
     @Test
     public void deploy_manifestTooLong() throws IOException, URISyntaxException,
             DeserializationException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The given contract manifest is too long.");
 
         File nefFile = new File(this.getClass().getClassLoader()
                 .getResource(TESTCONTRACT_NEF_FILE.toString()).toURI());
@@ -200,7 +194,10 @@ public class ContractManagementTest {
 
         ContractManifest tooBigManifest = getTooBigManifest();
 
-        new ContractManagement(neow3j).deploy(nef, tooBigManifest);
+        assertThrows("The given contract manifest is too long.",
+                IllegalArgumentException.class,
+                () -> new ContractManagement(neow3j).deploy(nef, tooBigManifest)
+        );
     }
 
     // Creates a ContractManifest that is one byte to long for deployment

--- a/contract/src/test/java/io/neow3j/contract/FungibleTokenTest.java
+++ b/contract/src/test/java/io/neow3j/contract/FungibleTokenTest.java
@@ -15,9 +15,7 @@ import io.neow3j.wallet.Wallet;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
-import java.io.IOException;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 
@@ -35,14 +33,12 @@ import static io.neow3j.utils.Numeric.hexStringToByteArray;
 import static java.util.Arrays.asList;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 public class FungibleTokenTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     private FungibleToken neoToken;
     private FungibleToken gasToken;
@@ -107,6 +103,7 @@ public class FungibleTokenTest {
     public void testGetBalanceOfAccount() throws Exception {
         setUpWireMockForBalanceOf(account1.getScriptHash().toString(),
                 "invokefunction_balanceOf_300000000.json");
+
         assertThat(gasToken.getBalanceOf(account1.getScriptHash()),
                 is(new BigInteger("300000000")));
     }
@@ -115,6 +112,7 @@ public class FungibleTokenTest {
     public void testGetBalanceOfAccount_address() throws Exception {
         setUpWireMockForBalanceOf(account1.getScriptHash().toString(),
                 "invokefunction_balanceOf_300000000.json");
+
         assertThat(gasToken.getBalanceOf(account1), is(new BigInteger("300000000")));
     }
 
@@ -122,6 +120,7 @@ public class FungibleTokenTest {
     public void testGetBalanceOfAccount_account() throws Exception {
         setUpWireMockForBalanceOf(account1.getScriptHash().toString(),
                 "invokefunction_balanceOf_300000000.json");
+
         assertThat(gasToken.getBalanceOf(account1), is(new BigInteger("300000000")));
     }
 
@@ -131,15 +130,16 @@ public class FungibleTokenTest {
                 "balanceOf", account1.getScriptHash().toString());
         setUpWireMockForCall("invokefunction", "invokefunction_balanceOf_300000000.json",
                 "balanceOf", account2.getScriptHash().toString());
+
         assertThat(gasToken.getBalanceOf(Wallet.withAccounts(account1, account2)),
                 is(new BigInteger("600000000")));
     }
 
     @Test
-    public void testTransfer_illegalAmountProvided() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("amount must be greater than or equal to 0");
-        neoToken.transfer(account1, RECIPIENT_SCRIPT_HASH, new BigInteger("-2"));
+    public void testTransfer_illegalAmountProvided() {
+        assertThrows("amount must be greater than or equal to 0", IllegalArgumentException.class,
+                () -> neoToken.transfer(account1, RECIPIENT_SCRIPT_HASH, new BigInteger("-2"))
+        );
     }
 
 }

--- a/contract/src/test/java/io/neow3j/contract/NefFileTest.java
+++ b/contract/src/test/java/io/neow3j/contract/NefFileTest.java
@@ -6,10 +6,7 @@ import io.neow3j.serialization.NeoSerializableInterface;
 import io.neow3j.serialization.exceptions.DeserializationException;
 import io.neow3j.types.CallFlags;
 import io.neow3j.types.Hash160;
-import org.hamcrest.core.StringContains;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.File;
 import java.io.IOException;
@@ -29,6 +26,7 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 
 public class NefFileTest {
 
@@ -57,14 +55,11 @@ public class NefFileTest {
                     "totalSupply", 0, true, CallFlags.ALL));
     private static final String TESTCONTRACT_WITH_TOKENS_CHECKSUM = "b559a069";
 
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void newNefFile() {
         byte[] script = hexStringToByteArray(TESTCONTRACT_SCRIPT);
         NefFile nef = new NefFile(TESTCONTRACT_COMPILER, script, null);
+
         assertThat(nef.getCompiler(), is(TESTCONTRACT_COMPILER));
         assertThat(nef.getScript(), is(script));
         assertThat(nef.getMethodTokens(), is(empty()));
@@ -75,6 +70,7 @@ public class NefFileTest {
     public void newNefFileWithMethodTokens() {
         byte[] script = hexStringToByteArray(TESTCONTRACT_WITH_TOKENS_SCRIPT);
         NefFile nef = new NefFile(TESTCONTRACT_COMPILER, script, TESTCONTRACT_METHOD_TOKENS);
+
         assertThat(nef.getCompiler(), is(TESTCONTRACT_COMPILER));
         assertThat(nef.getScript(), is(script));
         assertThat(nef.getMethodTokens(),
@@ -85,11 +81,11 @@ public class NefFileTest {
 
     @Test
     public void failConstructorWithToLongCompilerName() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        NefFile nef = new NefFile(
+        assertThrows(IllegalArgumentException.class, () -> new NefFile(
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", // 65 bytes
                 hexStringToByteArray(TESTCONTRACT_SCRIPT),
-                null);
+                null)
+        );
     }
 
     @Test
@@ -100,17 +96,19 @@ public class NefFileTest {
         File file = new File(Objects.requireNonNull(NefFileTest.class.getClassLoader()
                 .getResource(TESTCONTRACT_FILE)).toURI());
         NefFile nef = NefFile.readFromFile(file);
+
         assertThat(toHexStringNoPrefix(nef.getCheckSum()), is(TESTCONTRACT_CHECKSUM));
         assertThat(nef.getScript(), is(hexStringToByteArray(TESTCONTRACT_SCRIPT)));
     }
 
     @Test
-    public void readFromFileThatIsTooLarge() throws URISyntaxException, DeserializationException,
-            IOException {
+    public void readFromFileThatIsTooLarge() throws URISyntaxException {
         File file = new File(Objects.requireNonNull(NefFileTest.class.getClassLoader()
                 .getResource("contracts/too_large.nef")).toURI());
-        exceptionRule.expect(IllegalArgumentException.class);
-        NefFile.readFromFile(file);
+
+        assertThrows(IllegalArgumentException.class,
+                () -> NefFile.readFromFile(file)
+        );
     }
 
     @Test
@@ -122,6 +120,7 @@ public class NefFileTest {
 
         // deserialize
         NefFile nef = NeoSerializableInterface.from(nefBytes, NefFile.class);
+
         assertThat(nef.getCompiler(), is(TESTCONTRACT_COMPILER));
         assertThat(nef.getScript(),
                 is(hexStringToByteArray(TESTCONTRACT_WITH_TOKENS_SCRIPT)));
@@ -143,6 +142,7 @@ public class NefFileTest {
 
         // deserialize
         NefFile nef = NeoSerializableInterface.from(nefBytes, NefFile.class);
+
         assertThat(nef.getCompiler(), is(TESTCONTRACT_COMPILER));
         assertThat(nef.getScript(),
                 is(hexStringToByteArray(TESTCONTRACT_SCRIPT)));
@@ -155,7 +155,7 @@ public class NefFileTest {
     }
 
     @Test
-    public void deserializeWithWrongMagicNumber() throws DeserializationException {
+    public void deserializeWithWrongMagicNumber() {
         String nef = ""
                 + "00000000"
                 + TESTCONTRACT_COMPILER_HEX
@@ -165,13 +165,14 @@ public class NefFileTest {
                 + TESTCONTRACT_SCRIPT_SIZE + TESTCONTRACT_SCRIPT
                 + TESTCONTRACT_CHECKSUM;
         byte[] nefBytes = hexStringToByteArray(nef);
-        exceptionRule.expect(DeserializationException.class);
-        exceptionRule.expectMessage(new StringContains("magic"));
-        NeoSerializableInterface.from(nefBytes, NefFile.class);
+
+        assertThrows("magic", DeserializationException.class,
+                () -> NeoSerializableInterface.from(nefBytes, NefFile.class)
+        );
     }
 
     @Test
-    public void deserializeWithWrongCheckSum() throws DeserializationException {
+    public void deserializeWithWrongCheckSum() {
         String nef = MAGIC
                 + TESTCONTRACT_COMPILER_HEX
                 + RESERVED_BYTES
@@ -180,13 +181,14 @@ public class NefFileTest {
                 + TESTCONTRACT_SCRIPT_SIZE + TESTCONTRACT_SCRIPT
                 + "00000000";
         byte[] nefBytes = hexStringToByteArray(nef);
-        exceptionRule.expect(DeserializationException.class);
-        exceptionRule.expectMessage(new StringContains("checksum"));
-        NeoSerializableInterface.from(nefBytes, NefFile.class);
+
+        assertThrows("checksum", DeserializationException.class,
+                () -> NeoSerializableInterface.from(nefBytes, NefFile.class)
+        );
     }
 
     @Test
-    public void deserializeWithEmptyScript() throws DeserializationException {
+    public void deserializeWithEmptyScript() {
         String nef = MAGIC
                 + TESTCONTRACT_COMPILER_HEX
                 + RESERVED_BYTES
@@ -195,9 +197,10 @@ public class NefFileTest {
                 + "00" // empty script
                 + TESTCONTRACT_CHECKSUM;
         byte[] nefBytes = hexStringToByteArray(nef);
-        exceptionRule.expect(DeserializationException.class);
-        exceptionRule.expectMessage(new StringContains("Script cannot be empty"));
-        NeoSerializableInterface.from(nefBytes, NefFile.class);
+
+        assertThrows("Script cannot be empty", DeserializationException.class,
+                () -> NeoSerializableInterface.from(nefBytes, NefFile.class)
+        );
     }
 
     @Test
@@ -205,6 +208,7 @@ public class NefFileTest {
         byte[] nefBytes = Files.readAllBytes(Paths.get(NefFileTest.class.getClassLoader()
                 .getResource(TESTCONTRACT_FILE).toURI()));
         NefFile nef = NeoSerializableInterface.from(nefBytes, NefFile.class);
+
         assertThat(nef.getSize(), is(nefBytes.length));
     }
 
@@ -213,6 +217,7 @@ public class NefFileTest {
         byte[] nefBytes = hexStringToByteArray(
                 "4e4546336e656f2d636f72652d76332e3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000700fd411af77b6771cbbae9");
         NefFile nef = NeoSerializableInterface.from(nefBytes, NefFile.class);
+
         assertThat(nef.getCompiler(), is("neo-core-v3.0"));
         assertThat(nef.getScript(), is(hexStringToByteArray("00fd411af77b67")));
         assertThat(nef.getMethodTokens(), is(empty()));
@@ -225,6 +230,7 @@ public class NefFileTest {
                 "4e4546336e656f2d636f72652d76332e3000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000700fd411af77b6771cbbae9");
         ByteStringStackItem stackItem = new ByteStringStackItem(nefBytes);
         NefFile nef = NefFile.readFromStackItem(stackItem);
+
         assertThat(nef.getCompiler(), is("neo-core-v3.0"));
         assertThat(nef.getScript(), is(hexStringToByteArray("00fd411af77b67")));
         assertThat(nef.getMethodTokens(), is(empty()));
@@ -247,7 +253,7 @@ public class NefFileTest {
     }
 
     @Test
-    public void failDeserializationWithTooLongSourceUrl() throws DeserializationException {
+    public void failDeserializationWithTooLongSourceUrl() {
         String nefHex =
                 // beginning of nef
                 "4e4546336e656f2d636f72652d76332e30000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000" +
@@ -257,20 +263,24 @@ public class NefFileTest {
                         "1111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111111" +
                         "186769746875622e636f6d2f6e656f77336a2f6e656f77336a000000000700fd411af77b679cc8d824";
 
-        exceptionRule.expect(DeserializationException.class);
-        exceptionRule.expectMessage(new StringContains("must not be longer than"));
-        NeoSerializableInterface.from(hexStringToByteArray(nefHex), NefFile.class);
+        assertThrows("must not be longer than", DeserializationException.class,
+                () -> NeoSerializableInterface.from(hexStringToByteArray(nefHex), NefFile.class)
+        );
     }
 
     @Test
-    public void failConstructingWithTooLongSourceUrl() throws DeserializationException {
+    public void failConstructingWithTooLongSourceUrl() {
         // 256 bytes string
-        String url = "github.com/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/";
+        String url =
+                "github.com/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j" +
+                        "/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j" +
+                        "/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j/neow3j" +
+                        "/neow3j/neow3j/neow3j/neow3j/neow3j/";
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(new StringContains("must not be longer than"));
-        new NefFile("neo-core-v3.0", hexStringToByteArray("00fd411af77b67"), null,
-                url);
+        assertThrows("must not be longer than", IllegalArgumentException.class,
+                () -> new NefFile("neo-core-v3.0", hexStringToByteArray("00fd411af77b67"), null,
+                        url)
+        );
     }
 
 }

--- a/contract/src/test/java/io/neow3j/contract/NeoNameServiceTest.java
+++ b/contract/src/test/java/io/neow3j/contract/NeoNameServiceTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
@@ -36,15 +37,11 @@ import java.math.BigInteger;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class NeoNameServiceTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     private Account account1;
     private Account account2;
@@ -94,18 +91,21 @@ public class NeoNameServiceTest {
     @Test
     public void getTotalSupply() throws IOException {
         setUpWireMockForInvokeFunction(TOTAL_SUPPLY, "nns_invokefunction_totalSupply.json");
+
         assertThat(nameServiceContract.getTotalSupply(), is(new BigInteger("25001")));
     }
 
     @Test
     public void getSymbol() throws IOException {
         setUpWireMockForInvokeFunction(SYMBOL, "nns_invokefunction_symbol.json");
+
         assertThat(nameServiceContract.getSymbol(), is("NNS"));
     }
 
     @Test
     public void getDecimals() throws IOException {
         setUpWireMockForInvokeFunction(DECIMALS, "nns_invokefunction_decimals.json");
+
         assertThat(nameServiceContract.getDecimals(), is(0));
     }
 
@@ -114,6 +114,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(DECIMALS, "nns_invokefunction_decimals.json");
         setUpWireMockForInvokeFunction(OWNER_OF, "nns_ownerof.json");
+
         assertThat(nameServiceContract.ownerOf("client1.neo"),
                 is(new Hash160(TestProperties.defaultAccountScriptHash())));
     }
@@ -123,6 +124,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(PROPERTIES, "nns_invokefunction_properties.json");
         NameState nameState = nameServiceContract.properties("client1.neo");
+
         assertThat(nameState.getName(), is("client1.neo"));
         assertThat(nameState.getExpiration(), is(1646214292L));
     }
@@ -131,15 +133,17 @@ public class NeoNameServiceTest {
     public void properties_unexpectedReturnType() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(PROPERTIES, "invokefunction_returnInt.json");
-        exceptionRule.expect(UnexpectedReturnTypeException.class);
-        exceptionRule.expectMessage("Integer but expected Map");
-        nameServiceContract.properties("client1.neo");
+
+        assertThrows("Integer but expected Map", UnexpectedReturnTypeException.class,
+                () -> nameServiceContract.properties("client1.neo")
+        );
     }
 
     @Test
     public void balanceOf() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(BALANCE_OF, "nft_balanceof.json");
+
         assertThat(nameServiceContract.balanceOf(account1.getScriptHash()),
                 is(new BigInteger("244")));
     }
@@ -163,9 +167,10 @@ public class NeoNameServiceTest {
 
     @Test
     public void addRoot_checkRegexMatch() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The provided input does not match the required regex.");
-        nameServiceContract.addRoot("invalid.root");
+        assertThrows("The provided input does not match the required regex.",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.addRoot("invalid.root")
+        );
     }
 
     @Test
@@ -188,66 +193,71 @@ public class NeoNameServiceTest {
 
     @Test
     public void setPrice_negative() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The price needs to be");
-        new NeoNameService(nameServiceHash, neow).setPrice(new BigInteger("-1"));
+        assertThrows("The price needs to be", IllegalArgumentException.class,
+                () -> new NeoNameService(nameServiceHash, neow).setPrice(new BigInteger("-1"))
+        );
     }
 
     @Test
     public void setPrice_zero() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The price needs to be");
-        nameServiceContract.setPrice(new BigInteger("0"));
+        assertThrows("The price needs to be", IllegalArgumentException.class,
+                () -> nameServiceContract.setPrice(new BigInteger("0"))
+        );
     }
 
     @Test
     public void setPrice_tooHigh() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The price needs to be");
-        nameServiceContract.setPrice(new BigInteger("1000000000001"));
+        assertThrows("The price needs to be", IllegalArgumentException.class,
+                () -> nameServiceContract.setPrice(new BigInteger("1000000000001"))
+        );
     }
 
     @Test
     public void getPrice() throws IOException {
         setUpWireMockForInvokeFunction(GET_PRICE, "nns_invokefunction_getPrice.json");
+
         assertThat(nameServiceContract.getPrice(), is(new BigInteger("1000000000")));
     }
 
     @Test
     public void isAvailable() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
+
         assertFalse(nameServiceContract.isAvailable("second.neo"));
     }
 
     @Test
     public void isAvailable_rootNotExisting() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "nns_invalidOperation_dueToState.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The root domain 'neow' does not exist");
-        nameServiceContract.isAvailable("client1.neow");
+
+        assertThrows("The root domain 'neow' does not exist", IllegalArgumentException.class,
+                () -> nameServiceContract.isAvailable("client1.neow")
+        );
     }
 
     @Test
-    public void isAvailable_invalidDomainName() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The provided input does not match the required regex.");
-        nameServiceContract.isAvailable("Test.Neo");
+    public void isAvailable_invalidDomainName() {
+        assertThrows("The provided input does not match the required regex.",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.isAvailable("Test.Neo")
+        );
     }
 
     @Test
-    public void isAvailable_invalidDomainName_nameTooLong() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The provided input does not match the required regex.");
-        nameServiceContract.isAvailable(
-                "thistextis63byteslonganditisnotvalidforadomainnametobeusedinneo.neo");
+    public void isAvailable_invalidDomainName_nameTooLong() {
+        assertThrows("The provided input does not match the required regex.",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.isAvailable(
+                        "thistextis63byteslonganditisnotvalidforadomainnametobeusedinneo.neo")
+        );
     }
 
     @Test
-    public void isAvailable_invalidDomainName_moreThanTwoLevels() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Only second-level domain names are allowed to be " +
-                "registered");
-        nameServiceContract.isAvailable("third.second.first");
+    public void isAvailable_invalidDomainName_moreThanTwoLevels() {
+        assertThrows("Only second-level domain names are allowed to be registered",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.isAvailable("third.second.first")
+        );
     }
 
     @Test
@@ -263,15 +273,18 @@ public class NeoNameServiceTest {
 
         TransactionBuilder b = nameServiceContract
                 .register("client1.neo", account1.getScriptHash());
+
         assertThat(b.getScript(), is(expectedScript));
     }
 
     @Test
     public void register_domainNotAvailable() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The domain name 'client1.neo' is already taken.");
-        nameServiceContract.register("client1.neo", account2.getScriptHash());
+
+        assertThrows("The domain name 'client1.neo' is already taken.",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.register("client1.neo", account2.getScriptHash())
+        );
     }
 
     @Test
@@ -285,6 +298,7 @@ public class NeoNameServiceTest {
                 .toArray();
 
         TransactionBuilder b = nameServiceContract.renew("client1.neo");
+
         assertThat(b.getScript(), is(expectedScript));
     }
 
@@ -301,6 +315,7 @@ public class NeoNameServiceTest {
 
         TransactionBuilder b = nameServiceContract
                 .setAdmin("client1.neo", account2.getScriptHash());
+
         assertThat(b.getScript(), is(expectedScript));
     }
 
@@ -317,15 +332,17 @@ public class NeoNameServiceTest {
 
         TransactionBuilder b = nameServiceContract
                 .setRecord("client1.neo", RecordType.A, "127.0.0.1");
+
         assertThat(b.getScript(), is(expectedScript));
     }
 
     @Test
     public void setRecord_typeA_invalidType() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("input does not match the required regex.");
-        nameServiceContract.setRecord("client1.neo", RecordType.A, "notipv4");
+
+        assertThrows("input does not match the required regex.", IllegalArgumentException.class,
+                () -> nameServiceContract.setRecord("client1.neo", RecordType.A, "notipv4")
+        );
     }
 
     @Test
@@ -375,15 +392,18 @@ public class NeoNameServiceTest {
 
         TransactionBuilder b = nameServiceContract
                 .setRecord("client1.neo", RecordType.CNAME, "firstlevel.client1.neo");
+
         assertThat(b.getScript(), is(expectedScript));
     }
 
     @Test
     public void setRecord_typeCNAME_invalidType() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("input does not match the required regex.");
-        nameServiceContract.setRecord("client1.neo", RecordType.CNAME, "notcname");
+
+        assertThrows("input does not match the required regex.",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.setRecord("client1.neo", RecordType.CNAME, "notcname")
+        );
     }
 
     @Test
@@ -399,16 +419,19 @@ public class NeoNameServiceTest {
 
         TransactionBuilder b = nameServiceContract
                 .setRecord("client1.neo", RecordType.TXT, "textRecord");
+
         assertThat(b.getScript(), is(expectedScript));
     }
 
     @Test
     public void setRecord_typeTXT_tooLong() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("data is not valid for the record type TXT.");
-        nameServiceContract.setRecord("client1.neo", RecordType.TXT,
-                "thistextisintotal5onebyteslongtoberepeatedfivetimesthistextisintotal5onebyteslongtoberepeatedfivetimesthistextisintotal5onebyteslongtoberepeatedfivetimesthistextisintotal5onebyteslongtoberepeatedfivetimesthistextisintotal5onebyteslongtoberepeatedfivetimesx");
+
+        assertThrows("data is not valid for the record type TXT.",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.setRecord("client1.neo", RecordType.TXT,
+                        "thistextisintotal5onebyteslongtoberepeatedfivetimesthistextisintotal5onebyteslongtoberepeatedfivetimesthistextisintotal5onebyteslongtoberepeatedfivetimesthistextisintotal5onebyteslongtoberepeatedfivetimesthistextisintotal5onebyteslongtoberepeatedfivetimesx")
+        );
     }
 
     @Test
@@ -424,6 +447,7 @@ public class NeoNameServiceTest {
 
         TransactionBuilder b = nameServiceContract
                 .setRecord("client1.neo", RecordType.AAAA, "1234::1234");
+
         assertThat(b.getScript(), is(expectedScript));
     }
 
@@ -465,9 +489,10 @@ public class NeoNameServiceTest {
     @Test
     public void setRecord_typeAAAA_invalidType() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("input does not match the required regex.");
-        nameServiceContract.setRecord("client1.neo", RecordType.AAAA, "12345::2");
+
+        assertThrows("input does not match the required regex.", IllegalArgumentException.class,
+                () -> nameServiceContract.setRecord("client1.neo", RecordType.AAAA, "12345::2")
+        );
     }
 
     @Test
@@ -475,6 +500,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(GET_RECORD, "nns_getRecord_typeA.json");
         String record = nameServiceContract.getRecord("client1.neo", RecordType.A);
+
         assertThat(record, is("127.0.0.1"));
     }
 
@@ -483,6 +509,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(GET_RECORD, "nns_getRecord_typeCNAME.json");
         String record = nameServiceContract.getRecord("client1.neo", RecordType.CNAME);
+
         assertThat(record, is("second.client1.neo"));
     }
 
@@ -491,6 +518,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(GET_RECORD, "nns_getRecord_typeTXT.json");
         String record = nameServiceContract.getRecord("client1.neo", RecordType.TXT);
+
         assertThat(record, is("textRecord"));
     }
 
@@ -499,6 +527,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(GET_RECORD, "nns_getRecord_typeAAAA.json");
         String record = nameServiceContract.getRecord("client1.neo", RecordType.AAAA);
+
         assertThat(record, is("2001:0db8:0000:0000:0000:ff00:0042:8329"));
     }
 
@@ -506,18 +535,21 @@ public class NeoNameServiceTest {
     public void getRecord_noRecord() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(GET_RECORD, "nns_returnAny.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("No record of type AAAA found for the domain name " +
-                "'client1.neo'.");
-        nameServiceContract.getRecord("client1.neo", RecordType.AAAA);
+
+        assertThrows("No record of type AAAA found for the domain name 'client1.neo'.",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.getRecord("client1.neo", RecordType.AAAA)
+        );
     }
 
     @Test
     public void getRecord_noDomainRegistered() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnTrue.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The domain name 'client1.neow' is not registered.");
-        nameServiceContract.getRecord("client1.neow", RecordType.AAAA);
+
+        assertThrows("The domain name 'client1.neow' is not registered.",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.getRecord("client1.neow", RecordType.AAAA)
+        );
     }
 
     @Test
@@ -532,6 +564,7 @@ public class NeoNameServiceTest {
                 .toArray();
 
         TransactionBuilder b = nameServiceContract.deleteRecord("client1.neo", RecordType.TXT);
+
         assertThat(b.getScript(), is(expectedScript));
     }
 
@@ -541,6 +574,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(RESOLVE, "nns_getRecord_typeA.json");
         String record = nameServiceContract.resolve("client1.neo", RecordType.A);
+
         assertThat(record, is("127.0.0.1"));
     }
 
@@ -549,6 +583,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(RESOLVE, "nns_getRecord_typeCNAME.json");
         String record = nameServiceContract.resolve("client1.neo", RecordType.CNAME);
+
         assertThat(record, is("second.client1.neo"));
     }
 
@@ -557,6 +592,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(RESOLVE, "nns_getRecord_typeTXT.json");
         String record = nameServiceContract.resolve("client1.neo", RecordType.TXT);
+
         assertThat(record, is("textRecord"));
     }
 
@@ -565,6 +601,7 @@ public class NeoNameServiceTest {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(RESOLVE, "nns_getRecord_typeAAAA.json");
         String record = nameServiceContract.resolve("client1.neo", RecordType.AAAA);
+
         assertThat(record, is("2001:0db8:0000:0000:0000:ff00:0042:8329"));
     }
 
@@ -572,10 +609,11 @@ public class NeoNameServiceTest {
     public void resolve_noRecord() throws IOException {
         setUpWireMockForInvokeFunction(IS_AVAILABLE, "invokefunction_returnFalse.json");
         setUpWireMockForInvokeFunction(RESOLVE, "nns_returnAny.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("No record of type AAAA found for the domain name " +
-                "'client1.neo'.");
-        nameServiceContract.resolve("client1.neo", RecordType.AAAA);
+
+        assertThrows("No record of type AAAA found for the domain name 'client1.neo'.",
+                IllegalArgumentException.class,
+                () -> nameServiceContract.resolve("client1.neo", RecordType.AAAA)
+        );
     }
 
     @Test
@@ -595,6 +633,7 @@ public class NeoNameServiceTest {
 
         TransactionBuilder b = nameServiceContract
                 .transfer(account1, account2.getScriptHash(), "client1.neo");
+
         assertThat(b.getScript(), is(expectedScript));
     }
 

--- a/contract/src/test/java/io/neow3j/contract/NeoTokenTest.java
+++ b/contract/src/test/java/io/neow3j/contract/NeoTokenTest.java
@@ -16,7 +16,6 @@ import io.neow3j.wallet.Account;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -50,9 +49,6 @@ public class NeoTokenTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     private Account account1;
     private static final String NEOTOKEN_SCRIPTHASH = "ef4073a0f2b305a38ec4050e4d3d28bc40ea63f5";
@@ -193,6 +189,7 @@ public class NeoTokenTest {
         List<ECPublicKey> result = new NeoToken(neow).getCommittee();
         String expKeyHex = "02163946a133e3d2e0d987fb90cb01b060ed1780f1718e2da28edf13b965fd2b60";
         ECPublicKey expKey = new ECPublicKey(hexStringToByteArray(expKeyHex));
+
         assertThat(result, contains(expKey));
     }
 
@@ -213,6 +210,7 @@ public class NeoTokenTest {
         List<ECPublicKey> result = new NeoToken(neow).getNextBlockValidators();
         String expKeyHex = "02163946a133e3d2e0d987fb90cb01b060ed1780f1718e2da28edf13b965fd2b60";
         ECPublicKey expKey = new ECPublicKey(hexStringToByteArray(expKeyHex));
+
         assertThat(result, contains(expKey));
     }
 
@@ -281,6 +279,7 @@ public class NeoTokenTest {
                                 publicKey(pubKey.getEncoded(true))))
                 .toArray();
         byte[] script = new NeoToken(neow).buildVoteScript(account1.getScriptHash(), pubKey);
+
         assertThat(script, is(expectedScript));
     }
 
@@ -291,6 +290,7 @@ public class NeoTokenTest {
                         asList(hash160(account1.getScriptHash()), any(null)))
                 .toArray();
         byte[] script = new NeoToken(neow).buildVoteScript(account1.getScriptHash(), null);
+
         assertThat(script, is(expectedScript));
     }
 
@@ -300,13 +300,12 @@ public class NeoTokenTest {
 
         setUpWireMockForInvokeFunction(GET_GAS_PER_BLOCK, "invokefunction_getGasPerBlock.json");
         int res = new NeoToken(neow).getGasPerBlock().intValue();
+
         assertThat(res, is(500_000));
     }
 
     @Test
-    public void setGasPerBlockProducesCorrectScript()
-            throws IOException {
-
+    public void setGasPerBlockProducesCorrectScript() throws IOException {
         setUpWireMockForCall("invokescript", "invokescript_vote.json");
         setUpWireMockForCall("getblockcount", "getblockcount_1000.json");
 
@@ -328,6 +327,7 @@ public class NeoTokenTest {
 
         setUpWireMockForInvokeFunction(GET_REGISTER_PRICE, "invokefunction_getRegisterPrice.json");
         BigInteger res = new NeoToken(neow).getRegisterPrice();
+
         assertThat(res, is(new BigInteger("100000000000")));
     }
 
@@ -360,11 +360,14 @@ public class NeoTokenTest {
         setUpWireMockForInvokeFunction(GET_ACCOUNT_STATE, "neoToken_getAccountState.json");
         NeoAccountState neoAccountState =
                 new NeoToken(neow).getAccountState(account1.getScriptHash());
+
         assertThat(neoAccountState.getBalance(), is(BigInteger.valueOf(20000)));
         assertThat(neoAccountState.getBalanceHeight(), is(BigInteger.valueOf(259)));
+
         ECPublicKey publicKey =
                 new ECPublicKey(
                         "037279f3a507817251534181116cb38ef30468b25074827db34cbbc6adc8873932");
+
         assertThat(neoAccountState.getPublicKey(), is(publicKey));
     }
 
@@ -373,6 +376,7 @@ public class NeoTokenTest {
         setUpWireMockForInvokeFunction(GET_ACCOUNT_STATE, "neoToken_getAccountState_noVote.json");
         NeoAccountState neoAccountState =
                 new NeoToken(neow).getAccountState(account1.getScriptHash());
+
         assertThat(neoAccountState.getBalance(), is(BigInteger.valueOf(12000)));
         assertThat(neoAccountState.getBalanceHeight(), is(BigInteger.valueOf(820)));
         assertNull(neoAccountState.getPublicKey());
@@ -384,6 +388,7 @@ public class NeoTokenTest {
                 "neoToken_getAccountState_noBalance.json");
         NeoAccountState neoAccountState =
                 new NeoToken(neow).getAccountState(account1.getScriptHash());
+
         assertThat(neoAccountState.getBalance(), is(BigInteger.ZERO));
         assertNull(neoAccountState.getBalanceHeight());
         assertNull(neoAccountState.getPublicKey());
@@ -396,6 +401,8 @@ public class NeoTokenTest {
 
         ECPublicKey pubKey = new ECPublicKey(
                 "02c0b60c995bc092e866f15a37c176bb59b7ebacf069ba94c0ebf561cb8f956238");
+
         assertTrue(new NeoToken(neow).isCandidate(pubKey));
     }
+
 }

--- a/contract/src/test/java/io/neow3j/contract/NeoURITest.java
+++ b/contract/src/test/java/io/neow3j/contract/NeoURITest.java
@@ -13,7 +13,6 @@ import io.neow3j.wallet.Account;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.math.BigDecimal;
@@ -30,6 +29,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isOneOf;
+import static org.junit.Assert.assertThrows;
 
 public class NeoURITest {
 
@@ -53,9 +53,6 @@ public class NeoURITest {
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Before
     public void setUp() {
         // Configuring WireMock to use default host and the dynamic port set in WireMockRule.
@@ -73,62 +70,65 @@ public class NeoURITest {
 
     @Test
     public void fromURI_null() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The provided String is null.");
-        NeoURI.fromURI(null);
+        assertThrows("The provided String is null.", IllegalArgumentException.class,
+                () -> NeoURI.fromURI(null)
+        );
     }
 
     @Test
     public void fromURI_emptyString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("does not conform to the NEP-9 standard");
-        NeoURI.fromURI("");
+        assertThrows("does not conform to the NEP-9 standard", IllegalArgumentException.class,
+                () -> NeoURI.fromURI("")
+        );
     }
 
     @Test
     public void fromURI_invalidScheme() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("does not conform to the NEP-9 standard");
-        NeoURI.fromURI("nao:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj");
+        assertThrows("does not conform to the NEP-9 standard", IllegalArgumentException.class,
+                () -> NeoURI.fromURI("nao:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj")
+        );
     }
 
     @Test
     public void fromURI_invalidQuery() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("uri contains invalid queries.");
-        NeoURI.fromURI("neo:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj?asset==neo");
+        assertThrows("uri contains invalid queries.", IllegalArgumentException.class,
+                () -> NeoURI.fromURI("neo:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj?asset==neo")
+        );
     }
 
     @Test
     public void fromURI_invalidSeparator() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("does not conform to the NEP-9 standard");
-        NeoURI.fromURI("neo-NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj");
+        assertThrows("does not conform to the NEP-9 standard", IllegalArgumentException.class,
+                () -> NeoURI.fromURI("neo-NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj")
+        );
     }
 
     @Test
     public void fromURI_invalidURI_short() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("does not conform to the NEP-9 standard.");
-        NeoURI.fromURI("neo:AK2nJJpJr6o664");
+        assertThrows("does not conform to the NEP-9 standard.", IllegalArgumentException.class,
+                () -> NeoURI.fromURI("neo:AK2nJJpJr6o664")
+        );
     }
 
     @Test
-    public void fromURI_invalidScale_neo() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The Neo token does not support any decimal places.");
-        NeoURI.fromURI("neo:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj?asset=neo&amount=1.1")
-                .neow3j(neow3j)
-                .buildTransferFrom(SENDER_ACCOUNT);
+    public void fromURI_invalidScale_neo() {
+        assertThrows("The Neo token does not support any decimal places.",
+                IllegalArgumentException.class,
+                () -> NeoURI.fromURI("neo:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj?asset=neo&amount=1.1")
+                        .neow3j(neow3j)
+                        .buildTransferFrom(SENDER_ACCOUNT)
+        );
     }
 
     @Test
-    public void fromURI_invalidScale_gas() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The Gas token does not support more than 8 decimal places.");
-        NeoURI.fromURI("neo:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj?asset=gas&amount=0.000000001")
-                .neow3j(neow3j)
-                .buildTransferFrom(SENDER_ACCOUNT);
+    public void fromURI_invalidScale_gas() {
+        assertThrows("The Gas token does not support more than 8 decimal places.",
+                IllegalArgumentException.class,
+                () -> NeoURI.fromURI("neo:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj?asset=gas&amount=0" +
+                                ".000000001")
+                        .neow3j(neow3j)
+                        .buildTransferFrom(SENDER_ACCOUNT)
+        );
     }
 
     @Test
@@ -136,6 +136,7 @@ public class NeoURITest {
         URI uri = NeoURI.fromURI(BEGIN_TX_ASSET_AMOUNT_MULTIPLE_ASSETS_AND_AMOUNTS)
                 .buildURI()
                 .getURI();
+
         assertThat(uri, is(URI.create(BEGIN_TX_ASSET_AMOUNT)));
     }
 
@@ -148,6 +149,7 @@ public class NeoURITest {
                 .to(recipient)
                 .amount(BigDecimal.valueOf(13))
                 .buildURI();
+
         assertThat(neoURI.getURIAsString(), is("neo:NV4fSVvFNHAHtmyCVpQnQ85qXdttUaZkbS?" +
                 "asset=c0338c7be47126b92eae8a67a2ebaedbbdce6ceb&amount=13"));
     }
@@ -155,6 +157,7 @@ public class NeoURITest {
     @Test
     public void fromURI_nonNativeToken() {
         NeoURI neoURI = NeoURI.fromURI(BEGIN_TX_ASSET_NON_NATIVE);
+
         assertThat(neoURI.getToken(), is(new Hash160("b1e8f1ce80c81dc125e7d0e75e5ce3f7f4d4d36c")));
     }
 
@@ -201,15 +204,16 @@ public class NeoURITest {
         NeoURI neoURI = new NeoURI()
                 .to(RECIPIENT)
                 .buildURI();
+
         assertThat("getURI()", neoURI.getURI(), is(URI.create(BEGIN_TX)));
         assertThat("getURIAsString()", neoURI.getURIAsString(), is(BEGIN_TX));
     }
 
     @Test
     public void buildURI_noAddress() {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("Could not create a NEP-9 URI without a recipient address.");
-        new NeoURI().buildURI();
+        assertThrows("Could not create a NEP-9 URI without a recipient address.",
+                IllegalStateException.class, () -> new NeoURI().buildURI()
+        );
     }
 
     @Test
@@ -220,6 +224,7 @@ public class NeoURITest {
                 .buildURI();
 
         String BEGIN_TX_ASSET = "neo:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj?asset=neo";
+
         assertThat("getURI()", neoURI.getURI(), is(URI.create(BEGIN_TX_ASSET)));
         assertThat("getURIAsString()", neoURI.getURIAsString(), is(BEGIN_TX_ASSET));
     }
@@ -232,6 +237,7 @@ public class NeoURITest {
                 .buildURI();
 
         String beginTxAmount = "neo:NZNos2WqTbu5oCgyfss9kUJgBXJqhuYAaj?amount=1";
+
         assertThat("getURI()", neoURI.getURI(), is(URI.create(beginTxAmount)));
         assertThat("getURIAsString()", neoURI.getURIAsString(), is(beginTxAmount));
     }
@@ -312,32 +318,32 @@ public class NeoURITest {
     }
 
     @Test
-    public void buildTransfer_noNeow3j() throws IOException {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("Neow3j instance is not set.");
-        new NeoURI()
-                .to(RECIPIENT)
-                .buildTransferFrom(SENDER_ACCOUNT);
+    public void buildTransfer_noNeow3j() {
+        assertThrows("Neow3j instance is not set.", IllegalStateException.class,
+                () -> new NeoURI()
+                        .to(RECIPIENT)
+                        .buildTransferFrom(SENDER_ACCOUNT)
+        );
     }
 
     @Test
-    public void buildTransfer_noAddress() throws IOException {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("Recipient is not set.");
-        new NeoURI(neow3j)
-                .token(NeoToken.SCRIPT_HASH)
-                .amount(AMOUNT)
-                .buildTransferFrom(SENDER_ACCOUNT);
+    public void buildTransfer_noAddress() {
+        assertThrows("Recipient is not set.", IllegalStateException.class,
+                () -> new NeoURI(neow3j)
+                        .token(NeoToken.SCRIPT_HASH)
+                        .amount(AMOUNT)
+                        .buildTransferFrom(SENDER_ACCOUNT)
+        );
     }
 
     @Test
-    public void buildTransfer_noAmount() throws IOException {
-        exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("Amount is not set.");
-        new NeoURI(neow3j)
-                .token(NeoToken.SCRIPT_HASH)
-                .to(RECIPIENT)
-                .buildTransferFrom(SENDER_ACCOUNT);
+    public void buildTransfer_noAmount() {
+        assertThrows("Amount is not set.", IllegalStateException.class,
+                () -> new NeoURI(neow3j)
+                        .token(NeoToken.SCRIPT_HASH)
+                        .to(RECIPIENT)
+                        .buildTransferFrom(SENDER_ACCOUNT)
+        );
     }
 
     @Test
@@ -345,37 +351,42 @@ public class NeoURITest {
         setUpWireMockForCall("invokefunction", "invokefunction_decimals_nep17.json", "decimals");
         setUpWireMockForCall("invokefunction", "invokefunction_balanceOf_1000000.json",
                 "balanceOf");
+
         TransactionBuilder b = new NeoURI(neow3j)
                 .token("b1e8f1ce80c81dc125e7d0e75e5ce3f7f4d4d36c")
                 .to(RECIPIENT)
                 .amount(AMOUNT)
                 .buildTransferFrom(SENDER_ACCOUNT);
+
         assertThat(b, instanceOf(TransactionBuilder.class));
     }
 
     @Test
     public void buildTransfer_nonNativeAsset_invalidAmountDecimals() throws IOException {
         setUpWireMockForCall("invokefunction", "invokefunction_decimals_nep17.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The token 'b1e8f1ce80c81dc125e7d0e75e5ce3f7f4d4d36c' does " +
-                "not support more than 2 decimal places.");
-        new NeoURI(neow3j)
-                .token("b1e8f1ce80c81dc125e7d0e75e5ce3f7f4d4d36c")
-                .to(RECIPIENT)
-                .amount(new BigDecimal("0.001"))
-                .buildTransferFrom(SENDER_ACCOUNT);
+
+        assertThrows("The token 'b1e8f1ce80c81dc125e7d0e75e5ce3f7f4d4d36c' does not support more " +
+                        "than 2 decimal places.", IllegalArgumentException.class,
+                () -> new NeoURI(neow3j)
+                        .token("b1e8f1ce80c81dc125e7d0e75e5ce3f7f4d4d36c")
+                        .to(RECIPIENT)
+                        .amount(new BigDecimal("0.001"))
+                        .buildTransferFrom(SENDER_ACCOUNT)
+        );
     }
 
     @Test
     public void buildTransfer_nonNativeAsset_badDecimalReturn() throws IOException {
         setUpWireMockForCall("invokefunction", "invokefunction_decimals_nep17_badFormat.json");
-        exceptionRule.expect(UnexpectedReturnTypeException.class);
-        exceptionRule.expectMessage("Got stack item of type Boolean but expected Integer.");
-        new NeoURI(neow3j)
-                .token("b1e8f1ce80c81dc125e7d0e75e5ce3f7f4d4d36c")
-                .to(RECIPIENT)
-                .amount(AMOUNT)
-                .buildTransferFrom(SENDER_ACCOUNT);
+
+        assertThrows("Got stack item of type Boolean but expected Integer.",
+                UnexpectedReturnTypeException.class,
+                () -> new NeoURI(neow3j)
+                        .token("b1e8f1ce80c81dc125e7d0e75e5ce3f7f4d4d36c")
+                        .to(RECIPIENT)
+                        .amount(AMOUNT)
+                        .buildTransferFrom(SENDER_ACCOUNT)
+        );
     }
 
     @Test

--- a/contract/src/test/java/io/neow3j/contract/RoleManagementTest.java
+++ b/contract/src/test/java/io/neow3j/contract/RoleManagementTest.java
@@ -11,6 +11,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThrows;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -29,11 +30,9 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.hamcrest.core.StringContains;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class RoleManagementTest {
 
@@ -45,9 +44,6 @@ public class RoleManagementTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -78,6 +74,7 @@ public class RoleManagementTest {
 
         List<ECPublicKey> list =
                 roleManagement.getDesignatedByRole(Role.STATE_VALIDATOR, BigInteger.TEN);
+
         assertThat(list, contains(account1.getECKeyPair().getPublicKey()));
     }
 
@@ -89,24 +86,24 @@ public class RoleManagementTest {
 
         List<ECPublicKey> list =
                 roleManagement.getDesignatedByRole(Role.ORACLE, new BigInteger("12"));
+
         assertThat(list, hasSize(0));
     }
 
     @Test
-    public void testGetDesignatedByRole_negativeIndex() throws IOException {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(new StringContains("The block index has to be positive."));
-        roleManagement.getDesignatedByRole(Role.ORACLE, new BigInteger("-1"));
+    public void testGetDesignatedByRole_negativeIndex() {
+        assertThrows("The block index has to be positive.", IllegalArgumentException.class,
+                () -> roleManagement.getDesignatedByRole(Role.ORACLE, new BigInteger("-1"))
+        );
     }
 
     @Test
     public void testGetDesignatedByRole_indexTooHigh() throws IOException {
         setUpWireMockForCall("getblockcount", "getblockcount_1000.json");
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(
-                new StringContains("The provided block index (1001) is too high."));
-        roleManagement.getDesignatedByRole(Role.ORACLE, new BigInteger("1001"));
+        assertThrows("The provided block index (1001) is too high.", IllegalArgumentException.class,
+                () -> roleManagement.getDesignatedByRole(Role.ORACLE, new BigInteger("1001"))
+        );
     }
 
     @Test
@@ -135,27 +132,25 @@ public class RoleManagementTest {
         ArrayList<ECPublicKey> pubKeys = new ArrayList<>();
         pubKeys.add(account1.getECKeyPair().getPublicKey());
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(new StringContains("role cannot be null"));
-        roleManagement.designateAsRole(null, pubKeys);
+        assertThrows("role cannot be null", IllegalArgumentException.class,
+                () -> roleManagement.designateAsRole(null, pubKeys)
+        );
     }
 
     @Test
     public void testDesignate_pubKeysNull() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(
-                new StringContains("one public key is required for designation"));
-        roleManagement.designateAsRole(Role.ORACLE, null);
+        assertThrows("one public key is required for designation", IllegalArgumentException.class,
+                () -> roleManagement.designateAsRole(Role.ORACLE, null)
+        );
     }
 
     @Test
     public void testDesignate_pubKeysEmpty() {
         ArrayList<ECPublicKey> pubKeys = new ArrayList<>();
 
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(
-                new StringContains("one public key is required for designation"));
-        roleManagement.designateAsRole(Role.ORACLE, pubKeys);
+        assertThrows("one public key is required for designation", IllegalArgumentException.class,
+                () -> roleManagement.designateAsRole(Role.ORACLE, pubKeys)
+        );
     }
 
     @Test

--- a/contract/src/test/java/io/neow3j/contract/TokenTest.java
+++ b/contract/src/test/java/io/neow3j/contract/TokenTest.java
@@ -4,6 +4,7 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.options
 import static io.neow3j.test.WireMockTestHelper.setUpWireMockForInvokeFunction;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit.WireMockRule;
@@ -18,15 +19,11 @@ import io.neow3j.types.Hash160;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class TokenTest {
 
     @Rule
     public WireMockRule wireMockRule = new WireMockRule(options().dynamicPort());
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     private Token someToken;
     private static final Hash160 SOME_TOKEN_SCRIPT_HASH =
@@ -71,9 +68,10 @@ public class TokenTest {
     @Test
     public void testToFractions_tooHighScale() throws IOException {
         setUpWireMockForInvokeFunction("decimals", "invokefunction_decimals_nep17.json");
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The provided amount has too many decimal points.");
-        someToken.toFractions(new BigDecimal("1.023"));
+        assertThrows("The provided amount has too many decimal points.",
+                IllegalArgumentException.class,
+                () -> someToken.toFractions(new BigDecimal("1.023"))
+        );
     }
 
     @Test

--- a/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
+++ b/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
@@ -10,9 +10,7 @@ import io.neow3j.types.Hash160;
 import io.neow3j.types.Hash256;
 import io.neow3j.wallet.Account;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -42,15 +40,13 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class ContractParameterTest {
 
     private ContractParameter contractParameter;
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -96,10 +92,10 @@ public class ContractParameterTest {
 
     @Test
     public void testByteArrayParamCreationFromInvalidHexString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Argument is not a valid hex number.");
         String value = "value";
-        byteArray(value);
+        assertThrows("Argument is not a valid hex number.", IllegalArgumentException.class,
+                () -> byteArray(value)
+        );
     }
 
     @Test
@@ -154,10 +150,8 @@ public class ContractParameterTest {
 
     @Test
     public void testArrayParamCreationFromObjects_failUnSupportedObject() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage(
-                "provided object could not be casted into a supported contract");
-        array(new Object());
+        assertThrows("provided object could not be casted into a supported contract",
+                IllegalArgumentException.class, () -> array(new Object()));
     }
 
     @Test
@@ -218,31 +212,30 @@ public class ContractParameterTest {
 
     @Test
     public void testSignatureParamCreationFromTooShortString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Signature is expected to have a length of 64 bytes, but " +
-                "had 63.");
         String sig = "d8485d4771e9112cca6ac7e6b75fc52585a2e7ee9a702db4a39dfad0f888ea6c22b6185ceab" +
                 "38d8322b67737a5574d8b63f4e27b0d208f3f9efcdbf56093f2";
-        signature(sig);
+
+        assertThrows("Signature is expected to have a length of 64 bytes, but had 63.",
+                IllegalArgumentException.class, () -> signature(sig));
     }
 
     @Test
     public void testSignatureParamCreationFromTooLongString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Signature is expected to have a length of 64 bytes, but " +
-                "had 65.");
         String sig = "d8485d4771e9112cca6ac7e6b75fc52585a2e7ee9a702db4a39dfad0f888ea6c22b6185ceab" +
                 "38d8322b67737a5574d8b63f4e27b0d208f3f9efcdbf56093f213ff";
-        ContractParameter.signature(sig);
+
+        assertThrows("Signature is expected to have a length of 64 bytes, but had 65.",
+                IllegalArgumentException.class, () -> signature(sig));
     }
 
     @Test
     public void testSignatureParamCreationFromNoHexString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Argument is not a valid hex number.");
         String sig = "d8485d4771e9112cca6ac7e6b75fc52585t2e7ee9a702db4a39dfad0f888ea6c22b6185ceab" +
                 "38d8322b67737a5574d8b63f4e27b0d208f3f9efcdbf56093f213";
-        signature(sig);
+
+        assertThrows("Argument is not a valid hex number.", IllegalArgumentException.class,
+                () -> signature(sig)
+        );
     }
 
     @Test
@@ -300,9 +293,9 @@ public class ContractParameterTest {
 
     @Test
     public void testHash160_null() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The script hash argument must not be null");
-        hash160((Hash160) null);
+        assertThrows("The script hash argument must not be null", IllegalArgumentException.class,
+                () -> hash160((Hash160) null)
+        );
     }
 
     @Test
@@ -335,26 +328,29 @@ public class ContractParameterTest {
 
     @Test
     public void testHash256ParamCreationFromTooShortString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("must be 32 bytes but was 31 bytes.");
         String sig = "576f6f6c6f576f6f6c6f576f6f6c6f576f6f6c6ff6c6f576f6f6c6f576f6f6";
-        hash256(sig);
+
+        assertThrows("must be 32 bytes but was 31 bytes.", IllegalArgumentException.class,
+                () -> hash256(sig)
+        );
     }
 
     @Test
     public void testHash256ParamCreationFromTooLongString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("must be 32 bytes but was 33 bytes.");
         String sig = "576f6f6c6f576f6f6c6f576f6f6c6f576f6f6c6ff6c6f576f6f6c6f576f6f6cfaa";
-        hash256(sig);
+
+        assertThrows("must be 32 bytes but was 33 bytes.", IllegalArgumentException.class,
+                () -> hash256(sig)
+        );
     }
 
     @Test
     public void testHash256ParamCreationFromNoHexString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("is not a valid hex number");
         String sig = "576f6f6c6f576f6f6c6f576f6f6c6f576f6f6c6ff6c6f576f6f6c6f576f6f6cg";
-        hash256(sig);
+
+        assertThrows("is not a valid hex number", IllegalArgumentException.class,
+                () -> hash256(sig)
+        );
     }
 
     @Test
@@ -362,35 +358,39 @@ public class ContractParameterTest {
         byte[] pubKey = hexStringToByteArray(
                 "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816");
         ContractParameter p = publicKey(pubKey);
+
         assertThat((byte[]) p.getValue(), is(pubKey));
         assertEquals(ContractParameterType.PUBLIC_KEY, p.getParamType());
     }
 
     @Test
     public void testPublicKeyParamCreationFromInvalidByteArray() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("must be 33 bytes but was 32 bytes.");
-        // one byte too short
+        // One byte too short
         byte[] pubKey = hexStringToByteArray(
                 "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e1368");
-        publicKey(pubKey);
+
+        assertThrows("must be 33 bytes but was 32 bytes.", IllegalArgumentException.class,
+                () -> publicKey(pubKey)
+        );
     }
 
     @Test
     public void testPublicKeyParamCreationFromHexString() {
         String pubKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
         ContractParameter p = publicKey(pubKey);
+
         assertThat((byte[]) p.getValue(), is(hexStringToByteArray(pubKey)));
         assertEquals(ContractParameterType.PUBLIC_KEY, p.getParamType());
     }
 
     @Test
     public void testPublicKeyParamCreationFromInvalidHexString() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("must be 33 bytes but was 32 bytes.");
-        // one byte too short.
+        // One byte too short.
         String pubKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e1368";
-        publicKey(pubKey);
+
+        assertThrows("must be 33 bytes but was 32 bytes.", IllegalArgumentException.class,
+                () -> publicKey(pubKey)
+        );
     }
 
     @Test
@@ -399,6 +399,7 @@ public class ContractParameterTest {
         map.put(integer(1), string("first"));
         map.put(integer(2), string("second"));
         ContractParameter param = map(map);
+
         assertThat(param.getValue(), is(map));
     }
 
@@ -409,28 +410,29 @@ public class ContractParameterTest {
         map.put("two", 2);
         ContractParameter param = map(map);
         Map<?, ?> value = (Map<?, ?>) param.getValue();
+
         assertThat(value.keySet(), containsInAnyOrder(string("one"), string("two")));
         assertThat(value.values(), containsInAnyOrder(string("first"), integer(2)));
     }
 
     @Test
     public void testMap_invalidKeyType() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("The provided map contains an invalid key.");
-
         HashMap<ContractParameter, ContractParameter> map = new HashMap<>();
         map.put(array(integer(1), string("test")), string("first"));
-        map(map);
+
+        assertThrows("The provided map contains an invalid key.", IllegalArgumentException.class,
+                () -> map(map)
+        );
     }
 
     @Test
     public void testMap_empty() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("At least one map entry is required to create a map " +
-                "contract parameter.");
-
         HashMap<ContractParameter, ContractParameter> map = new HashMap<>();
-        map(map);
+
+        assertThrows("At least one map entry is required to create a map contract parameter.",
+                IllegalArgumentException.class,
+                () -> map(map)
+        );
     }
 
     @Test
@@ -445,7 +447,7 @@ public class ContractParameterTest {
 
     @Test
     public void testEquals() {
-        assertThat(contractParameter.equals("o"), is(false));
+        assertNotEquals("o", contractParameter);
         assertThat(contractParameter.equals(string("value")), is(true));
         assertNotEquals(contractParameter, string("test"));
         assertNotEquals(contractParameter, integer(1));

--- a/core/src/test/java/io/neow3j/contract/Hash160Test.java
+++ b/core/src/test/java/io/neow3j/contract/Hash160Test.java
@@ -7,9 +7,7 @@ import io.neow3j.serialization.BinaryWriter;
 import io.neow3j.serialization.NeoSerializableInterface;
 import io.neow3j.serialization.exceptions.DeserializationException;
 import io.neow3j.types.Hash160;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -27,11 +25,9 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 public class Hash160Test {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void createFromValidHash() {
@@ -44,30 +40,30 @@ public class Hash160Test {
 
     @Test
     public void createFromHashWithOddLength() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("String argument is not hexadecimal.");
-        new Hash160("0x23ba2703c53263e8d6e522dc32203339dcd8eee");
+        assertThrows("String argument is not hexadecimal.", IllegalArgumentException.class,
+                () -> new Hash160("0x23ba2703c53263e8d6e522dc32203339dcd8eee")
+        );
     }
 
     @Test
     public void createFromMalformedHash() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("String argument is not hexadecimal.");
-        new Hash160("g3ba2703c53263e8d6e522dc32203339dcd8eee9");
+        assertThrows("String argument is not hexadecimal.", IllegalArgumentException.class,
+                () -> new Hash160("g3ba2703c53263e8d6e522dc32203339dcd8eee9")
+        );
     }
 
     @Test
     public void createFromTooShortHash() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Hash must be 20 bytes long but was 19 bytes.");
-        new Hash160("23ba2703c53263e8d6e522dc32203339dcd8ee");
+        assertThrows("Hash must be 20 bytes long but was 19 bytes.", IllegalArgumentException.class,
+                () -> new Hash160("23ba2703c53263e8d6e522dc32203339dcd8ee")
+        );
     }
 
     @Test
     public void createFromTooLongHash() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Hash must be 20 bytes long but was 32 bytes.");
-        new Hash160("c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b");
+        assertThrows("Hash must be 20 bytes long but was 32 bytes.", IllegalArgumentException.class,
+                () -> new Hash160("c56f33fc6ecfcd0c225c4ab356fee59390af8560be0e930faebe74a6daff7c9b")
+        );
     }
 
     @Test
@@ -75,6 +71,7 @@ public class Hash160Test {
         Hash160 hash = new Hash160("23ba2703c53263e8d6e522dc32203339dcd8eee9");
         byte[] expected = reverseArray(hexStringToByteArray(
                 "23ba2703c53263e8d6e522dc32203339dcd8eee9"));
+
         assertArrayEquals(expected, hash.toLittleEndianArray());
     }
 
@@ -86,6 +83,7 @@ public class Hash160Test {
         byte[] actual = outStream.toByteArray();
         byte[] expected = reverseArray(hexStringToByteArray(
                 "23ba2703c53263e8d6e522dc32203339dcd8eee9"));
+
         assertArrayEquals(expected, actual);
     }
 
@@ -94,6 +92,7 @@ public class Hash160Test {
         byte[] data = reverseArray(hexStringToByteArray(
                 "23ba2703c53263e8d6e522dc32203339dcd8eee9"));
         Hash160 hash = NeoSerializableInterface.from(data, Hash160.class);
+
         assertThat(hash.toString(), is("23ba2703c53263e8d6e522dc32203339dcd8eee9"));
     }
 
@@ -105,6 +104,7 @@ public class Hash160Test {
         byte[] m2 = hexStringToByteArray("d802a401");
         Hash160 hash1 = Hash160.fromScript(m1);
         Hash160 hash2 = Hash160.fromScript(m2);
+
         assertNotEquals(hash1, hash2);
         assertNotEquals(hash2, hash1);
         assertEquals(hash1, hash1);
@@ -114,14 +114,15 @@ public class Hash160Test {
     public void fromValidAddress() {
         Hash160 hash = Hash160.fromAddress("NLnyLtep7jwyq1qhNPkwXbJpurC4jUT8ke");
         byte[] expectedHash = hexStringToByteArray("09a55874c2da4b86e5d49ff530a1b153eb12c7d6");
+
         assertThat(hash.toLittleEndianArray(), is(expectedHash));
     }
 
     @Test
     public void fromInvalidAddress() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Not a valid NEO address.");
-        Hash160.fromAddress("NLnyLtep7jwyq1qhNPkwXbJpurC4jUT8keas");
+        assertThrows("Not a valid NEO address.", IllegalArgumentException.class,
+                () -> Hash160.fromAddress("NLnyLtep7jwyq1qhNPkwXbJpurC4jUT8keas")
+        );
     }
 
     @Test
@@ -133,8 +134,8 @@ public class Hash160Test {
                 + OpCode.SYSCALL.toString()
                 + InteropService.SYSTEM_CRYPTO_CHECKSIG.getHash()
         );
-
         Hash160 hash = Hash160.fromPublicKey(hexStringToByteArray(key));
+
         assertThat(hash.toLittleEndianArray(), is(sha256AndThenRipemd160(script)));
     }
 
@@ -142,6 +143,7 @@ public class Hash160Test {
     public void fromPublicKeyByteArrays() {
         ECKeyPair.ECPublicKey pubKey = new ECKeyPair.ECPublicKey(defaultAccountPublicKey());
         Hash160 hash = Hash160.fromPublicKeys(asList(pubKey), 1);
+
         assertThat(hash.toString(), is(committeeAccountScriptHash()));
     }
 
@@ -161,6 +163,7 @@ public class Hash160Test {
         final String key = "031ccaaa46df7c494f442698c8c17c09311e3615c2dc042cbd3afeaba60fa40740";
         // Address generated from the above key, with address version 0x35.
         Hash160 sh = Hash160.fromPublicKey(hexStringToByteArray(defaultAccountPublicKey()));
+
         assertThat(sh.toAddress(), is(defaultAccountAddress()));
     }
 
@@ -188,6 +191,7 @@ public class Hash160Test {
     @Test
     public void getSize() {
         Hash160 hash = new Hash160("23ba2703c53263e8d6e522dc32203339dcd8eee9");
+
         assertThat(hash.getSize(), is(20));
     }
 

--- a/core/src/test/java/io/neow3j/contract/Hash256Test.java
+++ b/core/src/test/java/io/neow3j/contract/Hash256Test.java
@@ -7,6 +7,7 @@ import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 
 import io.neow3j.serialization.BinaryWriter;
 import io.neow3j.serialization.NeoSerializableInterface;
@@ -16,14 +17,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 
 import io.neow3j.types.Hash256;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class Hash256Test {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void createFromValidHash() {
@@ -39,30 +35,34 @@ public class Hash256Test {
 
     @Test
     public void createFromInvalidHexhWithOddLength() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("String argument is not hexadecimal.");
-        new Hash256("b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21ae");
+        assertThrows("String argument is not hexadecimal.", IllegalArgumentException.class,
+                () -> new Hash256(
+                        "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21ae")
+        );
     }
 
     @Test
     public void createFromMalformedHash() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("String argument is not hexadecimal.");
-        new Hash256("g804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a");
+        assertThrows("String argument is not hexadecimal.", IllegalArgumentException.class,
+                () -> new Hash256(
+                        "g804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a")
+        );
     }
 
     @Test
     public void createFromHashLessThan256Bits() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Hash must be 32 bytes long but was 31 bytes.");
-        new Hash256("0xb804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a2");
+        assertThrows("Hash must be 32 bytes long but was 31 bytes.", IllegalArgumentException.class,
+                () -> new Hash256(
+                        "0xb804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a2")
+        );
     }
 
     @Test
     public void createFromHashMoreThan256Bits() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Hash must be 32 bytes long but was 33 bytes.");
-        new Hash256("0xb804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a12");
+        assertThrows("Hash must be 32 bytes long but was 33 bytes.", IllegalArgumentException.class,
+                () -> new Hash256(
+                        "0xb804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a12")
+        );
     }
 
     @Test
@@ -70,6 +70,7 @@ public class Hash256Test {
         byte[] b = hexStringToByteArray(
                 "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a");
         Hash256 hash = new Hash256(b);
+
         assertThat(hash.toString(),
                 is("b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
     }
@@ -80,6 +81,7 @@ public class Hash256Test {
                 new Hash256("b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a");
         byte[] expected = reverseArray(hexStringToByteArray(
                 "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
+
         assertArrayEquals(expected, hash.toLittleEndianArray());
     }
 
@@ -92,6 +94,7 @@ public class Hash256Test {
         byte[] actual = outStream.toByteArray();
         byte[] expected = reverseArray(hexStringToByteArray(
                 "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
+
         assertArrayEquals(expected, actual);
     }
 
@@ -100,6 +103,7 @@ public class Hash256Test {
         byte[] data = reverseArray(hexStringToByteArray(
                 "b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
         Hash256 hash = NeoSerializableInterface.from(data, Hash256.class);
+
         assertThat(hash.toString(),
                 is("b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a"));
     }
@@ -118,6 +122,7 @@ public class Hash256Test {
         Hash256 hash2 = new Hash256(bytes2);
         Hash256 hash3 =
                 new Hash256("0xb804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a");
+
         assertNotEquals(hash1, hash2);
         assertNotEquals(hash2, hash1);
         assertEquals(hash1, hash1);
@@ -149,6 +154,7 @@ public class Hash256Test {
     public void getSize() {
         Hash256 hash =
                 new Hash256("b804a98220c69ab4674e97142beeeb00909113d417b9d6a67c12b71a3974a21a");
+
         assertThat(hash.getSize(), is(32));
     }
 

--- a/core/src/test/java/io/neow3j/crypto/Base58DecodeTest.java
+++ b/core/src/test/java/io/neow3j/crypto/Base58DecodeTest.java
@@ -18,9 +18,7 @@
 package io.neow3j.crypto;
 
 import io.neow3j.crypto.exceptions.AddressFormatException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -29,12 +27,10 @@ import java.util.Collection;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
 @RunWith(Parameterized.class)
 public class Base58DecodeTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     private final String input;
     private final byte[] expected;
@@ -66,9 +62,9 @@ public class Base58DecodeTest {
 
     @Test
     public void testDecode_invalidBase58() {
-        exceptionRule.expect(AddressFormatException.class);
-        exceptionRule.expectMessage("Invalid character ' ' at position 4");
-        Base58.decode("This isn't valid base58");
+        assertThrows("Invalid character ' ' at position 4", AddressFormatException.class,
+                () -> Base58.decode("This isn't valid base58")
+        );
     }
 
 }

--- a/core/src/test/java/io/neow3j/crypto/SignTest.java
+++ b/core/src/test/java/io/neow3j/crypto/SignTest.java
@@ -4,9 +4,7 @@ import io.neow3j.crypto.ECKeyPair.ECPrivateKey;
 import io.neow3j.crypto.ECKeyPair.ECPublicKey;
 import io.neow3j.types.Hash160;
 import io.neow3j.utils.Numeric;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.security.SignatureException;
 
@@ -20,12 +18,10 @@ import static io.neow3j.utils.Numeric.toHexString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class SignTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     private static final String TEST_MESSAGE = "A test message";
     private static final byte[] TEST_MESSAGE_BYTES = TEST_MESSAGE.getBytes();
@@ -106,11 +102,12 @@ public class SignTest {
     }
 
     @Test
-    public void testInvalidSignature() throws SignatureException {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("r must be 32 bytes.");
-        signedMessageToKey(TEST_MESSAGE_BYTES, new Sign.SignatureData((byte) 27, new byte[]{1},
-                new byte[]{0}));
+    public void testInvalidSignature() {
+        assertThrows("r must be 32 bytes.", RuntimeException.class,
+                () -> signedMessageToKey(TEST_MESSAGE_BYTES, new Sign.SignatureData((byte) 27,
+                        new byte[]{1},
+                        new byte[]{0}))
+        );
     }
 
     @Test

--- a/core/src/test/java/io/neow3j/crypto/WIFTest.java
+++ b/core/src/test/java/io/neow3j/crypto/WIFTest.java
@@ -2,29 +2,28 @@ package io.neow3j.crypto;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 
 import io.neow3j.utils.Numeric;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class WIFTest {
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void testWIF() {
-        final String privateKey = "9117f4bf9be717c9a90994326897f4243503accd06712162267e77f18b49c3a3";
-        byte[] privateKeyFromWIF = WIF.getPrivateKeyFromWIF("L25kgAQJXNHnhc7Sx9bomxxwVSMsZdkaNQ3m2VfHrnLzKWMLP13A");
+        final String privateKey =
+                "9117f4bf9be717c9a90994326897f4243503accd06712162267e77f18b49c3a3";
+        byte[] privateKeyFromWIF =
+                WIF.getPrivateKeyFromWIF("L25kgAQJXNHnhc7Sx9bomxxwVSMsZdkaNQ3m2VfHrnLzKWMLP13A");
         assertThat(Numeric.toHexStringNoPrefix(privateKeyFromWIF), is(privateKey));
     }
 
     @Test
     public void testWIFLargerThan38() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Incorrect WIF format.");
-        WIF.getPrivateKeyFromWIF("L25kgAQJXNHnhc7Sx9bomxxwVSMsZdkaNQ3m2VfHrnLzKWMLP13Ahc7S");
+        assertThrows("Incorrect WIF format.", IllegalArgumentException.class,
+                () -> WIF.getPrivateKeyFromWIF(
+                        "L25kgAQJXNHnhc7Sx9bomxxwVSMsZdkaNQ3m2VfHrnLzKWMLP13Ahc7S")
+        );
     }
 
     @Test
@@ -32,9 +31,10 @@ public class WIFTest {
         byte[] wifBytes = Base58.decode("L25kgAQJXNHnhc7Sx9bomxxwVSMsZdkaNQ3m2VfHrnLzKWMLP13A");
         wifBytes[0] = (byte) 0x81;
         String wifString = Base58.encode(wifBytes);
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Incorrect WIF format.");
-        WIF.getPrivateKeyFromWIF(wifString);
+
+        assertThrows("Incorrect WIF format.", IllegalArgumentException.class,
+                () -> WIF.getPrivateKeyFromWIF(wifString)
+        );
     }
 
     @Test
@@ -42,31 +42,35 @@ public class WIFTest {
         byte[] wifBytes = Base58.decode("L25kgAQJXNHnhc7Sx9bomxxwVSMsZdkaNQ3m2VfHrnLzKWMLP13A");
         wifBytes[33] = (byte) 0x00;
         String wifString = Base58.encode(wifBytes);
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Incorrect WIF format.");
-        WIF.getPrivateKeyFromWIF(wifString);
+
+        assertThrows("Incorrect WIF format.", IllegalArgumentException.class,
+                () -> WIF.getPrivateKeyFromWIF(wifString)
+        );
     }
 
     @Test
     public void testWIFNull() {
-        exceptionRule.expect(NullPointerException.class);
-        WIF.getPrivateKeyFromWIF(null);
+        assertThrows(NullPointerException.class, () -> WIF.getPrivateKeyFromWIF(null));
     }
 
     @Test
     public void privateKeyToWif() {
-        final String privateKey = "9117f4bf9be717c9a90994326897f4243503accd06712162267e77f18b49c3a3";
+        final String privateKey =
+                "9117f4bf9be717c9a90994326897f4243503accd06712162267e77f18b49c3a3";
         String result = WIF.getWIFFromPrivateKey(Numeric.hexStringToByteArray(privateKey));
         String expected = "L25kgAQJXNHnhc7Sx9bomxxwVSMsZdkaNQ3m2VfHrnLzKWMLP13A";
+
         assertThat(result, is(expected));
     }
 
     @Test
     public void failUsingWrongSizePrivateKey() {
         final String privateKey = "9117f4bf9be717c9a90994326897f4243503accd06712162267e77f18b49c3";
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Given key is not of expected length (32 bytes).");
-        WIF.getWIFFromPrivateKey(Numeric.hexStringToByteArray(privateKey));
+
+        assertThrows("Given key is not of expected length (32 bytes).",
+                IllegalArgumentException.class,
+                () -> WIF.getWIFFromPrivateKey(Numeric.hexStringToByteArray(privateKey))
+        );
     }
 
 }

--- a/core/src/test/java/io/neow3j/protocol/core/JsonRpc2_0Neow3jTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/JsonRpc2_0Neow3jTest.java
@@ -3,13 +3,12 @@ package io.neow3j.protocol.core;
 import io.neow3j.protocol.Neow3j;
 import io.neow3j.protocol.Neow3jConfig;
 import io.neow3j.protocol.Neow3jService;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
@@ -24,9 +23,6 @@ public class JsonRpc2_0Neow3jTest {
             .setPollingInterval(10)
             .setScheduledExecutorService(scheduledExecutorService));
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void testStopExecutorOnShutdown() throws Exception {
         neow3j.shutdown();
@@ -40,9 +36,7 @@ public class JsonRpc2_0Neow3jTest {
         doThrow(new IOException("Failed to close"))
                 .when(service).close();
 
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Failed to close");
-        neow3j.shutdown();
+        assertThrows("Failed to close", RuntimeException.class, () -> neow3j.shutdown());
     }
 
 }

--- a/core/src/test/java/io/neow3j/protocol/core/stackitem/StackItemTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/stackitem/StackItemTest.java
@@ -5,11 +5,7 @@ import io.neow3j.types.StackItemType;
 import io.neow3j.protocol.ResponseTester;
 import io.neow3j.protocol.exceptions.StackItemCastException;
 import io.neow3j.utils.Numeric;
-import org.hamcrest.core.StringContains;
-import org.hamcrest.text.StringContainsInOrder;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.math.BigInteger;
@@ -29,15 +25,14 @@ import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.Matchers.stringContainsInOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class StackItemTest extends ResponseTester {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     private final static String BYTESTRING_JSON =
             "{\"type\":\"ByteString\",\"value\":\"V29vbG9uZw==\"}";
@@ -46,90 +41,103 @@ public class StackItemTest extends ResponseTester {
     public void throwOnCastingToMapFromIllegalType() throws IOException {
         StackItem rawItem = getObjectMapper().readValue("{\"type\":\"Integer\",\"value\":\"1124\"}",
                 StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                rawItem::getMap);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList(StackItemType.INTEGER.getValue(), "1124")));
-        rawItem.getMap();
     }
 
     @Test
     public void throwOnCastingToListFromIllegalType() throws IOException {
         StackItem rawItem = getObjectMapper().readValue("{\"type\":\"Integer\",\"value\":\"1124\"}",
                 StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                rawItem::getList);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList(StackItemType.INTEGER.getValue(), "1124")));
-        rawItem.getList();
     }
 
     @Test
     public void throwOnCastingToPointerFromIllegalType() throws IOException {
         StackItem rawItem = getObjectMapper().readValue("{\"type\":\"Integer\",\"value\":\"1124\"}",
                 StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                rawItem::getPointer);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList(StackItemType.INTEGER.getValue(), "1124")));
-        rawItem.getPointer();
     }
 
     @Test
     public void throwOnCastingToInteropInterfaceFromIllegalType() throws IOException {
         StackItem rawItem = getObjectMapper().readValue("{\"type\":\"Integer\",\"value\":\"1124\"}",
                 StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                rawItem::getIterator);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList(StackItemType.INTEGER.getValue(), "1124")));
-        rawItem.getIterator();
     }
 
     @Test
     public void throwOnCastingToAddressFromIllegalType() throws IOException {
         StackItem rawItem = getObjectMapper().readValue("{\"type\":\"Integer\",\"value\":\"1124\"}",
                 StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                rawItem::getAddress);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
                 asList(StackItemType.INTEGER.getValue(), "1124")));
-        rawItem.getAddress();
     }
 
     @Test
     public void throwOnCastingToBooleanFromIllegalType() throws IOException {
         StackItem rawItem = getObjectMapper().readValue("{\"type\":\"Integer\",\"value\":\"1124\"}",
                 StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                asList(StackItemType.INTEGER.getValue(), "1124")));
-        rawItem.getBoolean();
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                rawItem::getBoolean);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList(StackItemType.INTEGER.getValue(), "1124"))
+        );
     }
 
     @Test
     public void throwOnCastingToHexStringFromIllegalType() throws IOException {
         StackItem rawItem = getObjectMapper().readValue("{\"type\":\"Boolean\",\"value\":\"true\"}",
                 StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                asList(StackItemType.BOOLEAN.getValue(), "true")));
-        rawItem.getHexString();
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                rawItem::getHexString);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList(StackItemType.BOOLEAN.getValue(), "true"))
+        );
     }
 
     @Test
     public void throwOnCastingToStringFromIllegalType() throws IOException {
         StackItem rawItem = getObjectMapper().readValue("{\"type\":\"Pointer\",\"value\":\"1124\"}",
                 StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                asList(StackItemType.POINTER.getValue(), "1124")));
-        rawItem.getString();
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                rawItem::getString);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList(StackItemType.POINTER.getValue(), "1124"))
+        );
     }
 
     @Test
     public void throwOnCastingToByteArrayFromIllegalType() throws IOException {
         StackItem rawItem = getObjectMapper().readValue("{\"type\":\"Boolean\",\"value\":\"true\"}",
                 StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                asList(StackItemType.BOOLEAN.getValue(), "true")));
-        rawItem.getByteArray();
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                rawItem::getByteArray);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList(StackItemType.BOOLEAN.getValue(), "true"))
+        );
     }
 
     @Test
@@ -143,30 +151,33 @@ public class StackItemTest extends ResponseTester {
                 "        }\n" +
                 "    ]\n" +
                 "}", StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContainsInOrder(
-                asList(StackItemType.ARRAY.getValue(), "false")));
-        item.getInteger();
+
+        StackItemCastException thrown = assertThrows(StackItemCastException.class,
+                item::getInteger);
+        assertThat(thrown.getMessage(), stringContainsInOrder(
+                asList(StackItemType.ARRAY.getValue(), "false"))
+        );
     }
 
     @Test
     public void throwOnGettingValuefromNullIntegerStackItem() throws IOException {
         StackItem item = getObjectMapper().readValue("{\"type\":\"Integer\"," +
                 "\"value\":\"\"}", StackItem.class);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContains("Cannot cast stack item because its value " +
-                "is null"));
-        item.getInteger();
+
+        assertThrows("Cannot cast stack item because its value is null",
+                StackItemCastException.class, item::getInteger);
     }
 
     @Test
     public void testDeserializeAnyStackItem() throws IOException {
         String json = "{\"type\":\"Any\", \"value\":null}";
         StackItem item = getObjectMapper().readValue(json, StackItem.class);
+
         assertThat(item.getType(), is(StackItemType.ANY));
         assertThat(item.getValue(), is(nullValue()));
 
         AnyStackItem other = new AnyStackItem(null);
+
         assertEquals(other, item);
         assertEquals(other.hashCode(), item.hashCode());
     }
@@ -175,10 +186,12 @@ public class StackItemTest extends ResponseTester {
     public void testDeserializePointerStackItem() throws IOException {
         String json = "{\"type\":\"Pointer\", \"value\":\"123456\"}";
         StackItem item = getObjectMapper().readValue(json, StackItem.class);
+
         assertThat(item.getType(), is(StackItemType.POINTER));
         assertThat(item.getPointer(), is(new BigInteger("123456")));
 
         PointerStackItem other = new PointerStackItem(new BigInteger("123456"));
+
         assertEquals(other, item);
         assertEquals(other.hashCode(), item.hashCode());
     }
@@ -186,6 +199,7 @@ public class StackItemTest extends ResponseTester {
     @Test
     public void testDeserializeByteStringStackItem() throws IOException {
         StackItem item = getObjectMapper().readValue(BYTESTRING_JSON, StackItem.class);
+
         assertEquals(StackItemType.BYTE_STRING, item.getType());
         assertThat(item.getHexString(), is("576f6f6c6f6e67"));
         assertThat(item.getByteArray(), is(Numeric.hexStringToByteArray("576f6f6c6f6e67")));
@@ -194,12 +208,14 @@ public class StackItemTest extends ResponseTester {
         String json = "{\"type\":\"ByteString\", \"value\":\"aWQ=\"}";
 
         item = getObjectMapper().readValue(json, StackItem.class);
+
         assertThat(item.getByteArray(), is(Numeric.hexStringToByteArray("6964")));
         assertThat(item.getInteger(), is(new BigInteger("25705")));
 
         // The script hash hex string in little-endian format
         json = "{\"type\":\"ByteString\", \"value\":\"1Cz3qTHOPEZVD9kN5IJYP8XqcBo=\"}";
         item = getObjectMapper().readValue(json, StackItem.class);
+
         assertThat(item.getAddress(), is("NfFrJpFaLPCVuRRPhmBYRmZqSQLJ5fPuhz"));
         assertThat(item.getHexString(), is("d42cf7a931ce3c46550fd90de482583fc5ea701a"));
         assertThat(item.getByteArray(),
@@ -207,6 +223,7 @@ public class StackItemTest extends ResponseTester {
 
         ByteStringStackItem other = new ByteStringStackItem(
                 Numeric.hexStringToByteArray("d42cf7a931ce3c46550fd90de482583fc5ea701a"));
+
         assertEquals(other, item);
         assertEquals(other.hashCode(), item.hashCode());
     }
@@ -372,7 +389,8 @@ public class StackItemTest extends ResponseTester {
                 "    ],\n" +
                 "    \"truncated\": true\n" +
                 "}";
-        InteropInterfaceStackItem item = getObjectMapper().readValue(json, InteropInterfaceStackItem.class);
+        InteropInterfaceStackItem item =
+                getObjectMapper().readValue(json, InteropInterfaceStackItem.class);
         assertThat(item.getType(), is(StackItemType.INTEROP_INTERFACE));
         List<StackItem> list = new ArrayList<>();
         list.add(new ByteStringStackItem("0e"));
@@ -407,11 +425,11 @@ public class StackItemTest extends ResponseTester {
     @Test
     public void testDeserializeInteropInterfaceStackItem_noIterator() throws IOException {
         String json = "{\"type\": \"InteropInterface\"}";
-        InteropInterfaceStackItem item = getObjectMapper().readValue(json, InteropInterfaceStackItem.class);
+        InteropInterfaceStackItem item =
+                getObjectMapper().readValue(json, InteropInterfaceStackItem.class);
+
         assertThat(item.getType(), is(StackItemType.INTEROP_INTERFACE));
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage("to an iterator.");
-        item.getIterator();
+        assertThrows("to an iterator.", StackItemCastException.class, item::getIterator);
     }
 
     @Test
@@ -468,21 +486,22 @@ public class StackItemTest extends ResponseTester {
 
     @Test
     public void testStackItemType_InvalidByteValue() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("no stack item with the provided byte value");
-        StackItemType.valueOf((byte) 31);
+        assertThrows("no stack item with the provided byte value", IllegalArgumentException.class,
+                () -> StackItemType.valueOf((byte) 31)
+        );
     }
 
     @Test
     public void testStackItemType_InvalidJsonValue() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("no stack item with the provided json value");
-        StackItemType.fromJsonValue("Enum");
+        assertThrows("no stack item with the provided json value", IllegalArgumentException.class,
+                () -> StackItemType.fromJsonValue("Enum")
+        );
     }
 
     @Test
     public void anyStackItemValueToString() {
         AnyStackItem item = new AnyStackItem(null);
+
         assertThat(item.toString(), is("Any{value='null'}"));
     }
 
@@ -513,10 +532,9 @@ public class StackItemTest extends ResponseTester {
         assertFalse(item.getBoolean());
 
         item = new BufferStackItem();
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContains("Cannot cast stack item because its value " +
-                "is null"));
-        item.getBoolean();
+
+        assertThrows("Cannot cast stack item because its value is null",
+                StackItemCastException.class, item::getBoolean);
     }
 
     @Test
@@ -524,6 +542,7 @@ public class StackItemTest extends ResponseTester {
         BufferStackItem item1 = new BufferStackItem(Numeric.hexStringToByteArray("010203"));
         BufferStackItem item2 = new BufferStackItem(Numeric.hexStringToByteArray("010203"));
         ByteStringStackItem item3 = new ByteStringStackItem(Numeric.hexStringToByteArray("010203"));
+
         assertEquals(item1, item1);
         assertEquals(item1, item2);
         assertNotEquals(item1, item3);
@@ -534,6 +553,7 @@ public class StackItemTest extends ResponseTester {
         ByteStringStackItem item1 = new ByteStringStackItem(Numeric.hexStringToByteArray("010203"));
         ByteStringStackItem item2 = new ByteStringStackItem(Numeric.hexStringToByteArray("010203"));
         BufferStackItem item3 = new BufferStackItem(Numeric.hexStringToByteArray("010203"));
+
         assertEquals(item1, item1);
         assertEquals(item1, item2);
         assertNotEquals(item1, item3);
@@ -543,6 +563,7 @@ public class StackItemTest extends ResponseTester {
     public void getBooleanFromIntegerStackItem() {
         IntegerStackItem item1 = new IntegerStackItem(BigInteger.ONE);
         assertTrue(item1.getBoolean());
+
         item1 = new IntegerStackItem(BigInteger.ZERO);
         assertFalse(item1.getBoolean());
     }
@@ -550,19 +571,15 @@ public class StackItemTest extends ResponseTester {
     @Test
     public void throwExceptionOnGetAddressFromByteArrayWithIllegalAddress() {
         ByteStringStackItem item = new ByteStringStackItem(Numeric.hexStringToByteArray("010203"));
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContains(
-                IllegalArgumentException.class.getSimpleName()));
-        item.getAddress();
+        assertThrows(IllegalArgumentException.class.getSimpleName(), StackItemCastException.class,
+                item::getAddress);
     }
 
     @Test
     public void throwExceptionOnGetIntegerFromEmptyByteArray() {
         ByteStringStackItem item = new ByteStringStackItem(new byte[]{});
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContains(
-                NumberFormatException.class.getSimpleName()));
-        item.getInteger();
+        assertThrows(NumberFormatException.class.getSimpleName(), StackItemCastException.class,
+                item::getInteger);
     }
 
     @Test
@@ -574,10 +591,9 @@ public class StackItemTest extends ResponseTester {
     @Test
     public void throwOnGetStringFromNullIntegerStackItem() {
         IntegerStackItem item = new IntegerStackItem(null);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContains("Cannot cast stack item because its value " +
-                "is null"));
-        item.getString();
+
+        assertThrows("Cannot cast stack item because its value is null",
+                StackItemCastException.class, item::getString);
     }
 
     @Test
@@ -589,10 +605,8 @@ public class StackItemTest extends ResponseTester {
     @Test
     public void throwOnGetHexStringFromNullIntegerStackItem() {
         IntegerStackItem item = new IntegerStackItem(null);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContains("Cannot cast stack item because its value " +
-                "is null"));
-        item.getHexString();
+        assertThrows("Cannot cast stack item because its value is null",
+                StackItemCastException.class, item::getHexString);
     }
 
     @Test
@@ -604,10 +618,8 @@ public class StackItemTest extends ResponseTester {
     @Test
     public void throwOnGetByteArrayFromNullIntegerStackItem() {
         IntegerStackItem item = new IntegerStackItem(null);
-        exceptionRule.expect(StackItemCastException.class);
-        exceptionRule.expectMessage(new StringContains("Cannot cast stack item because its value " +
-                "is null"));
-        item.getByteArray();
+        assertThrows("Cannot cast stack item because its value is null",
+                StackItemCastException.class, item::getByteArray);
     }
 
     @Test
@@ -626,6 +638,7 @@ public class StackItemTest extends ResponseTester {
         map.put(new ByteStringStackItem("key2".getBytes(UTF_8)),
                 new IntegerStackItem(BigInteger.ZERO));
         MapStackItem item = new MapStackItem(map);
+
         assertThat(item.valueToString(), containsString(
                 "ByteString{value='6b657932'} -> Integer{value='0'}"));
         assertThat(item.valueToString(), containsString(

--- a/core/src/test/java/io/neow3j/serialization/BinaryReaderTest.java
+++ b/core/src/test/java/io/neow3j/serialization/BinaryReaderTest.java
@@ -1,9 +1,7 @@
 package io.neow3j.serialization;
 
 import io.neow3j.serialization.exceptions.DeserializationException;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -12,6 +10,7 @@ import java.math.BigInteger;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThrows;
 
 public class BinaryReaderTest extends TestBinaryUtils {
 
@@ -21,22 +20,18 @@ public class BinaryReaderTest extends TestBinaryUtils {
     private BigInteger readResultInt;
     private String readResultString;
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     // region Read push data byte array
 
     @Test
-    public void failReadPushDataByteArray() throws DeserializationException {
+    public void failReadPushDataByteArray() {
         // Uses a prefix different from any of the PUSHDATA OpCodes and should therefore fail.
         this.arrayBuilder = new ByteArrayBuilder()
                 .setPrefix("4b")
                 .setAnyDataWithSize(1)
                 .setSuffix("0000");
-        exceptionRule.expect(DeserializationException.class);
-        exceptionRule.expectMessage("Stream did not contain a PUSHDATA OpCode at the current " +
-                "position.");
-        readPushDataByteArray();
+
+        assertThrows("Stream did not contain a PUSHDATA OpCode at the current position.",
+                DeserializationException.class, this::readPushDataByteArray);
     }
 
     @Test
@@ -146,11 +141,10 @@ public class BinaryReaderTest extends TestBinaryUtils {
     }
 
     @Test
-    public void failReadPushIntegerUnsupported() throws DeserializationException {
+    public void failReadPushIntegerUnsupported() {
         this.arrayBuilder = new ByteArrayBuilder().setPrefix("0e"); // Not a PUSH OpCode
-        exceptionRule.expect(DeserializationException.class);
-        exceptionRule.expectMessage("Couldn't parse PUSHINT OpCode");
-        readPushInteger();
+        assertThrows("Couldn't parse PUSHINT OpCode", DeserializationException.class,
+                this::readPushInteger);
     }
 
     @Test

--- a/core/src/test/java/io/neow3j/transaction/TransactionTest.java
+++ b/core/src/test/java/io/neow3j/transaction/TransactionTest.java
@@ -14,9 +14,7 @@ import io.neow3j.types.Hash160;
 import io.neow3j.types.Hash256;
 import io.neow3j.wallet.Account;
 import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 import org.mockito.Mockito;
 
 import java.io.IOException;
@@ -34,6 +32,7 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 
 public class TransactionTest {
 
@@ -42,9 +41,6 @@ public class TransactionTest {
     private Hash160 account3;
 
     private final Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"));
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Before
     public void setUp() {
@@ -264,8 +260,7 @@ public class TransactionTest {
     }
 
     @Test
-    public void failDeserializingWithTooManyTransactionAttributes()
-            throws DeserializationException {
+    public void failDeserializingWithTooManyTransactionAttributes() {
         StringBuilder txString = new StringBuilder(""
                 + "00" // version 0
                 + "62bdaa0e"  // nonce
@@ -281,10 +276,9 @@ public class TransactionTest {
         // additional bytes are not needed for this test
         byte[] txBytes = hexStringToByteArray(txString.toString());
 
-        exceptionRule.expect(DeserializationException.class);
-        exceptionRule.expectMessage("A transaction can hold at most ");
-
-        NeoSerializableInterface.from(txBytes, Transaction.class);
+        assertThrows("A transaction can hold at most ", DeserializationException.class,
+                () -> NeoSerializableInterface.from(txBytes, Transaction.class)
+        );
     }
 
     @Test
@@ -360,7 +354,7 @@ public class TransactionTest {
     }
 
     @Test
-    public void testTooBigTransaction() throws IOException {
+    public void testTooBigTransaction() {
         // The following transaction is 29 bytes without the script
         // The script needs additional 4 bytes to specify its length.
         byte[] scriptForTooBigTx = new byte[NeoConstants.MAX_TRANSACTION_SIZE - 29 - 4 + 1];
@@ -377,9 +371,9 @@ public class TransactionTest {
 
         assertThat(tx.getSize(), is(NeoConstants.MAX_TRANSACTION_SIZE + 1));
 
-        exceptionRule.expect(TransactionConfigurationException.class);
-        exceptionRule.expectMessage("The transaction exceeds the maximum transaction size.");
-        tx.send();
+        assertThrows("The transaction exceeds the maximum transaction size.",
+                TransactionConfigurationException.class, tx::send
+        );
     }
 
     @Test

--- a/core/src/test/java/io/neow3j/transaction/WitnessScopeTest.java
+++ b/core/src/test/java/io/neow3j/transaction/WitnessScopeTest.java
@@ -3,10 +3,7 @@ package io.neow3j.transaction;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.ValueInstantiationException;
 import io.neow3j.protocol.ObjectMapperFactory;
-import org.hamcrest.core.StringContains;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -16,11 +13,9 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
 
 public class WitnessScopeTest {
-
-    @Rule
-    public ExpectedException expectedException = ExpectedException.none();
 
     @Test
     public void combineScopes() {
@@ -80,14 +75,14 @@ public class WitnessScopeTest {
     }
 
     @Test
-    public void failFromJson() throws IOException {
+    public void failFromJson() {
         ObjectMapper mapper = ObjectMapperFactory.getObjectMapper();
         String json = "\"NonExistent\"";
 
-        expectedException.expect(ValueInstantiationException.class);
-        expectedException.expectMessage(new StringContains(
-                String.format("%s value type not found.", WitnessScope.class.getName())));
-        mapper.readValue(json, WitnessScope.class);
+        assertThrows(String.format("%s value type not found.", WitnessScope.class.getName()),
+                ValueInstantiationException.class,
+                () -> mapper.readValue(json, WitnessScope.class)
+        );
     }
 
 }

--- a/core/src/test/java/io/neow3j/utils/AddressUtilsTest.java
+++ b/core/src/test/java/io/neow3j/utils/AddressUtilsTest.java
@@ -1,9 +1,7 @@
 package io.neow3j.utils;
 
 import io.neow3j.protocol.Neow3jConfig;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static io.neow3j.crypto.Hash.sha256AndThenRipemd160;
 import static io.neow3j.utils.AddressUtils.addressToScriptHash;
@@ -15,12 +13,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class AddressUtilsTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void testCreatesScriptHashThenToAddress() {
@@ -59,16 +55,16 @@ public class AddressUtilsTest {
 
     @Test
     public void testAddressToScriptHash_InvalidAddress() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Not a valid NEO address.");
-        addressToScriptHash("NfAmTpaR5kxaUDs6LDBR9DWau53NsEz88");
+        assertThrows("Not a valid NEO address.", IllegalArgumentException.class,
+                () -> addressToScriptHash("NfAmTpaR5kxaUDs6LDBR9DWau53NsEz88")
+        );
     }
 
     @Test
     public void testToScriptHashLargerThan25Chars() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Not a valid NEO address.");
-        addressToScriptHash("NfAmTpaR5kxaUDs6LDBR9DWau53NsEz88ue");
+        assertThrows("Not a valid NEO address.", IllegalArgumentException.class,
+                () -> addressToScriptHash("NfAmTpaR5kxaUDs6LDBR9DWau53NsEz88ue")
+        );
     }
 
     @Test
@@ -83,6 +79,7 @@ public class AddressUtilsTest {
         Neow3jConfig.setAddressVersion((byte) 0x37);
         byte[] scriptHash = hexStringToByteArray("c67d4f062a94e9ed6a110264e50881500d4cf1bb");
         String address = "PRivaTenetyWuqK7Gj7Vd747d77ssYeDhL";
+
         assertThat(scriptHashToAddress(scriptHash), is(address));
         Neow3jConfig.setAddressVersion((byte) 0x35);
     }
@@ -98,9 +95,8 @@ public class AddressUtilsTest {
         assertFalse(isValidAddress("NWcx4EfYdfqn5jNjDz8AHE6hWtWdUGDdmyU"));
 
         // If the address string is null, we don't want to say it is an invalid address because
-        // there isn't even an address to be deemed invalid. Therefore expect NullPointerException.
-        exceptionRule.expect(NullPointerException.class);
-        isValidAddress(null);
+        // there isn't even an address to be deemed invalid. Therefore, expect NullPointerException.
+        assertThrows(NullPointerException.class, () -> isValidAddress(null));
     }
 
 }

--- a/core/src/test/java/io/neow3j/utils/ArrayUtilsTest.java
+++ b/core/src/test/java/io/neow3j/utils/ArrayUtilsTest.java
@@ -1,9 +1,7 @@
 package io.neow3j.utils;
 
 import org.hamcrest.CoreMatchers;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import static io.neow3j.utils.ArrayUtils.concatenate;
 import static io.neow3j.utils.ArrayUtils.getFirstNBytes;
@@ -17,11 +15,9 @@ import static io.neow3j.utils.ArrayUtils.xor;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
+import static org.junit.Assert.assertThrows;
 
 public class ArrayUtilsTest {
-
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
 
     @Test
     public void testToPrimitive() {
@@ -30,6 +26,7 @@ public class ArrayUtilsTest {
         byte b3 = 0x03;
         Byte[] testArray = new Byte[]{b1, b2, b3};
         byte[] arrayOfBytesPrimitive = toPrimitive(testArray);
+
         assertThat(arrayOfBytesPrimitive[0], is(b1));
         assertThat(arrayOfBytesPrimitive[1], is(b2));
         assertThat(arrayOfBytesPrimitive[2], is(b3));
@@ -39,6 +36,7 @@ public class ArrayUtilsTest {
     public void testToPrimitive_Empty() {
         Byte[] testArray = new Byte[]{};
         byte[] arrayOfBytesPrimitive = toPrimitive(testArray);
+
         assertThat(arrayOfBytesPrimitive.length, is(0));
     }
 
@@ -46,6 +44,7 @@ public class ArrayUtilsTest {
     public void testToPrimitive_Null() {
         Byte[] testArray = null;
         byte[] arrayOfBytesPrimitive = toPrimitive(testArray);
+
         assertThat(arrayOfBytesPrimitive, nullValue());
     }
 
@@ -66,21 +65,22 @@ public class ArrayUtilsTest {
         byte b1 = 0x02;
         byte b2 = 0x11;
         byte[] xorResult = xor(new byte[]{a1, a2}, new byte[]{b1, b2});
+
         assertThat(xorResult, is(new byte[]{0x03, 0x01}));
     }
 
     @Test
     public void testXor_Different_Sizes() {
-        exceptionRule.expect(IllegalArgumentException.class);
-        exceptionRule.expectMessage("Arrays do not have the same length to perform the XOR " +
-                "operation.");
-        xor(new byte[]{0x01, 0x02}, new byte[]{0x01});
+        assertThrows("Arrays do not have the same length to perform the XOR operation.",
+                IllegalArgumentException.class,
+                () -> xor(new byte[]{0x01, 0x02}, new byte[]{0x01}));
     }
 
     @Test
     public void testGetFirstNBytes() {
         assertThat(getFirstNBytes(new byte[]{0x01, 0x02, 0x03}, 2), is(new byte[]{0x01, 0x02}));
-        assertThat(getFirstNBytes(new byte[]{0x01, 0x02, 0x03}, 3), is(new byte[]{0x01, 0x02, 0x03}));
+        assertThat(getFirstNBytes(new byte[]{0x01, 0x02, 0x03}, 3), is(new byte[]{0x01, 0x02,
+                0x03}));
         assertThat(getFirstNBytes(new byte[]{0x01, 0x02, 0x03}, 0), is(new byte[]{}));
         assertThat(getFirstNBytes(new byte[]{}, 2), is(new byte[]{}));
         assertThat(getFirstNBytes(null, 2), is(new byte[]{}));
@@ -89,7 +89,8 @@ public class ArrayUtilsTest {
     @Test
     public void testGetLastNBytes() {
         assertThat(getLastNBytes(new byte[]{0x01, 0x02, 0x03}, 2), is(new byte[]{0x02, 0x03}));
-        assertThat(getLastNBytes(new byte[]{0x01, 0x02, 0x03}, 3), is(new byte[]{0x01, 0x02, 0x03}));
+        assertThat(getLastNBytes(new byte[]{0x01, 0x02, 0x03}, 3), is(new byte[]{0x01, 0x02,
+                0x03}));
         assertThat(getLastNBytes(new byte[]{0x01, 0x02, 0x03}, 0), is(new byte[]{}));
         assertThat(getLastNBytes(new byte[]{}, 2), is(new byte[]{}));
         assertThat(getLastNBytes(null, 2), is(new byte[]{}));
@@ -97,11 +98,16 @@ public class ArrayUtilsTest {
 
     @Test
     public void testConcatenate() {
-        assertThat(concatenate(new byte[]{0x01, 0x02, 0x03}, new byte[]{0x04}), is(new byte[]{0x01, 0x02, 0x03, 0x04}));
-        assertThat(concatenate(new byte[]{0x01, 0x02, 0x03}, (byte) 0x04), is(new byte[]{0x01, 0x02, 0x03, 0x04}));
-        assertThat(concatenate((byte) 0x04, new byte[]{0x01, 0x02, 0x03}), is(new byte[]{0x04, 0x01, 0x02, 0x03}));
-        assertThat(concatenate(new byte[]{0x01, 0x02, 0x03}, new byte[]{0x01, 0x02, 0x03}, new byte[]{0x04}), is(new byte[]{0x01, 0x02, 0x03, 0x01, 0x02, 0x03, 0x04}));
-        assertThat(concatenate(new byte[]{}, new byte[]{0x01, 0x02, 0x03}, new byte[]{}, new byte[]{0x01}), is(new byte[]{0x01, 0x02, 0x03, 0x01}));
+        assertThat(concatenate(new byte[]{0x01, 0x02, 0x03}, new byte[]{0x04}),
+                is(new byte[]{0x01, 0x02, 0x03, 0x04}));
+        assertThat(concatenate(new byte[]{0x01, 0x02, 0x03}, (byte) 0x04), is(new byte[]{0x01,
+                0x02, 0x03, 0x04}));
+        assertThat(concatenate((byte) 0x04, new byte[]{0x01, 0x02, 0x03}), is(new byte[]{0x04,
+                0x01, 0x02, 0x03}));
+        assertThat(concatenate(new byte[]{0x01, 0x02, 0x03}, new byte[]{0x01, 0x02, 0x03},
+                new byte[]{0x04}), is(new byte[]{0x01, 0x02, 0x03, 0x01, 0x02, 0x03, 0x04}));
+        assertThat(concatenate(new byte[]{}, new byte[]{0x01, 0x02, 0x03}, new byte[]{},
+                new byte[]{0x01}), is(new byte[]{0x01, 0x02, 0x03, 0x01}));
     }
 
     @Test
@@ -112,40 +118,47 @@ public class ArrayUtilsTest {
         assertThat(reverseArray(new byte[]{}), is(new byte[]{}));
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void testReverseArray_Null() {
-        reverseArray(null);
+        assertThrows(NullPointerException.class, () -> reverseArray(null));
     }
 
     @Test
     public void testTrimLeadingBytes() {
-        assertThat(trimLeadingBytes(new byte[]{0x01, 0x02, 0x03}, (byte) 0x01), is(new byte[]{0x02, 0x03}));
-        assertThat(trimLeadingBytes(new byte[]{0x01, 0x02, 0x03}, (byte) 0x02), is(new byte[]{0x01, 0x02, 0x03}));
-        assertThat(trimLeadingBytes(new byte[]{0x05, 0x02, 0x03}, (byte) 0x02), is(new byte[]{0x05, 0x02, 0x03}));
-        assertThat(trimLeadingBytes(new byte[]{0x05, 0x02, 0x03}, (byte) 0x05), is(new byte[]{0x02, 0x03}));
-        assertThat(trimLeadingBytes(new byte[]{0x05, 0x02, 0x03}, (byte) 0x05), is(new byte[]{0x02, 0x03}));
-        assertThat(trimLeadingBytes(new byte[]{0x05, 0x02, 0x05, 0x03}, (byte) 0x05), is(new byte[]{0x02, 0x05, 0x03}));
+        assertThat(trimLeadingBytes(new byte[]{0x01, 0x02, 0x03}, (byte) 0x01),
+                is(new byte[]{0x02, 0x03}));
+        assertThat(trimLeadingBytes(new byte[]{0x01, 0x02, 0x03}, (byte) 0x02),
+                is(new byte[]{0x01, 0x02, 0x03}));
+        assertThat(trimLeadingBytes(new byte[]{0x05, 0x02, 0x03}, (byte) 0x02),
+                is(new byte[]{0x05, 0x02, 0x03}));
+        assertThat(trimLeadingBytes(new byte[]{0x05, 0x02, 0x03}, (byte) 0x05),
+                is(new byte[]{0x02, 0x03}));
+        assertThat(trimLeadingBytes(new byte[]{0x05, 0x02, 0x03}, (byte) 0x05),
+                is(new byte[]{0x02, 0x03}));
+        assertThat(trimLeadingBytes(new byte[]{0x05, 0x02, 0x05, 0x03}, (byte) 0x05),
+                is(new byte[]{0x02, 0x05, 0x03}));
     }
 
     @Test
     public void testToByteArray() {
-        assertThat(toByteArray(0), is(new byte[]{ 0x00, 0x00, 0x00, 0x00 }));
-        assertThat(toByteArray(16), is(new byte[]{ 0x00, 0x00, 0x00, 0x10 }));
-        assertThat(toByteArray(255), is(new byte[]{ 0x00, 0x00, 0x00, (byte) 0xFF }));
-        assertThat(toByteArray(2147483647), is(new byte[]{ 0x7F, (byte) 0xFF, (byte) 0xFF, (byte) 0xFF }));
+        assertThat(toByteArray(0), is(new byte[]{0x00, 0x00, 0x00, 0x00}));
+        assertThat(toByteArray(16), is(new byte[]{0x00, 0x00, 0x00, 0x10}));
+        assertThat(toByteArray(255), is(new byte[]{0x00, 0x00, 0x00, (byte) 0xFF}));
+        assertThat(toByteArray(2147483647), is(new byte[]{0x7F, (byte) 0xFF, (byte) 0xFF,
+                (byte) 0xFF}));
     }
 
     @Test
     public void longToByteArray() {
         assertThat(toByteArray(0L),
-                is(new byte[]{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00 }));
+                is(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00}));
         assertThat(toByteArray(16L),
-                is(new byte[]{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10 }));
+                is(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10}));
         assertThat(toByteArray(255L),
-                is(new byte[]{ 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xFF }));
+                is(new byte[]{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, (byte) 0xFF}));
         assertThat(toByteArray(2147483647L),
                 is(new byte[]{0x00, 0x00, 0x00, 0x00, 0x7F, (byte) 0xFF, (byte) 0xFF,
-                        (byte) 0xFF }));
+                        (byte) 0xFF}));
     }
 
     @Test

--- a/core/src/test/java/io/neow3j/utils/NumericTest.java
+++ b/core/src/test/java/io/neow3j/utils/NumericTest.java
@@ -2,10 +2,7 @@ package io.neow3j.utils;
 
 import io.neow3j.utils.exceptions.MessageDecodingException;
 import io.neow3j.utils.exceptions.MessageEncodingException;
-import org.junit.Assert;
-import org.junit.Rule;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
@@ -14,6 +11,7 @@ import static junit.framework.TestCase.assertFalse;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class NumericTest {
@@ -31,9 +29,6 @@ public class NumericTest {
 
     private static final String HEX_RANGE_STRING = "0x0123456789abcdef";
 
-    @Rule
-    public ExpectedException exceptionRule = ExpectedException.none();
-
     @Test
     public void testQuantityEncodeLeadingZero() {
         assertThat(Numeric.toHexStringWithPrefixSafe(BigInteger.valueOf(0L)), equalTo("0x00"));
@@ -41,7 +36,7 @@ public class NumericTest {
         assertThat(Numeric.toHexStringWithPrefixSafe(BigInteger.valueOf(Long.MAX_VALUE)),
                 equalTo("0x7fffffffffffffff"));
         assertThat(Numeric.toHexStringWithPrefixSafe(
-                new BigInteger("204516877000845695339750056077105398031")),
+                        new BigInteger("204516877000845695339750056077105398031")),
                 equalTo("0x99dc848b94efc27edfad28def049810f"));
     }
 
@@ -58,23 +53,26 @@ public class NumericTest {
 
     @Test
     public void testQuantityDecodeLeadingZeroException() {
-        exceptionRule.expect(MessageDecodingException.class);
-        exceptionRule.expectMessage("Value must be in format 0x[1-9]+[0-9]* or 0x0");
-        Numeric.decodeQuantity("0x0400");
+        assertThrows("Value must be in format 0x[1-9]+[0-9]* or 0x0",
+                MessageDecodingException.class,
+                () -> Numeric.decodeQuantity("0x0400")
+        );
     }
 
     @Test
     public void testQuantityDecodeMissingPrefix() {
-        exceptionRule.expect(MessageDecodingException.class);
-        exceptionRule.expectMessage("Value must be in format 0x[1-9]+[0-9]* or 0x0");
-        Numeric.decodeQuantity("ff");
+        assertThrows("Value must be in format 0x[1-9]+[0-9]* or 0x0",
+                MessageDecodingException.class,
+                () -> Numeric.decodeQuantity("ff")
+        );
     }
 
     @Test
     public void testQuantityDecodeMissingValue() {
-        exceptionRule.expect(MessageDecodingException.class);
-        exceptionRule.expectMessage("Value must be in format 0x[1-9]+[0-9]* or 0x0");
-        Numeric.decodeQuantity("0x");
+        assertThrows("Value must be in format 0x[1-9]+[0-9]* or 0x0",
+                MessageDecodingException.class,
+                () -> Numeric.decodeQuantity("0x")
+        );
     }
 
     @Test
@@ -85,15 +83,15 @@ public class NumericTest {
         assertThat(Numeric.encodeQuantity(
                 BigInteger.valueOf(Long.MAX_VALUE)), is("0x7fffffffffffffff"));
         assertThat(Numeric.encodeQuantity(
-                new BigInteger("204516877000845695339750056077105398031")),
+                        new BigInteger("204516877000845695339750056077105398031")),
                 is("0x99dc848b94efc27edfad28def049810f"));
     }
 
     @Test
     public void testQuantityEncodeNegative() {
-        exceptionRule.expect(MessageEncodingException.class);
-        exceptionRule.expectMessage("Negative values are not supported");
-        Numeric.encodeQuantity(BigInteger.valueOf(-1));
+        assertThrows("Negative values are not supported", MessageEncodingException.class,
+                () -> Numeric.encodeQuantity(BigInteger.valueOf(-1))
+        );
     }
 
     @Test
@@ -136,9 +134,9 @@ public class NumericTest {
 
     @Test
     public void testToBytesPaddedInvalid() {
-        exceptionRule.expect(RuntimeException.class);
-        exceptionRule.expectMessage("Input is too large to put in byte array of size 7");
-        Numeric.toBytesPadded(BigInteger.valueOf(Long.MAX_VALUE), 7);
+        assertThrows("Input is too large to put in byte array of size 7", RuntimeException.class,
+                () -> Numeric.toBytesPadded(BigInteger.valueOf(Long.MAX_VALUE), 7)
+        );
     }
 
     @Test
@@ -204,16 +202,16 @@ public class NumericTest {
 
     @Test
     public void testToHexStringZeroPaddedNegative() {
-        exceptionRule.expect(UnsupportedOperationException.class);
-        exceptionRule.expectMessage("Value cannot be negative");
-        Numeric.toHexStringNoPrefixZeroPadded(BigInteger.valueOf(-1), 20);
+        assertThrows("Value cannot be negative", UnsupportedOperationException.class,
+                () -> Numeric.toHexStringNoPrefixZeroPadded(BigInteger.valueOf(-1), 20)
+        );
     }
 
     @Test
     public void testToHexStringZeroPaddedTooLargs() {
-        exceptionRule.expect(UnsupportedOperationException.class);
-        exceptionRule.expectMessage("Value cannot be negative");
-        Numeric.toHexStringNoPrefixZeroPadded(BigInteger.valueOf(-1), 5);
+        assertThrows("Value cannot be negative", UnsupportedOperationException.class,
+                () -> Numeric.toHexStringNoPrefixZeroPadded(BigInteger.valueOf(-1), 5)
+        );
     }
 
     @Test
@@ -254,7 +252,7 @@ public class NumericTest {
         String hex = "bc99b2a477e28581b2fd04249ba27599ebd736d3";
         String reversed = "d336d7eb9975a29b2404fdb28185e277a4b299bc";
 
-        Assert.assertThat(Numeric.reverseHexString(hex), is(reversed));
+        assertThat(Numeric.reverseHexString(hex), is(reversed));
     }
 
     @Test
@@ -262,7 +260,7 @@ public class NumericTest {
         String hex = "72656164";
         String original = "read";
 
-        Assert.assertThat(Numeric.hexToString(hex), is(original));
+        assertThat(Numeric.hexToString(hex), is(original));
     }
 
     @Test
@@ -270,7 +268,7 @@ public class NumericTest {
         String hex = "b100";
         BigInteger original = BigInteger.valueOf(177);
 
-        Assert.assertThat(Numeric.hexToInteger(hex), is(original));
+        assertThat(Numeric.hexToInteger(hex), is(original));
     }
 
     @Test


### PR DESCRIPTION
Refactored tests to replace the deprecated ExpectedException with Assert.assertThrows.