### PR TITLE
Add support for NeoVM's ASSERT

### DIFF
--- a/compiler/src/main/java/io/neow3j/compiler/NeoMethod.java
+++ b/compiler/src/main/java/io/neow3j/compiler/NeoMethod.java
@@ -619,6 +619,9 @@ public class NeoMethod {
      * @return the last instruction.
      */
     public NeoInstruction getLastInstruction() {
+        if (this.instructions.size() == 0) {
+            throw new CompilerException("Could not find any instruction in this NeoMethod.");
+        }
         return this.instructions.get(this.instructions.lastKey());
     }
 

--- a/compiler/src/main/java/io/neow3j/compiler/converters/JumpsConverter.java
+++ b/compiler/src/main/java/io/neow3j/compiler/converters/JumpsConverter.java
@@ -1,8 +1,5 @@
 package io.neow3j.compiler.converters;
 
-import static io.neow3j.compiler.Compiler.addPushNumber;
-import static java.lang.String.format;
-
 import io.neow3j.compiler.CompilationUnit;
 import io.neow3j.compiler.CompilerException;
 import io.neow3j.compiler.JVMOpcode;
@@ -10,7 +7,9 @@ import io.neow3j.compiler.NeoInstruction;
 import io.neow3j.compiler.NeoJumpInstruction;
 import io.neow3j.compiler.NeoMethod;
 import io.neow3j.script.OpCode;
+
 import java.util.List;
+
 import org.objectweb.asm.Label;
 import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.JumpInsnNode;
@@ -18,16 +17,17 @@ import org.objectweb.asm.tree.LabelNode;
 import org.objectweb.asm.tree.LookupSwitchInsnNode;
 import org.objectweb.asm.tree.TableSwitchInsnNode;
 
+import static io.neow3j.compiler.Compiler.addPushNumber;
+import static java.lang.String.format;
+
 public class JumpsConverter implements Converter {
 
     @Override
-    public AbstractInsnNode convert(AbstractInsnNode insn, NeoMethod neoMethod,
-            CompilationUnit compUnit) {
+    public AbstractInsnNode convert(AbstractInsnNode insn, NeoMethod neoMethod, CompilationUnit compUnit) {
 
-        // Java jump addresses are restricted to 2 bytes, i.e. there are no 4-byte jump
-        // addresses as in NeoVM. It is simpler for the compiler implementation to always
-        // use the 4-byte NeoVM jump opcodes and then optimize (to 1-byte addresses) in a
-        // second step. This is how the dotnet-devpack handles it too.
+        // Java jump addresses are restricted to 2 bytes, i.e. there are no 4-byte jump addresses as in NeoVM. It is
+        // simpler for the compiler implementation to always use the 4-byte NeoVM jump opcodes and then optimize (to
+        // 1-byte addresses) in a second step. This is how the dotnet-devpack handles it too.
 
         JVMOpcode opcode = JVMOpcode.get(insn.getOpcode());
         switch (opcode) {
@@ -64,9 +64,9 @@ public class JumpsConverter implements Converter {
             // endregion ### INTEGER COMPARISON ###
 
             // region ### INTEGER COMPARISON WITH ZERO ###
-            // These opcodes operate on boolean, byte, char, short, and int. In the latter four
-            // cases (IFLT, IFLE, IFGT, and IFGE) the NeoVM opcode is switched, e.g., from GT to
-            // LE because zero value will be on top of the stack and not the integer value.
+            // These opcodes operate on boolean, byte, char, short, and int. In the latter four cases (IFLT, IFLE,
+            // IFGT, and IFGE) the NeoVM opcode is switched, e.g., from GT to LE because zero value will be on top of
+            // the stack and not the integer value.
             case IFEQ: // Tests if the value on the stack is equal to zero.
                 addJumpInstruction(neoMethod, insn, OpCode.JMPIFNOT_L);
                 break;
@@ -101,15 +101,14 @@ public class JumpsConverter implements Converter {
 
             case LCMP:
                 // Comparison of two longs resulting in an integer with value -1, 0, or 1.
-                // This opcode has no direct counterpart in NeoVM because NeoVM does not
-                // differentiate between int and long.
+                // This opcode has no direct counterpart in NeoVM because NeoVM does not differentiate between int
+                // and long.
                 insn = handleLongComparison(neoMethod, insn);
                 break;
             case GOTO:
             case GOTO_W:
                 // Unconditionally branch of to another code location.
-                neoMethod.addInstruction(new NeoJumpInstruction(OpCode.JMP_L,
-                        ((JumpInsnNode) insn).label.getLabel()));
+                neoMethod.addInstruction(new NeoJumpInstruction(OpCode.JMP_L, ((JumpInsnNode) insn).label.getLabel()));
                 break;
             case LOOKUPSWITCH:
                 handleLookupSwitch(neoMethod, insn);
@@ -120,23 +119,20 @@ public class JumpsConverter implements Converter {
             case JSR:
             case RET:
             case JSR_W:
-                throw new CompilerException(neoMethod, format("JVM opcode %s is not supported.",
-                        opcode.name()));
+                throw new CompilerException(neoMethod, format("JVM opcode %s is not supported.", opcode.name()));
         }
         return insn;
     }
 
-    private static void addJumpInstruction(NeoMethod neoMethod, AbstractInsnNode insn,
-            OpCode jmpOpcode) {
+    private static void addJumpInstruction(NeoMethod neoMethod, AbstractInsnNode insn, OpCode jmpOpcode) {
         Label jmpLabel = ((JumpInsnNode) insn).label.getLabel();
         neoMethod.addInstruction(new NeoJumpInstruction(jmpOpcode, jmpLabel));
     }
 
-    private static AbstractInsnNode handleLongComparison(NeoMethod neoMethod,
-            AbstractInsnNode insn) {
+    private static AbstractInsnNode handleLongComparison(NeoMethod neoMethod, AbstractInsnNode insn) {
         JumpInsnNode jumpInsn = (JumpInsnNode) insn.getNext();
         JVMOpcode jvmOpcode = JVMOpcode.get(jumpInsn.getOpcode());
-        assert jvmOpcode != null : "Opcode of of jump instruction was not set.";
+        assert jvmOpcode != null : "Opcode of jump instruction was not set.";
         switch (jvmOpcode) {
             case IFEQ:
                 addJumpInstruction(neoMethod, jumpInsn, OpCode.JMPEQ_L);
@@ -157,8 +153,8 @@ public class JumpsConverter implements Converter {
                 addJumpInstruction(neoMethod, jumpInsn, OpCode.JMPGE_L);
                 break;
             default:
-                throw new CompilerException(neoMethod, format("Unexpected JVM opcode %s following "
-                                + "long comparison (%s)", jvmOpcode.name(), JVMOpcode.LCMP.name()));
+                throw new CompilerException(neoMethod, format("Unexpected JVM opcode %s following long comparison " +
+                        "(%s)", jvmOpcode.name(), JVMOpcode.LCMP.name()));
         }
         return jumpInsn;
     }
@@ -169,20 +165,18 @@ public class JumpsConverter implements Converter {
             int key = switchNode.keys.get(i);
             processCase(i, key, switchNode.labels, switchNode.dflt.getLabel(), neoMethod);
         }
-        // After handling the `LookupSwitchInsnNode` the compiler can continue processing all the
-        // case branches in its `handleInsn(...)` method.
+        // After handling the `LookupSwitchInsnNode` the compiler can continue processing all the case branches in
+        // its `handleInsn(...)` method.
     }
 
-    private static void processCase(int i, int key, List<LabelNode> labels, Label defaultLabel,
-            NeoMethod neoMethod) {
-        // The nextCaseLabel is used to connect the current case with the next case. If the
-        // current case is not successful, then the process will jump to the next case marked
-        // with this label.
+    private static void processCase(int i, int key, List<LabelNode> labels, Label defaultLabel, NeoMethod neoMethod) {
+        // The nextCaseLabel is used to connect the current case with the next case. If the current case is not
+        // successful, then the process will jump to the next case marked with this label.
         Label nextCaseLabel;
         boolean isLastCase = isLastCase(i, labels, defaultLabel);
         if (isLastCase) {
-            // If this is the last case statement (before the `default`) then we don't
-            // need to duplicate the value and the next label is the one of the default body.
+            // If this is the last case statement (before the `default`) then we don't need to duplicate the value
+            // and the next label is the one of the default body.
             nextCaseLabel = defaultLabel;
         } else {
             nextCaseLabel = new Label();
@@ -199,14 +193,13 @@ public class JumpsConverter implements Converter {
         }
         Label jmpLabel = labels.get(i).getLabel();
         neoMethod.addInstruction(new NeoJumpInstruction(OpCode.JMP_L, jmpLabel));
-        // Set the nextCaseLabel on the NeoMethod so that the next added instruction becomes
-        // the jump target.
+        // Set the nextCaseLabel on the NeoMethod so that the next added instruction becomes the jump target.
         neoMethod.setCurrentLabel(nextCaseLabel);
     }
 
-    // Checks if the given index marks the last case in the given list of case statements (i.e.
-    // labels of the cases' jump targets). If the case is only followed by cases that target the
-    // default case it is still considered to be last.
+    // Checks if the given index marks the last case in the given list of case statements (i.e. labels of the cases'
+    // jump targets). If the case is only followed by cases that target the default case it is still considered to be
+    // last.
     private static boolean isLastCase(int i, List<LabelNode> labelNodes, Label defaultLbl) {
         assert i < labelNodes.size() && i >= 0 : "Index was outside of the list of label nodes.";
         if (i == labelNodes.size() - 1 && !(labelNodes.get(i).getLabel() == defaultLbl)) {
@@ -231,8 +224,8 @@ public class JumpsConverter implements Converter {
             int key = switchNode.min + i;
             processCase(i, key, switchNode.labels, switchNode.dflt.getLabel(), neoMethod);
         }
-        // After handling the `TableSwitchInsnNode` the compiler can continue processing all the
-        // case branches in its `handleInsn(...)` method.
+        // After handling the `TableSwitchInsnNode` the compiler can continue processing all the case branches in its
+        // `handleInsn(...)` method.
     }
 
 }

--- a/compiler/src/main/java/io/neow3j/compiler/converters/ObjectsConverter.java
+++ b/compiler/src/main/java/io/neow3j/compiler/converters/ObjectsConverter.java
@@ -298,7 +298,7 @@ public class ObjectsConverter implements Converter {
                 break;
             case JMPIF:
             case JMPIF_L:
-                // JMPIF_L does not require a replacement.
+                // JMPIF and JMPIF_L do not require a replacement.
                 break;
             default:
                 throw new CompilerException("Could not handle jump condition. The compiler does not support hard " +

--- a/compiler/src/main/java/io/neow3j/compiler/converters/ObjectsConverter.java
+++ b/compiler/src/main/java/io/neow3j/compiler/converters/ObjectsConverter.java
@@ -268,27 +268,35 @@ public class ObjectsConverter implements Converter {
         NeoInstruction lastInstruction = neoMethod.getLastInstruction();
         neoMethod.removeLastInstruction();
         switch (lastInstruction.getOpcode()) {
+            case JMPEQ:
             case JMPEQ_L:
                 neoMethod.addInstruction(new NeoInstruction(OpCode.EQUAL));
                 break;
+            case JMPNE:
             case JMPNE_L:
                 neoMethod.addInstruction(new NeoInstruction(OpCode.NOTEQUAL));
                 break;
+            case JMPLT:
             case JMPLT_L:
                 neoMethod.addInstruction(new NeoInstruction(OpCode.LT));
                 break;
+            case JMPGT:
             case JMPGT_L:
                 neoMethod.addInstruction(new NeoInstruction(OpCode.GT));
                 break;
+            case JMPLE:
             case JMPLE_L:
                 neoMethod.addInstruction(new NeoInstruction(OpCode.LE));
                 break;
+            case JMPGE:
             case JMPGE_L:
                 neoMethod.addInstruction(new NeoInstruction(OpCode.GE));
                 break;
+            case JMPIFNOT:
             case JMPIFNOT_L:
                 neoMethod.addInstruction(new NeoInstruction(OpCode.NOT));
                 break;
+            case JMPIF:
             case JMPIF_L:
                 // JMPIF_L does not require a replacement.
                 break;

--- a/compiler/src/main/java/io/neow3j/compiler/converters/ObjectsConverter.java
+++ b/compiler/src/main/java/io/neow3j/compiler/converters/ObjectsConverter.java
@@ -262,7 +262,8 @@ public class ObjectsConverter implements Converter {
         // are in the following transpiled into corresponding NeoVM opcodes that just return 0 or 1.
         if (neoMethod.getInstructions().size() == 0) {
             throw new CompilerException(format("The method '%s' seems to hold a hard coded 'assert false' statement " +
-                    "or it throws an 'AssertionError'. The compiler does not support that.", neoMethod.getName()));
+                    "or it throws an 'AssertionError'. The compiler does not support that. Use 'Helper.abort()' " +
+                    "instead.", neoMethod.getName()));
         }
         NeoInstruction lastInstruction = neoMethod.getLastInstruction();
         neoMethod.removeLastInstruction();
@@ -292,8 +293,9 @@ public class ObjectsConverter implements Converter {
                 // JMPIF_L does not require a replacement.
                 break;
             default:
-                throw new CompilerException("Could not handle jump condition. Make sure not to hard code an 'assert " +
-                        "false' statement and to not throw an 'AssertionError'.");
+                throw new CompilerException("Could not handle jump condition. The compiler does not support hard " +
+                        "coded 'assert false' statements nor throwing an 'AssertionError'. Use 'Helper.abort()' " +
+                        "instead.");
         }
     }
 

--- a/compiler/src/main/java/io/neow3j/compiler/converters/ObjectsConverter.java
+++ b/compiler/src/main/java/io/neow3j/compiler/converters/ObjectsConverter.java
@@ -52,8 +52,8 @@ public class ObjectsConverter implements Converter {
     private static final String TOSTRING_METHOD_NAME = "toString";
 
     @Override
-    public AbstractInsnNode convert(AbstractInsnNode insn, NeoMethod neoMethod,
-            CompilationUnit compUnit) throws IOException {
+    public AbstractInsnNode convert(AbstractInsnNode insn, NeoMethod neoMethod, CompilationUnit compUnit)
+            throws IOException {
 
         JVMOpcode opcode = JVMOpcode.get(insn.getOpcode());
         switch (requireNonNull(opcode)) {
@@ -101,21 +101,20 @@ public class ObjectsConverter implements Converter {
         Type type = Type.getObjectType(typeInsn.desc);
         StackItemType stackItemType = Compiler.mapTypeToStackItemType(type);
         if (stackItemType.equals(StackItemType.BOOLEAN)) {
-            // The Boolean stack item almost never appears because bool values are usually
-            // represented as 0 and 1 valued integer stack items.
+            // The Boolean stack item almost never appears because bool values are usually represented as 0 and 1
+            // valued integer stack items.
             stackItemType = StackItemType.INTEGER;
         }
         if (stackItemType.equals(StackItemType.ANY)) {
-            throw new CompilerException(neoMethod, format("The type '%s' is not supported for " +
-                    "the instanceof operation.", getFullyQualifiedNameForInternalName(
-                    type.getInternalName())));
+            throw new CompilerException(neoMethod, format("The type '%s' is not supported for the instanceof " +
+                    "operation.", getFullyQualifiedNameForInternalName(type.getInternalName())));
         }
-        neoMethod.addInstruction(
-                new NeoInstruction(OpCode.ISTYPE, new byte[]{stackItemType.byteValue()}));
+        neoMethod.addInstruction(new NeoInstruction(OpCode.ISTYPE, new byte[]{stackItemType.byteValue()}));
     }
 
-    public static void addLoadStaticField(FieldInsnNode fieldInsn, NeoMethod neoMethod,
-            CompilationUnit compUnit) throws IOException {
+    public static void addLoadStaticField(FieldInsnNode fieldInsn, NeoMethod neoMethod, CompilationUnit compUnit)
+            throws IOException {
+
         int neoVmIdx = compUnit.getNeoModule().getContractVariable(fieldInsn, compUnit).getNeoIdx();
         neoMethod.addInstruction(buildStoreOrLoadVariableInsn(neoVmIdx, OpCode.LDSFLD));
     }
@@ -135,9 +134,10 @@ public class ObjectsConverter implements Converter {
 
         ClassNode ownerClassNode = getAsmClassForInternalName(typeInsn.desc, compUnit.getClassLoader());
         MethodInsnNode ctorMethodInsn = skipToCtorCall(typeInsn.getNext(), ownerClassNode);
-        MethodNode ctorMethod = getMethodNode(ctorMethodInsn, ownerClassNode).orElseThrow(() ->
-                new CompilerException(callingNeoMethod, format("Couldn't find constructor '%s' on class '%s'.",
-                        ctorMethodInsn.name, getClassNameForInternalName(ownerClassNode.name))));
+        MethodNode ctorMethod = getMethodNode(ctorMethodInsn, ownerClassNode)
+                .orElseThrow(() -> new CompilerException(callingNeoMethod,
+                        format("Couldn't find constructor '%s' on class '%s'.", ctorMethodInsn.name,
+                                getClassNameForInternalName(ownerClassNode.name))));
 
         // Annotations in struct constructors are ignored
         if (ctorMethod.invisibleAnnotations == null || ctorMethod.invisibleAnnotations.size() == 0) {
@@ -168,24 +168,27 @@ public class ObjectsConverter implements Converter {
                 : "Expected DUP after NEW but got other instructions";
 
         if (isNewStringBuilder(typeInsn)) {
-            // Java, in the background, performs String concatenation, like `s1 + s2`, with the
-            // instantiation of a StringBuilder. This is handled here.
+            // Java, in the background, performs String concatenation, like `s1 + s2`, with the instantiation of a
+            // StringBuilder. This is handled here.
             return handleStringConcatenation(typeInsn, callingNeoMethod, compUnit);
         }
 
-        if (isNewThrowable(typeInsn, compUnit)) {
-            return handleNewThrowable(typeInsn, callingNeoMethod, compUnit);
+        if (isAssertion(typeInsn, compUnit)) {
+            return handleAssertion(typeInsn, callingNeoMethod);
+        }
+
+        if (isNewException(typeInsn, compUnit)) {
+            return handleNewException(typeInsn, callingNeoMethod, compUnit);
         }
 
         ClassNode owner = getAsmClassForInternalName(typeInsn.desc, compUnit.getClassLoader());
         MethodInsnNode ctorMethodInsn = skipToCtorCall(typeInsn.getNext(), owner);
-        MethodNode ctorMethod = getMethodNode(ctorMethodInsn, owner).orElseThrow(() ->
-                new CompilerException(callingNeoMethod, format(
-                        "Couldn't find constructor '%s' on class '%s'.",
-                        ctorMethodInsn.name, getClassNameForInternalName(owner.name))));
+        MethodNode ctorMethod = getMethodNode(ctorMethodInsn, owner)
+                .orElseThrow(() -> new CompilerException(callingNeoMethod,
+                        format("Couldn't find constructor '%s' on class '%s'.", ctorMethodInsn.name,
+                                getClassNameForInternalName(owner.name))));
 
-        if (ctorMethod.invisibleAnnotations == null
-                || ctorMethod.invisibleAnnotations.size() == 0) {
+        if (ctorMethod.invisibleAnnotations == null || ctorMethod.invisibleAnnotations.size() == 0) {
             // It's a generic constructor without any Neo-specific annotations.
             return convertConstructorCall(typeInsn, ctorMethod, owner, callingNeoMethod, compUnit);
         } else { // The constructor has some Neo-specific annotation.
@@ -208,104 +211,137 @@ public class ObjectsConverter implements Converter {
         return typeInsn.desc.equals(getInternalName(StringBuilder.class));
     }
 
-    private static boolean isNewThrowable(TypeInsnNode typeInsn,
-            CompilationUnit compUnit) throws IOException {
-
+    private static boolean isAssertion(TypeInsnNode typeInsn, CompilationUnit compUnit) throws IOException {
         ClassNode type = getAsmClassForInternalName(typeInsn.desc, compUnit.getClassLoader());
-
-        if (getFullyQualifiedNameForInternalName(type.name).equals(
-                Throwable.class.getCanonicalName())) {
+        if (getFullyQualifiedNameForInternalName(type.name).equals(AssertionError.class.getCanonicalName())) {
             return true;
         }
         while (type.superName != null) {
             type = getAsmClassForInternalName(type.superName, compUnit.getClassLoader());
-            if (getFullyQualifiedNameForInternalName(type.name).equals(
-                    Throwable.class.getCanonicalName())) {
+            if (getFullyQualifiedNameForInternalName(type.name).equals(AssertionError.class.getCanonicalName())) {
                 return true;
             }
         }
         return false;
     }
 
-    private static AbstractInsnNode handleNewThrowable(TypeInsnNode typeInsn,
-            NeoMethod callingNeoMethod, CompilationUnit compUnit) throws IOException {
+    private static boolean isNewException(TypeInsnNode typeInsn, CompilationUnit compUnit) throws IOException {
+        ClassNode type = getAsmClassForInternalName(typeInsn.desc, compUnit.getClassLoader());
+        if (getFullyQualifiedNameForInternalName(type.name).equals(Exception.class.getCanonicalName())) {
+            return true;
+        }
+        while (type.superName != null) {
+            type = getAsmClassForInternalName(type.superName, compUnit.getClassLoader());
+            if (getFullyQualifiedNameForInternalName(type.name).equals(Exception.class.getCanonicalName())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static AbstractInsnNode handleAssertion(TypeInsnNode typeInsn, NeoMethod callingNeoMethod) {
+        convertJumpConditionBeforeAssertion(callingNeoMethod);
+
+        AbstractInsnNode insn = typeInsn.getNext().getNext();
+        while (!isCallToCtor(insn, Type.getType(AssertionError.class).getInternalName())) {
+            // Instructions between the type instruction and <init> method of the AssertionError can be ignored.
+            insn = insn.getNext();
+        }
+
+        Type[] argTypes = Type.getType(((MethodInsnNode) insn).desc).getArgumentTypes();
+        if (argTypes.length != 0) {
+            throw new CompilerException("Passing a message with the 'assert' statement is not supported.");
+        }
+        callingNeoMethod.addInstruction(new NeoInstruction(OpCode.ASSERT));
+        return insn.getNext(); // Skip the throw instruction.
+    }
+
+    private static void convertJumpConditionBeforeAssertion(NeoMethod neoMethod) {
+        // The JVM assert conditions are jump instructions to jump over the <init> instruction of AssertionError and
+        // potential additional instructions (e.g., a message). For the NeoVM ASSERT opcode, these jump instructions
+        // are in the following transpiled into corresponding NeoVM opcodes that just return 0 or 1.
+        if (neoMethod.getInstructions().size() == 0) {
+            throw new CompilerException(format("The method '%s' seems to hold a hard coded 'assert false' statement " +
+                    "or it throws an 'AssertionError'. The compiler does not support that.", neoMethod.getName()));
+        }
+        NeoInstruction lastInstruction = neoMethod.getLastInstruction();
+        neoMethod.removeLastInstruction();
+        switch (lastInstruction.getOpcode()) {
+            case JMPEQ_L:
+                neoMethod.addInstruction(new NeoInstruction(OpCode.EQUAL));
+                break;
+            case JMPNE_L:
+                neoMethod.addInstruction(new NeoInstruction(OpCode.NOTEQUAL));
+                break;
+            case JMPLT_L:
+                neoMethod.addInstruction(new NeoInstruction(OpCode.LT));
+                break;
+            case JMPGT_L:
+                neoMethod.addInstruction(new NeoInstruction(OpCode.GT));
+                break;
+            case JMPLE_L:
+                neoMethod.addInstruction(new NeoInstruction(OpCode.LE));
+                break;
+            case JMPGE_L:
+                neoMethod.addInstruction(new NeoInstruction(OpCode.GE));
+                break;
+            case JMPIFNOT_L:
+                neoMethod.addInstruction(new NeoInstruction(OpCode.NOT));
+                break;
+            case JMPIF_L:
+                // JMPIF_L does not require a replacement.
+                break;
+            default:
+                throw new CompilerException("Could not handle jump condition. Make sure not to hard code an 'assert " +
+                        "false' statement and to not throw an 'AssertionError'.");
+        }
+    }
+
+    private static AbstractInsnNode handleNewException(TypeInsnNode typeInsn, NeoMethod callingNeoMethod,
+            CompilationUnit compUnit) throws IOException {
 
         String fullyQualifiedExceptionName = getFullyQualifiedNameForInternalName(typeInsn.desc);
-        ThrowableType throwableType = getThrowableType(fullyQualifiedExceptionName);
-        if (throwableType.equals(ThrowableType.OTHER)) {
-            throw new CompilerException(callingNeoMethod, format("Contract uses exception of type" +
-                            " %s but only %s and %s are allowed.", fullyQualifiedExceptionName,
-                    Exception.class.getCanonicalName(), AssertionError.class.getCanonicalName()));
+        if (!fullyQualifiedExceptionName.equals(Exception.class.getCanonicalName())) {
+            throw new CompilerException(callingNeoMethod,
+                    format("Contract uses exception of type %s but only %s is allowed.", fullyQualifiedExceptionName,
+                            Exception.class.getCanonicalName()));
         }
         // Skip to the next instruction after DUP.
         AbstractInsnNode insn = typeInsn.getNext().getNext();
         // Process any instructions that come before the INVOKESPECIAL, e.g., a PUSHDATA insn.
-        while (!isCallToCtor(insn, Type.getType(Exception.class).getInternalName()) &&
-                !isCallToCtor(insn, Type.getType(AssertionError.class).getInternalName())) {
+        while (!isCallToCtor(insn, Type.getType(Exception.class).getInternalName())) {
             insn = handleInsn(insn, callingNeoMethod, compUnit);
             insn = insn.getNext();
         }
 
         Type[] argTypes = Type.getType(((MethodInsnNode) insn).desc).getArgumentTypes();
-        checkForInvalidExceptionArguments(argTypes, throwableType, callingNeoMethod);
-
-        if (argTypes.length == 0) {
+        if (argTypes.length > 1) {
+            throw new CompilerException(callingNeoMethod, format("An exception thrown in a contract can either take " +
+                    "no arguments or a String argument. You provided %d arguments.", argTypes.length));
+        } else if (argTypes.length == 1) {
+            if (!getFullyQualifiedNameForInternalName(argTypes[0].getInternalName())
+                    .equals(String.class.getCanonicalName())) {
+                // Only string messages are allowed in exceptions.
+                throw new CompilerException(callingNeoMethod, "An exception thrown in a contract can either take no " +
+                        "arguments or a String argument. You provided a non-string argument.");
+            }
+        } else {
             // No exception message is given, thus a dummy message is added.
             String dummyMessage = "error";
-            if (throwableType.equals(ThrowableType.ASSERTION)) {
-                dummyMessage = "assertion failed";
-            }
             callingNeoMethod.addInstruction(buildPushDataInsn(dummyMessage));
         }
         return insn;
     }
 
-    private static void checkForInvalidExceptionArguments(Type[] argTypes,
-            ThrowableType throwableType, NeoMethod callingNeoMethod) {
-
-        if (argTypes.length > 1) {
-            throw new CompilerException(callingNeoMethod, format("An exception thrown in a contract"
-                    + " can either take no arguments or a String argument. You provided %d "
-                    + "arguments.", argTypes.length));
-        }
-
-        // Only string messages are allowed in exceptions. In assert statements, this cannot
-        // be checked properly. Therefore, if an assertion message is not a string, it is
-        // ignored when converting it.
-        if (argTypes.length == 1 && !throwableType.equals(ThrowableType.ASSERTION) &&
-                !getFullyQualifiedNameForInternalName(argTypes[0].getInternalName())
-                        .equals(String.class.getCanonicalName())) {
-            throw new CompilerException(callingNeoMethod, "An exception thrown in a contract " +
-                    "can either take no arguments or a String argument. You provided a " +
-                    "non-string argument.");
-        }
-    }
-
-    private static ThrowableType getThrowableType(String fullyQualifiedExceptionName) {
-        if (Exception.class.getCanonicalName().equals(fullyQualifiedExceptionName)) {
-            return ThrowableType.EXCEPTION;
-        }
-        if (AssertionError.class.getCanonicalName().equals(fullyQualifiedExceptionName)) {
-            return ThrowableType.ASSERTION;
-        }
-        return ThrowableType.OTHER;
-    }
-
-    private enum ThrowableType {
-        EXCEPTION,
-        ASSERTION,
-        OTHER
-    }
-
     /**
-     * Handles the concatenation of strings, as in {@code "hello" + " world"}. Java in the
-     * background uses a StringBuilder for this.
+     * Handles the concatenation of strings, as in {@code "hello" + " world"}. Java in the background uses a
+     * StringBuilder for this.
      *
-     * @param typeInsnNode The NEW instruction concerning the StringBuilder.
+     * @param typeInsnNode the NEW instruction concerning the StringBuilder.
      * @return the last processed instruction.
      */
-    private static AbstractInsnNode handleStringConcatenation(TypeInsnNode typeInsnNode,
-            NeoMethod neoMethod, CompilationUnit compUnit) throws IOException {
+    private static AbstractInsnNode handleStringConcatenation(TypeInsnNode typeInsnNode, NeoMethod neoMethod,
+            CompilationUnit compUnit) throws IOException {
 
         // Skip to the next instruction after DUP and INVOKESPECIAL.
         AbstractInsnNode insn = typeInsnNode.getNext().getNext().getNext();
@@ -326,16 +362,15 @@ public class ObjectsConverter implements Converter {
                 break; // End of string concatenation.
             }
             if (isCallToAnyStringBuilderMethod(insn)) {
-                throw new CompilerException(neoMethod, format("Only 'append()' and 'toString()' "
-                                + "are supported for StringBuilder, but '%s' was called",
-                        ((MethodInsnNode) insn).name));
+                throw new CompilerException(neoMethod, format("Only 'append()' and 'toString()' are supported for " +
+                        "StringBuilder, but '%s' was called", ((MethodInsnNode) insn).name));
             }
             insn = handleInsn(insn, neoMethod, compUnit);
             insn = insn.getNext();
         }
         if (insn == null) {
-            throw new CompilerException(neoMethod, "Expected to find ScriptBuilder.toString() but "
-                    + "reached end of method.");
+            throw new CompilerException(neoMethod, "Expected to find ScriptBuilder.toString() but reached end of " +
+                    "method.");
         }
         return insn;
     }
@@ -457,26 +492,26 @@ public class ObjectsConverter implements Converter {
         List<NeoEvent> events = compUnit.getNeoModule().getEvents();
         NeoEvent event = events.stream()
                 .filter(e -> eventVariableName.equals(e.getAsmVariable().name))
-                .findFirst().orElseThrow(() -> new CompilerException(neoMethod, "Couldn't find " +
-                        "triggered event in list of events. Make sure to declare events only in" +
-                        " the main contract class."));
+                .findFirst()
+                .orElseThrow(() -> new CompilerException(neoMethod,
+                        "Couldn't find triggered event in list of events. Make sure to declare events only in the " +
+                                "main contract class."));
 
         AbstractInsnNode insn = eventFieldInsn.getNext();
         while (!isMethodCallToEventSend(insn, compUnit)) {
             insn = handleInsn(insn, neoMethod, compUnit);
             insn = insn.getNext();
-            assert insn != null : "Expected to find call to send() method of an event but reached"
-                    + " the end of the instructions.";
+            assert insn != null : "Expected to find call to send() method of an event but reached the end of the " +
+                    "instructions.";
         }
 
-        // The current instruction is the method call to Event.send(...). We can pack the arguments
-        // and do the syscall instead of actually calling the send(...) method.
+        // The current instruction is the method call to Event.send(...). We can pack the arguments and do the
+        // syscall instead of actually calling the send(...) method.
         addReverseArguments(neoMethod, event.getNumberOfParams());
         addPushNumber(event.getNumberOfParams(), neoMethod);
         neoMethod.addInstruction(new NeoInstruction(OpCode.PACK));
         neoMethod.addInstruction(buildPushDataInsn(event.getDisplayName()));
-        byte[] syscallHash = Numeric.hexStringToByteArray(
-                InteropService.SYSTEM_RUNTIME_NOTIFY.getHash());
+        byte[] syscallHash = Numeric.hexStringToByteArray(InteropService.SYSTEM_RUNTIME_NOTIFY.getHash());
         neoMethod.addInstruction(new NeoInstruction(OpCode.SYSCALL, syscallHash));
         return insn;
     }

--- a/compiler/src/test-integration/java/io/neow3j/compiler/AssertionIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/AssertionIntegrationTest.java
@@ -2,6 +2,7 @@ package io.neow3j.compiler;
 
 import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.Runtime;
+import io.neow3j.devpack.contracts.StdLib;
 import io.neow3j.protocol.core.response.InvocationResult;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.types.NeoVMStateType;
@@ -195,6 +196,22 @@ public class AssertionIntegrationTest {
         assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
     }
 
+    @Test
+    public void testComplexAssertion() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName,
+                string("string"), string("string"), integer(5), string("5"), bool(false));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+        response = ct.callInvokeFunction(testName,
+                string("string"), string("not-string"), integer(42), string("5"), bool(true));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+        response = ct.callInvokeFunction(testName,
+                string("hello" + ", world!"), string("not-string"), integer(1), string("5"), bool(false));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+        response = ct.callInvokeFunction(testName,
+                string("string"), string("not-string"), integer(1), string("1"), bool(true));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+    }
+
     static class AssertionTestContract {
 
         public static int VAR = 42;
@@ -250,6 +267,10 @@ public class AssertionIntegrationTest {
 
         public static void testIF(boolean b) {
             assert b;
+        }
+
+        public static void testComplexAssertion(String a, String b, Integer i, String n, boolean c) {
+            assert a == b && i == StdLib.atoi(n, 10) || i == 42 && c || a == getString();
         }
 
     }

--- a/compiler/src/test-integration/java/io/neow3j/compiler/AssertionIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/AssertionIntegrationTest.java
@@ -4,6 +4,7 @@ import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.Runtime;
 import io.neow3j.protocol.core.response.InvocationResult;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
+import io.neow3j.types.NeoVMStateType;
 import io.neow3j.wallet.Account;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -13,15 +14,20 @@ import org.junit.rules.TestName;
 import java.io.IOException;
 
 import static io.neow3j.transaction.AccountSigner.calledByEntry;
+import static io.neow3j.types.ContractParameter.bool;
 import static io.neow3j.types.ContractParameter.hash160;
 import static io.neow3j.types.ContractParameter.integer;
+import static io.neow3j.types.ContractParameter.string;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
-import static org.junit.Assert.assertFalse;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class AssertionIntegrationTest {
+
+    private static final String NEOVM_FAILED_ASSERT_MESSAGE = "ASSERT is executed with false result.";
 
     @Rule
     public TestName testName = new TestName();
@@ -31,14 +37,13 @@ public class AssertionIntegrationTest {
 
     @Test
     public void testAssertion() throws IOException {
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, integer(11));
-        InvocationResult result = response.getInvocationResult();
-        assertTrue(result.hasStateFault());
-        assertThat(result.getException(), containsString("assertion failed"));
+        InvocationResult result = ct.callInvokeFunction(testName, integer(17)).getInvocationResult();
+        assertThat(result.getState(), is(NeoVMStateType.HALT));
+        assertNull(result.getException());
 
-        response = ct.callInvokeFunction(testName, integer(17));
-        result = response.getInvocationResult();
-        assertFalse(result.hasStateFault());
+        result = ct.callInvokeFunction(testName, integer(18)).getInvocationResult();
+        assertThat(result.getState(), is(NeoVMStateType.FAULT));
+        assertThat(result.getException(), is(NEOVM_FAILED_ASSERT_MESSAGE));
     }
 
     @Test
@@ -46,44 +51,148 @@ public class AssertionIntegrationTest {
         NeoInvokeFunction response = ct.callInvokeFunction(testName, integer(100));
         InvocationResult result = response.getInvocationResult();
         assertTrue(result.hasStateFault());
-        assertThat(result.getException(), containsString("neoowww"));
+        assertThat(result.getException(), is(NEOVM_FAILED_ASSERT_MESSAGE));
 
         response = ct.callInvokeFunction(testName, integer(42));
         result = response.getInvocationResult();
-        assertFalse(result.hasStateFault());
-        assertTrue(result.getStack().get(0).getBoolean());
+        assertThat(result.getState(), is(NeoVMStateType.HALT));
     }
 
     @Test
     public void testWitnessCheck() throws Throwable {
         Account a = Account.fromWIF("L4NH7MLEdnX6u8vGx1qTLnuE9Aa5ovKcrVtUQfhyksqcAwZ4Xfto");
-        NeoInvokeFunction response = ct.getContract()
-                .callInvokeFunction(testName.getMethodName(), asList(hash160(a)),
-                        calledByEntry(Account.create()));
+        NeoInvokeFunction response = ct.getContract().callInvokeFunction(
+                testName.getMethodName(),
+                asList(hash160(a)),
+                calledByEntry(Account.create()));
         InvocationResult result = response.getInvocationResult();
         assertTrue(result.hasStateFault());
-        assertThat(result.getException(), containsString("No authorization!"));
+        assertThat(result.getException(), is(NEOVM_FAILED_ASSERT_MESSAGE));
 
-        response = ct.getContract()
-                .callInvokeFunction(testName.getMethodName(), asList(hash160(a)), calledByEntry(a));
+        response = ct.getContract().callInvokeFunction(
+                testName.getMethodName(),
+                asList(hash160(a)),
+                calledByEntry(a));
         result = response.getInvocationResult();
-        assertFalse(result.hasStateFault());
+        assertThat(result.getState(), is(NeoVMStateType.HALT));
     }
 
     @Test
-    public void testWitnessCheckWithErrorMessageFromMethod() throws Throwable {
-        Account a = Account.fromWIF("L4NH7MLEdnX6u8vGx1qTLnuE9Aa5ovKcrVtUQfhyksqcAwZ4Xfto");
-        NeoInvokeFunction response = ct.getContract()
-                .callInvokeFunction(testName.getMethodName(), asList(hash160(a)),
-                        calledByEntry(Account.create()));
-        InvocationResult result = response.getInvocationResult();
-        assertTrue(result.hasStateFault());
-        assertThat(result.getException(), containsString("hello, world!"));
+    public void testAssertionWithMethod() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, string("hello, world!"));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
 
-        response = ct.getContract()
-                .callInvokeFunction(testName.getMethodName(), asList(hash160(a)), calledByEntry(a));
-        result = response.getInvocationResult();
-        assertFalse(result.hasStateFault());
+        response = ct.callInvokeFunction(testName, string("hello world"));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+        assertThat(response.getInvocationResult().getException(), containsString(NEOVM_FAILED_ASSERT_MESSAGE));
+    }
+
+    @Test
+    public void testEQ() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, integer(41));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, integer(42));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, integer(41));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, integer(43));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+    }
+
+    @Test
+    public void testNE() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, integer(41));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, integer(42));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, integer(41));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, integer(43));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+    }
+
+    @Test
+    public void testLT() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, integer(40));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, integer(41));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, integer(42));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, integer(43));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+    }
+
+    @Test
+    public void testGT() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, integer(41));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, integer(42));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, integer(43));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, integer(44));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+    }
+
+    @Test
+    public void testLE() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, integer(41));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, integer(42));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, integer(43));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, integer(44));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+    }
+
+    @Test
+    public void testGE() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, integer(40));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, integer(41));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, integer(42));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, integer(43));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+    }
+
+    @Test
+    public void testIFNOT() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, bool(false));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+
+        response = ct.callInvokeFunction(testName, bool(true));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+    }
+
+    @Test
+    public void testIF() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, bool(false));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+
+        response = ct.callInvokeFunction(testName, bool(true));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
     }
 
     static class AssertionTestContract {
@@ -95,21 +204,54 @@ public class AssertionIntegrationTest {
         }
 
         public static boolean testAssertionWithStaticVar(int i) {
-            assert VAR == i : "neoowww";
+            assert VAR == i;
             return true;
         }
 
         public static void testWitnessCheck(Hash160 witness) {
-            assert Runtime.checkWitness(witness) : "No authorization!";
+            assert Runtime.checkWitness(witness);
         }
 
-        public static void testWitnessCheckWithErrorMessageFromMethod(Hash160 witness) {
-            assert Runtime.checkWitness(witness) : getString();
+        public static void testAssertionWithMethod(String value) {
+            assert value == getString();
         }
 
         private static String getString() {
             return "hello" + ", world!";
         }
+
+        public static void testEQ(int i) {
+            assert i == VAR;
+        }
+
+        public static void testNE(int i) {
+            assert i != VAR;
+        }
+
+        public static void testLT(int i) {
+            assert i < VAR;
+        }
+
+        public static void testGT(int i) {
+            assert i > VAR;
+        }
+
+        public static void testLE(int i) {
+            assert i <= VAR;
+        }
+
+        public static void testGE(int i) {
+            assert i >= VAR;
+        }
+
+        public static void testIFNOT(boolean b) {
+            assert !b;
+        }
+
+        public static void testIF(boolean b) {
+            assert b;
+        }
+
     }
 
 }

--- a/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/ECPointIntegrationTest.java
@@ -4,7 +4,6 @@ import io.neow3j.protocol.core.stackitem.StackItem;
 import io.neow3j.devpack.ByteString;
 import io.neow3j.devpack.ECPoint;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
-import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -17,6 +16,7 @@ import static io.neow3j.devpack.StringLiteralHelper.hexToBytes;
 import static io.neow3j.types.ContractParameter.byteArray;
 import static io.neow3j.types.ContractParameter.integer;
 import static io.neow3j.types.ContractParameter.publicKey;
+import static io.neow3j.utils.Numeric.hexStringToByteArray;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -28,23 +28,20 @@ public class ECPointIntegrationTest {
     public TestName testName = new TestName();
 
     @ClassRule
-    public static ContractTestRule ct = new ContractTestRule(
-            ECPointIntegrationTestContract.class.getName());
+    public static ContractTestRule ct = new ContractTestRule(ECPointIntegrationTestContract.class.getName());
 
     @Test
     public void createECPointFromByteArray() throws IOException {
         String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(publicKey));
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(publicKey));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(publicKey));
     }
 
     @Test
     public void createECPointFromString() throws IOException {
         String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(publicKey));
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(publicKey));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(publicKey));
     }
 
     @Test
@@ -54,8 +51,8 @@ public class ECPointIntegrationTest {
         String invalidPubKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e1368";
         int otherValue = 123456;
 
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validPubKey),
-                byteArray(invalidPubKey), integer(otherValue));
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validPubKey), byteArray(invalidPubKey),
+                integer(otherValue));
         List<StackItem> array = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(array.get(0).getBoolean());
         assertFalse(array.get(1).getBoolean());
@@ -68,15 +65,14 @@ public class ECPointIntegrationTest {
         String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, publicKey(publicKey));
         assertThat(response.getInvocationResult().getStack().get(0).getByteArray(),
-                is(Numeric.hexStringToByteArray(publicKey)));
+                is(hexStringToByteArray(publicKey)));
     }
 
     @Test
     public void ecPointAsByteString() throws IOException {
         String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, publicKey(publicKey));
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(publicKey));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(publicKey));
     }
 
     @Test
@@ -84,14 +80,14 @@ public class ECPointIntegrationTest {
         String publicKey = "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816";
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
         assertThat(response.getInvocationResult().getStack().get(0).getByteArray(),
-                is(Numeric.hexStringToByteArray(publicKey)));
+                is(hexStringToByteArray(publicKey)));
     }
 
     static class ECPointIntegrationTestContract {
 
         public static ECPoint createECPointFromByteArray(ByteString b) {
             byte[] buffer = b.toByteArray();
-            assert buffer instanceof byte[] : "Value is not of type buffer.";
+            assert buffer instanceof byte[];
             return new ECPoint(buffer);
         }
 
@@ -99,8 +95,7 @@ public class ECPointIntegrationTest {
             return new ECPoint(s);
         }
 
-        public static boolean[] isObjectValidECPoint(Object validECPoint, Object invalidECPoint,
-                Object integer) {
+        public static boolean[] isObjectValidECPoint(Object validECPoint, Object invalidECPoint, Object integer) {
             boolean[] b = new boolean[4];
             b[0] = ECPoint.isValid(validECPoint);
             b[1] = ECPoint.isValid(invalidECPoint);
@@ -111,22 +106,23 @@ public class ECPointIntegrationTest {
         }
 
         public static byte[] ecPointToByteArrayFromStringLiteral() {
-            ECPoint point = new ECPoint(hexToBytes(
-                    "03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816"));
+            ECPoint point = new ECPoint(
+                    hexToBytes("03b4af8d061b6b320cce6c63bc4ec7894dce107bfc5f5ef5c68a93b4ad1e136816"));
             byte[] pointBuffer = point.toByteArray();
-            assert pointBuffer instanceof byte[] : "Value is not of type buffer.";
+            assert pointBuffer instanceof byte[];
             return pointBuffer;
         }
 
         public static byte[] ecPointToByteArray(ECPoint ecPoint) {
             byte[] pointBuffer = ecPoint.toByteArray();
-            assert pointBuffer instanceof byte[] : "Value is not of type buffer.";
+            assert pointBuffer instanceof byte[];
             return pointBuffer;
         }
 
         public static ByteString ecPointAsByteString(ECPoint ecPoint) {
             return ecPoint.toByteString();
         }
+
     }
 
 }

--- a/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/HashIntegrationTest.java
@@ -6,7 +6,6 @@ import io.neow3j.devpack.Hash256;
 import io.neow3j.devpack.StringLiteralHelper;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.stackitem.StackItem;
-import io.neow3j.utils.Numeric;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
@@ -19,6 +18,8 @@ import static io.neow3j.types.ContractParameter.byteArray;
 import static io.neow3j.types.ContractParameter.hash160;
 import static io.neow3j.types.ContractParameter.hash256;
 import static io.neow3j.types.ContractParameter.integer;
+import static io.neow3j.utils.Numeric.hexStringToByteArray;
+import static io.neow3j.utils.Numeric.reverseHexString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertFalse;
@@ -30,23 +31,20 @@ public class HashIntegrationTest {
     public TestName testName = new TestName();
 
     @ClassRule
-    public static ContractTestRule ct = new ContractTestRule(
-            HashIntegrationTestContract.class.getName());
+    public static ContractTestRule ct = new ContractTestRule(HashIntegrationTestContract.class.getName());
 
     @Test
     public void getZeroHash160() throws IOException {
         String zeroHash = "0000000000000000000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(zeroHash));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(zeroHash));
     }
 
     @Test
     public void isHash160Zero() throws IOException {
         Hash160 zeroHash = new Hash160("0000000000000000000000000000000000000000");
         Hash160 nonZeroHash = new Hash160("0000000000000000000000000000000000000001");
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, hash160(zeroHash),
-                hash160(nonZeroHash));
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, hash160(zeroHash), hash160(nonZeroHash));
         List<StackItem> array = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(array.get(0).getBoolean());
         assertFalse(array.get(1).getBoolean());
@@ -57,8 +55,8 @@ public class HashIntegrationTest {
         String validHash = "0000000000000000000000000000000000000001";
         String invalidHash = "00000000000000000000000000000000000001"; // One byte short.
         int otherValue = 10;
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validHash),
-                byteArray(invalidHash), integer(otherValue));
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validHash), byteArray(invalidHash),
+                integer(otherValue));
         List<StackItem> array = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(array.get(0).getBoolean());
         assertFalse(array.get(1).getBoolean());
@@ -70,24 +68,21 @@ public class HashIntegrationTest {
     public void createHash160FromByteArray() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(hash));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(hash));
     }
 
     @Test
     public void createHash160FromString() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(hash));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(hash));
     }
 
     @Test
     public void hash160ToByteArray() throws IOException {
         Hash160 hash = new Hash160("03b4af8d061b6b320cce6c63bc4ec7894dce107b");
         NeoInvokeFunction response = ct.callInvokeFunction(testName, hash160(hash));
-        assertThat(response.getInvocationResult().getStack().get(0).getAddress(),
-                is(hash.toAddress()));
+        assertThat(response.getInvocationResult().getStack().get(0).getAddress(), is(hash.toAddress()));
     }
 
     @Test
@@ -95,23 +90,21 @@ public class HashIntegrationTest {
         Hash160 hash = new Hash160("03b4af8d061b6b320cce6c63bc4ec7894dce107b");
         NeoInvokeFunction response = ct.callInvokeFunction(testName, hash160(hash));
         assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(Numeric.reverseHexString(hash.toString())));
+                is(reverseHexString(hash.toString())));
     }
 
     @Test
     public void getZeroHash256() throws IOException {
         String zeroHash = "0000000000000000000000000000000000000000000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName);
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(zeroHash));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(zeroHash));
     }
 
     @Test
     public void isHash256Zero() throws IOException {
         String zeroHash = "0000000000000000000000000000000000000000000000000000000000000000";
         String nonZeroHash = "0000000000000000000000000000000000000000000000000000000000000001";
-        NeoInvokeFunction response =
-                ct.callInvokeFunction(testName, hash256(zeroHash), hash256(nonZeroHash));
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, hash256(zeroHash), hash256(nonZeroHash));
         List<StackItem> array = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(array.get(0).getBoolean());
         assertFalse(array.get(1).getBoolean());
@@ -123,8 +116,8 @@ public class HashIntegrationTest {
         // One byte too short.
         String invalidHash = "00000000000000000000000000000000000000000000000000000000000001";
         int otherValue = 10;
-        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validHash),
-                byteArray(invalidHash), integer(otherValue));
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(validHash), byteArray(invalidHash),
+                integer(otherValue));
         List<StackItem> array = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(array.get(0).getBoolean());
         assertFalse(array.get(1).getBoolean());
@@ -136,16 +129,14 @@ public class HashIntegrationTest {
     public void createHash256FromByteArray() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(hash));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(hash));
     }
 
     @Test
     public void createHash256FromString() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, byteArray(hash));
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(hash));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(hash));
     }
 
     @Test
@@ -153,15 +144,14 @@ public class HashIntegrationTest {
         String hash256 = "03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, hash256(hash256));
         assertThat(response.getInvocationResult().getStack().get(0).getByteArray(),
-                is(Numeric.hexStringToByteArray(Numeric.reverseHexString(hash256))));
+                is(hexStringToByteArray(reverseHexString(hash256))));
     }
 
     @Test
     public void hash256ToString() throws IOException {
         String hash = "03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000";
         NeoInvokeFunction response = ct.callInvokeFunction(testName, hash256(hash));
-        assertThat(response.getInvocationResult().getStack().get(0).getHexString(),
-                is(Numeric.reverseHexString(hash)));
+        assertThat(response.getInvocationResult().getStack().get(0).getHexString(), is(reverseHexString(hash)));
     }
 
     @Test
@@ -184,16 +174,14 @@ public class HashIntegrationTest {
             return io.neow3j.devpack.Hash160.zero();
         }
 
-        public static boolean[] isHash160Zero(io.neow3j.devpack.Hash160 hash1,
-                io.neow3j.devpack.Hash160 hash2) {
+        public static boolean[] isHash160Zero(io.neow3j.devpack.Hash160 hash1, io.neow3j.devpack.Hash160 hash2) {
             boolean[] b = new boolean[2];
             b[0] = hash1.isZero();
             b[1] = hash2.isZero();
             return b;
         }
 
-        public static boolean[] isObjectValidHash160(Object validHash, Object invalidHash,
-                Object integer) {
+        public static boolean[] isObjectValidHash160(Object validHash, Object invalidHash, Object integer) {
             boolean[] b = new boolean[4];
             b[0] = io.neow3j.devpack.Hash160.isValid(validHash);
             b[1] = io.neow3j.devpack.Hash160.isValid(invalidHash);
@@ -205,7 +193,7 @@ public class HashIntegrationTest {
 
         public static io.neow3j.devpack.Hash160 createHash160FromByteArray(ByteString b) {
             byte[] buffer = b.toByteArray();
-            assert buffer instanceof byte[] : "Value is not of type buffer.";
+            assert buffer instanceof byte[];
             return new io.neow3j.devpack.Hash160(buffer);
         }
 
@@ -232,8 +220,7 @@ public class HashIntegrationTest {
             return b;
         }
 
-        public static boolean[] isObjectValidHash256(Object validHash, Object invalidHash,
-                Object integer) {
+        public static boolean[] isObjectValidHash256(Object validHash, Object invalidHash, Object integer) {
             boolean[] b = new boolean[4];
             b[0] = io.neow3j.devpack.Hash256.isValid(validHash);
             b[1] = io.neow3j.devpack.Hash256.isValid(invalidHash);
@@ -245,7 +232,7 @@ public class HashIntegrationTest {
 
         public static Hash256 createHash256FromByteArray(ByteString b) {
             byte[] buffer = b.toByteArray();
-            assert buffer instanceof byte[] : "Value is not of type buffer.";
+            assert buffer instanceof byte[];
             return new Hash256(buffer);
         }
 
@@ -262,13 +249,13 @@ public class HashIntegrationTest {
         }
 
         public static io.neow3j.devpack.Hash160 hash160FromStringLiteral() {
-            return new io.neow3j.devpack.Hash160(StringLiteralHelper.hexToBytes(
-                    "03b4af8d061b6b320cce6c63bc4ec7894dce107b"));
+            return new io.neow3j.devpack.Hash160(
+                    StringLiteralHelper.hexToBytes("03b4af8d061b6b320cce6c63bc4ec7894dce107b"));
         }
 
         public static Hash256 hash256FromStringLiteral() {
-            return new Hash256(StringLiteralHelper.hexToBytes(
-                    "03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000"));
+            return new Hash256(
+                    StringLiteralHelper.hexToBytes("03b4af8d061b6b320cce6c63bc4ec7894dce107b000000000000000000000000"));
         }
     }
 

--- a/compiler/src/test-integration/java/io/neow3j/compiler/TryCatchBlocksTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/TryCatchBlocksTest.java
@@ -19,6 +19,8 @@ import static org.junit.Assert.assertTrue;
 
 public class TryCatchBlocksTest {
 
+    private static final String NEOVM_FAILED_ASSERT_MESSAGE = "ASSERT is executed with false result.";
+
     @Rule
     public TestName testName = new TestName();
 
@@ -81,8 +83,7 @@ public class TryCatchBlocksTest {
 
     @Test
     public void hitFirstExceptionInMultipleTryCatchFinallyBlocks() throws IOException {
-        NeoInvokeFunction response = ct.callInvokeFunction("multipleTryCatchFinallyBlocks",
-                integer(1), integer(0));
+        NeoInvokeFunction response = ct.callInvokeFunction("multipleTryCatchFinallyBlocks", integer(1), integer(0));
         List<StackItem> res = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(res.get(0).getBoolean());
         assertFalse(res.get(1).getBoolean());
@@ -95,15 +96,13 @@ public class TryCatchBlocksTest {
 
     @Test
     public void hitSecondExceptionInMultipleTryCatchFinallyBlocks() throws IOException {
-        NeoInvokeFunction response = ct.callInvokeFunction("multipleTryCatchFinallyBlocks",
-                integer(0), integer(1));
+        NeoInvokeFunction response = ct.callInvokeFunction("multipleTryCatchFinallyBlocks", integer(0), integer(1));
         assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
     }
 
     @Test
     public void dontHitAnyExceptionsInMultipleTryCatchFinallyBlocks() throws IOException {
-        NeoInvokeFunction response = ct.callInvokeFunction("multipleTryCatchFinallyBlocks",
-                integer(0), integer(0));
+        NeoInvokeFunction response = ct.callInvokeFunction("multipleTryCatchFinallyBlocks", integer(0), integer(0));
         List<StackItem> res = response.getInvocationResult().getStack().get(0).getList();
         assertFalse(res.get(0).getBoolean());
         assertTrue(res.get(1).getBoolean());
@@ -116,9 +115,7 @@ public class TryCatchBlocksTest {
 
     @Test
     public void hitFirstExceptionInNestedTryCatchFinallyBlocks() throws IOException {
-        NeoInvokeFunction response =
-                ct.callInvokeFunction("nestedTryCatchFinallyBlocks", integer(1),
-                        integer(0));
+        NeoInvokeFunction response = ct.callInvokeFunction("nestedTryCatchFinallyBlocks", integer(1), integer(0));
         List<StackItem> res = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(res.get(0).getBoolean());
         assertFalse(res.get(1).getBoolean());
@@ -133,9 +130,7 @@ public class TryCatchBlocksTest {
 
     @Test
     public void hitSecondExceptionInNestedTryCatchBlocks() throws IOException {
-        NeoInvokeFunction response =
-                ct.callInvokeFunction("nestedTryCatchFinallyBlocks", integer(0),
-                        integer(1));
+        NeoInvokeFunction response = ct.callInvokeFunction("nestedTryCatchFinallyBlocks", integer(0), integer(1));
         List<StackItem> res = response.getInvocationResult().getStack().get(0).getList();
         assertFalse(res.get(0).getBoolean());
         assertTrue(res.get(1).getBoolean());
@@ -150,9 +145,7 @@ public class TryCatchBlocksTest {
 
     @Test
     public void hitNoExceptionsInNestedTryCatchBlocks() throws IOException {
-        NeoInvokeFunction response =
-                ct.callInvokeFunction("nestedTryCatchFinallyBlocks", integer(0),
-                        integer(0));
+        NeoInvokeFunction response = ct.callInvokeFunction("nestedTryCatchFinallyBlocks", integer(0), integer(0));
         List<StackItem> res = response.getInvocationResult().getStack().get(0).getList();
         assertFalse(res.get(0).getBoolean());
         assertTrue(res.get(1).getBoolean());
@@ -185,8 +178,7 @@ public class TryCatchBlocksTest {
 
     @Test
     public void hitExceptionInNestedBlockInCatch() throws IOException {
-        NeoInvokeFunction response = ct.callInvokeFunction("nestedBlockInCatch",
-                integer(1), integer(1));
+        NeoInvokeFunction response = ct.callInvokeFunction("nestedBlockInCatch", integer(1), integer(1));
         List<StackItem> res = response.getInvocationResult().getStack().get(0).getList();
         assertFalse(res.get(0).getBoolean());
         assertTrue(res.get(1).getBoolean());
@@ -197,8 +189,7 @@ public class TryCatchBlocksTest {
 
     @Test
     public void dontHitExceptionsInNestedBlockInCatch() throws IOException {
-        NeoInvokeFunction response = ct.callInvokeFunction("nestedBlockInCatch",
-                integer(1), integer(0));
+        NeoInvokeFunction response = ct.callInvokeFunction("nestedBlockInCatch", integer(1), integer(0));
         List<StackItem> res = response.getInvocationResult().getStack().get(0).getList();
         assertTrue(res.get(0).getBoolean());
         assertFalse(res.get(1).getBoolean());
@@ -236,17 +227,14 @@ public class TryCatchBlocksTest {
     }
 
     @Test
-    public void getCaughtAssertionMessage() throws IOException {
-        NeoInvokeFunction response = ct.callInvokeFunction(testName);
-        StackItem res = response.getInvocationResult().getStack().get(0);
-        assertThat(res.getString(), is("Assert not passed."));
-    }
+    public void tryToCatchAssertion() throws IOException {
+        NeoInvokeFunction response = ct.callInvokeFunction(testName, integer(11));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.FAULT));
+        assertThat(response.getInvocationResult().getException(), is(NEOVM_FAILED_ASSERT_MESSAGE));
 
-    @Test
-    public void getCaughtAssertionMessageInAssertionError() throws IOException {
-        NeoInvokeFunction response = ct.callInvokeFunction(testName);
-        StackItem res = response.getInvocationResult().getStack().get(0);
-        assertThat(res.getString(), is("Assertion not passed."));
+        response = ct.callInvokeFunction(testName, integer(12));
+        assertThat(response.getInvocationResult().getState(), is(NeoVMStateType.HALT));
+        assertThat(response.getInvocationResult().getStack().get(0).getString(), is("neoww"));
     }
 
     static class TryCatchBlocks {
@@ -368,7 +356,7 @@ public class TryCatchBlocksTest {
             }
         }
 
-        public static boolean[] nestedBlockInCatch(int i, int j) throws Exception {
+        public static boolean[] nestedBlockInCatch(int i, int j) {
             boolean[] b = new boolean[5];
             try {
                 if (i == 1) {
@@ -428,22 +416,15 @@ public class TryCatchBlocksTest {
             }
         }
 
-        public static String getCaughtAssertionMessage() {
+        public static String tryToCatchAssertion(int i) {
             try {
-                assert false : "Assert not passed.";
+                assert i == 12;
             } catch (Exception e) {
                 return e.getMessage();
             }
-            return "";
-        }
-
-        public static String getCaughtAssertionMessageInAssertionError() {
-            try {
-                throw new AssertionError("Assertion not passed.");
-            } catch (Exception e) {
-                return e.getMessage();
-            }
+            return "neoww";
         }
 
     }
+
 }

--- a/compiler/src/test/java/io/neow3j/compiler/AssertionTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/AssertionTest.java
@@ -16,9 +16,10 @@ import static org.junit.Assert.assertThrows;
 public class AssertionTest {
 
     private static final String NO_INSN_BEFORE_ASSERTION_MSG = " seems to hold a hard coded 'assert false' statement " +
-            "or it throws an 'AssertionError'. The compiler does not support that.";
-    private static final String UNSUPPORTED_JUMP_CONDITION_CONVERSION_MSG = "Could not handle jump condition. Make " +
-            "sure not to hard code an 'assert false' statement and to not throw an 'AssertionError'.";
+            "or it throws an 'AssertionError'. The compiler does not support that. Use 'Helper.abort()' instead.";
+    private static final String UNSUPPORTED_JUMP_CONDITION_CONVERSION_MSG = "Could not handle jump condition. The " +
+            "compiler does not support hard coded 'assert false' statements nor throwing an 'AssertionError'. Use " +
+            "'Helper.abort()' instead.";
 
     @Test
     public void testInitsslotOnlyAssertionInstructions() throws IOException {

--- a/core/src/main/java/io/neow3j/script/OpCode.java
+++ b/core/src/main/java/io/neow3j/script/OpCode.java
@@ -7,8 +7,7 @@ import java.lang.annotation.Annotation;
 /**
  * This enum contains a <b>subset</b> of NEO VM opcodes.
  * <p>
- * See <a href="https://github.com/neo-project/neo-vm/blob/master/src/neo-vm/OpCode.cs">here</a> for
- * a complete list.
+ * See <a href="https://github.com/neo-project/neo-vm/blob/master/src/neo-vm/OpCode.cs">here</a> for a complete list.
  */
 public enum OpCode {
 
@@ -415,7 +414,7 @@ public enum OpCode {
     XDROP(0x48, 1 << 4),
 
     /**
-     * Clear the stack
+     * Clears the stack.
      */
     CLEAR(0x49, 1 << 4),
 
@@ -776,7 +775,7 @@ public enum OpCode {
 //region Bitwise logic
 
     /**
-     * Flips all of the bits in the input.
+     * Flips all bits in the input.
      */
     INVERT(0x90, 1 << 2),
 
@@ -931,12 +930,12 @@ public enum OpCode {
     GE(0xB8, 1 << 3),
 
     /**
-     * Returns the smaller of a and b.
+     * Returns the smallest of a and b.
      */
     MIN(0xB9, 1 << 3),
 
     /**
-     * Returns the larger of a and b.
+     * Returns the largest of a and b.
      */
     MAX(0xBA, 1 << 3),
 
@@ -1129,8 +1128,7 @@ public enum OpCode {
                 return c;
             }
         }
-        throw new IllegalArgumentException("No Opcode found for byte value " +
-                Numeric.toHexString(code) + ".");
+        throw new IllegalArgumentException("No Opcode found for byte value " + Numeric.toHexString(code) + ".");
     }
 
     @Override


### PR DESCRIPTION
Closes #744.

The use of Java's `assert` statement is refactored, so that it is now handled as the equivalent of the NeoVM's opcode `ASSERT`.

Further:
- Messages can no longer be added to the `assert` statement, since NeoVM's `ASSERT` does not consume a message. The compiler throws a `CompilerException` if a message exists.
- A hard coded `assert false` statement or throwing a `new AssertionError()` results in a `CompilerException`.