### PR TITLE
Support nested Map and List Objects in ContractParameter

### DIFF
--- a/core/src/main/java/io/neow3j/types/ContractParameter.java
+++ b/core/src/main/java/io/neow3j/types/ContractParameter.java
@@ -198,6 +198,8 @@ public class ContractParameter {
             return hash160((Account) o);
         } else if (o == null) {
             return any(null);
+        } else if (o instanceof List) {
+            return array((List<?>) o);
         } else {
             throw new IllegalArgumentException("The provided object could not be casted into " +
                     "a supported contract parameter type.");

--- a/core/src/main/java/io/neow3j/types/ContractParameter.java
+++ b/core/src/main/java/io/neow3j/types/ContractParameter.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
 import io.neow3j.constants.NeoConstants;
 import io.neow3j.crypto.Base64;
+import io.neow3j.crypto.ECKeyPair;
 import io.neow3j.crypto.Sign;
 import io.neow3j.types.ContractParameter.ContractParameterSerializer;
 import io.neow3j.wallet.Account;
@@ -369,6 +370,16 @@ public class ContractParameter {
                     hash.length + " bytes.");
         }
         return hash256(new Hash256(hash));
+    }
+
+    /**
+     * Creates a public key parameter from the given public key.
+     *
+     * @param publicKey the public key.
+     * @return the contract parameter.
+     */
+    public static ContractParameter publicKey(ECKeyPair.ECPublicKey publicKey) {
+        return publicKey(publicKey.getEncoded(true));
     }
 
     /**

--- a/core/src/main/java/io/neow3j/types/ContractParameter.java
+++ b/core/src/main/java/io/neow3j/types/ContractParameter.java
@@ -197,6 +197,10 @@ public class ContractParameter {
             return hash256((Hash256) o);
         } else if (o instanceof Account) {
             return hash160((Account) o);
+        } else if (o instanceof ECKeyPair.ECPublicKey) {
+            return publicKey((ECKeyPair.ECPublicKey) o);
+        } else if (o instanceof Sign.SignatureData) {
+            return signature((Sign.SignatureData) o);
         } else if (o instanceof List) {
             return array((List<?>) o);
         } else if (o instanceof Map) {

--- a/core/src/main/java/io/neow3j/types/ContractParameter.java
+++ b/core/src/main/java/io/neow3j/types/ContractParameter.java
@@ -196,10 +196,12 @@ public class ContractParameter {
             return hash256((Hash256) o);
         } else if (o instanceof Account) {
             return hash160((Account) o);
-        } else if (o == null) {
-            return any(null);
         } else if (o instanceof List) {
             return array((List<?>) o);
+        } else if (o instanceof Map) {
+            return map((Map<?, ?>) o);
+        } else if (o == null) {
+            return any(null);
         } else {
             throw new IllegalArgumentException("The provided object could not be casted into " +
                     "a supported contract parameter type.");

--- a/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
+++ b/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
@@ -41,7 +41,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertThrows;
-import static org.junit.Assert.assertTrue;
 
 @SuppressWarnings("unchecked")
 public class ContractParameterTest {
@@ -166,7 +165,39 @@ public class ContractParameterTest {
         ContractParameter param = array((Object) null);
         ContractParameter[] value = (ContractParameter[]) param.getValue();
         assertThat(value.length, is(1));
-        assertTrue(value[0].getParamType().equals(ContractParameterType.ANY));
+        assertEquals(value[0].getParamType(), ContractParameterType.ANY);
+    }
+
+    @Test
+    public void testNestedArrayParamCreationFromObject() {
+        List<Object> params = new ArrayList<>();
+        String p1 = "value";
+        String p2 = "0x0101";
+        BigInteger p3 = BigInteger.valueOf(420);
+
+        List<Object> p4 = new ArrayList<>();
+        int p4_1 = 1024;
+        String p4_2 = "neow3j";
+        p4.add(p4_1);
+        p4.add(p4_2);
+
+        List<Object> p4_3 = new ArrayList<>();
+        BigInteger p4_3_1 = BigInteger.TEN;
+        p4_3.add(p4_3_1);
+        p4.add(p4_3);
+
+        params.add(p1);
+        params.add(p2);
+        params.add(p3);
+        params.add(p4);
+        ContractParameter p = array(params);
+
+        assertEquals(ContractParameterType.ARRAY, p.getParamType());
+        assertEquals(ContractParameter[].class, p.getValue().getClass());
+        assertEquals(string(p1), ((ContractParameter[]) p.getValue())[0]);
+        assertEquals(string(p2), ((ContractParameter[]) p.getValue())[1]);
+        assertEquals(integer(p3), ((ContractParameter[]) p.getValue())[2]);
+        assertEquals(array(p4_1, p4_2, array(p4_3)), ((ContractParameter[]) p.getValue())[3]);
     }
 
     @Test

--- a/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
+++ b/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
@@ -1,6 +1,7 @@
 package io.neow3j.contract;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.neow3j.crypto.ECKeyPair;
 import io.neow3j.crypto.Sign;
 import io.neow3j.protocol.ObjectMapperFactory;
 import io.neow3j.script.ScriptBuilder;
@@ -385,6 +386,16 @@ public class ContractParameterTest {
     }
 
     @Test
+    public void testPublicKeyParamCreationFromECPublicKey() {
+        ECKeyPair.ECPublicKey publicKey = new ECKeyPair.ECPublicKey(
+                "03b4af8efe55d98b44eedfcfaa39642fd5d53ad543d18d3cc2db5880970a4654f6");
+        ContractParameter p = publicKey(publicKey);
+
+        assertThat((byte[]) p.getValue(), is(publicKey.getEncoded(true)));
+        assertEquals(ContractParameterType.PUBLIC_KEY, p.getParamType());
+    }
+
+    @Test
     public void testPublicKeyParamCreationFromByteArray() {
         byte[] pubKey = hexStringToByteArray(
                 "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816");
@@ -463,7 +474,8 @@ public class ContractParameterTest {
         ContractParameter param = map(map);
         Map<?, ?> value = (Map<?, ?>) param.getValue();
 
-        assertThat(value.keySet(), containsInAnyOrder(string("one"), string("two"), integer(map1Key)));
+        assertThat(value.keySet(), containsInAnyOrder(string("one"), string("two"),
+                integer(map1Key)));
         assertThat(value.values(), containsInAnyOrder(string("first"), integer(2), map(map1)));
         assertThat(value.get(string("one")), is(string("first")));
         assertThat(value.get(string("two")), is(integer(2)));

--- a/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
+++ b/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
@@ -447,6 +447,30 @@ public class ContractParameterTest {
     }
 
     @Test
+    public void testMap_withNestedObjects() {
+        Map<Object, Object> map = new HashMap<>();
+        map.put("one", "first");
+        map.put("two", 2);
+
+        int map1Key = 5;
+        HashMap<Object, Object> map1 = new HashMap<>();
+        String map1_1 = "hello";
+        int map1_2 = 1234;
+        map1.put(map1_1, map1_2);
+
+        map.put(map1Key, map1);
+
+        ContractParameter param = map(map);
+        Map<?, ?> value = (Map<?, ?>) param.getValue();
+
+        assertThat(value.keySet(), containsInAnyOrder(string("one"), string("two"), integer(map1Key)));
+        assertThat(value.values(), containsInAnyOrder(string("first"), integer(2), map(map1)));
+        assertThat(value.get(string("one")), is(string("first")));
+        assertThat(value.get(string("two")), is(integer(2)));
+        assertThat(value.get(integer(map1Key)), is(map(map1)));
+    }
+
+    @Test
     public void testMap_invalidKeyType() {
         HashMap<ContractParameter, ContractParameter> map = new HashMap<>();
         map.put(array(integer(1), string("test")), string("first"));


### PR DESCRIPTION
Resolves #700.

- Support automatic conversion of nested maps and lists to the corresponding ContractParameter types.
- Support automatic conversion of ECPublicKey and Sign.SignatureData to the corresponding ContractParameter using `mapToContractParameter`.
- Added static method ContractParameter.publicKey(ECPublicKey).