### PR TITLE
Fix handling of branch number in string switch-case compilation

### DIFF
--- a/compiler/src/main/java/io/neow3j/compiler/converters/MethodsConverter.java
+++ b/compiler/src/main/java/io/neow3j/compiler/converters/MethodsConverter.java
@@ -432,11 +432,9 @@ public class MethodsConverter implements Converter {
     private static int extractBranchNumber(AbstractInsnNode insn, NeoMethod neoMethod) {
         if (insn instanceof InsnNode) {
             return insn.getOpcode() - 3;
-        }
-        if (insn instanceof IntInsnNode) {
+        } else {
             return ((IntInsnNode) insn).operand;
         }
-        throw new CompilerException(neoMethod, "Unexpected instruction in branch of a switch-case.");
     }
 
     // Checks if the given instruction is a method call to the `String.equals()` method.

--- a/compiler/src/main/java/io/neow3j/compiler/converters/MethodsConverter.java
+++ b/compiler/src/main/java/io/neow3j/compiler/converters/MethodsConverter.java
@@ -25,6 +25,7 @@ import org.objectweb.asm.tree.AbstractInsnNode;
 import org.objectweb.asm.tree.AnnotationNode;
 import org.objectweb.asm.tree.ClassNode;
 import org.objectweb.asm.tree.InsnNode;
+import org.objectweb.asm.tree.IntInsnNode;
 import org.objectweb.asm.tree.JumpInsnNode;
 import org.objectweb.asm.tree.LookupSwitchInsnNode;
 import org.objectweb.asm.tree.MethodInsnNode;
@@ -400,11 +401,11 @@ public class MethodsConverter implements Converter {
             assert jumpInsn.getOpcode() == JVMOpcode.IFEQ.getOpcode();
             // Next, follow instructions for the equality case. We retrieve the number that
             // points us to the correct case in the TABLESWITCH instruction following later.
-            InsnNode branchNumberInsn = (InsnNode) jumpInsn.getNext();
-            int branchNr = branchNumberInsn.getOpcode() - 3;
+            insn = jumpInsn.getNext();
+            int branchNr = extractBranchNumber(insn, callingNeoMethod);
             // The branch number gets stored to a local variable in the next opcode. But we
             // can ignore that.
-            insn = branchNumberInsn.getNext();
+            insn = insn.getNext();
             assert insn.getType() == AbstractInsnNode.VAR_INSN;
             // The next instruction opcode jumps to the TABLESWITCH instruction but we need
             // to replace this with a jump directly to the correct branch after the TABLESWITCH.
@@ -426,6 +427,16 @@ public class MethodsConverter implements Converter {
                     secondLookupSwitchInsn.dflt.getLabel()));
             return secondLookupSwitchInsn;
         }
+    }
+
+    private static int extractBranchNumber(AbstractInsnNode insn, NeoMethod neoMethod) {
+        if (insn instanceof InsnNode) {
+            return insn.getOpcode() - 3;
+        }
+        if (insn instanceof IntInsnNode) {
+            return ((IntInsnNode) insn).operand;
+        }
+        throw new CompilerException(neoMethod, "Unexpected instruction in branch of a switch-case.");
     }
 
     // Checks if the given instruction is a method call to the `String.equals()` method.

--- a/compiler/src/main/java/io/neow3j/compiler/converters/MethodsConverter.java
+++ b/compiler/src/main/java/io/neow3j/compiler/converters/MethodsConverter.java
@@ -402,7 +402,7 @@ public class MethodsConverter implements Converter {
             // Next, follow instructions for the equality case. We retrieve the number that
             // points us to the correct case in the TABLESWITCH instruction following later.
             insn = jumpInsn.getNext();
-            int branchNr = extractBranchNumber(insn, callingNeoMethod);
+            int branchNr = extractBranchNumber(insn);
             // The branch number gets stored to a local variable in the next opcode. But we
             // can ignore that.
             insn = insn.getNext();
@@ -429,7 +429,7 @@ public class MethodsConverter implements Converter {
         }
     }
 
-    private static int extractBranchNumber(AbstractInsnNode insn, NeoMethod neoMethod) {
+    private static int extractBranchNumber(AbstractInsnNode insn) {
         if (insn instanceof InsnNode) {
             return insn.getOpcode() - 3;
         } else {

--- a/compiler/src/test-integration/java/io/neow3j/compiler/SwitchCaseIntegrationTest.java
+++ b/compiler/src/test-integration/java/io/neow3j/compiler/SwitchCaseIntegrationTest.java
@@ -105,6 +105,21 @@ public class SwitchCaseIntegrationTest {
         assertThat(retVal.get(1).getString(), is("isDefault"));
     }
 
+    @Test
+    public void largeSwitchCase() throws IOException {
+        InvocationResult r = ct.callInvokeFunction(testName, string("hello")).getInvocationResult();
+        assertThat(r.getStack().get(0).getInteger().intValue(), is(1));
+
+        r = ct.callInvokeFunction(testName, string("concept")).getInvocationResult();
+        assertThat(r.getStack().get(0).getInteger().intValue(), is(6));
+
+        r = ct.callInvokeFunction(testName, string("giraffe")).getInvocationResult();
+        assertThat(r.getStack().get(0).getInteger().intValue(), is(14));
+
+        r = ct.callInvokeFunction(testName, string("unknown")).getInvocationResult();
+        assertThat(r.getStack().get(0).getInteger().intValue(), is(15));
+    }
+
     static class SwitchCaseIntegrationTestContract {
 
         public static Object[] switchWithString(String s) {
@@ -252,6 +267,57 @@ public class SwitchCaseIntegrationTest {
                     localString = "isDefault";
             }
             return new Object[]{localInt, localString};
+        }
+
+        public static int largeSwitchCase(String s) {
+            int i;
+            switch (s) {
+                case "hello":
+                    i = 1;
+                    break;
+                case "some":
+                    i = 2;
+                    break;
+                case "other":
+                    i = 3;
+                    break;
+                case "each":
+                    i = 4;
+                    break;
+                case "structure":
+                    i = 5;
+                    break;
+                case "concept":
+                    i = 6;
+                    break;
+                case "abstract":
+                    i = 7;
+                    break;
+                case "what":
+                    i = 8;
+                    break;
+                case "not":
+                    i = 9;
+                    break;
+                case "icarus":
+                    i = 10;
+                    break;
+                case "flamingo":
+                    i = 11;
+                    break;
+                case "pelican":
+                    i = 12;
+                    break;
+                case "rhinoceros":
+                    i = 13;
+                    break;
+                case "giraffe":
+                    i = 14;
+                    break;
+                default:
+                    i = 15;
+            }
+            return i;
         }
 
     }


### PR DESCRIPTION
The compiler failed compiling large switch-case constructs (more than 6 branches).