### PR TITLE
Fix bug when in compilation of Event without any arguments

### DIFF
--- a/compiler/src/main/java/io/neow3j/compiler/AsmHelper.java
+++ b/compiler/src/main/java/io/neow3j/compiler/AsmHelper.java
@@ -364,7 +364,7 @@ public class AsmHelper {
      */
     public static List<String> extractTypeParametersFromSignature(FieldNode fieldNode) {
         String sig = fieldNode.signature;
-        if (!sig.contains("<")) {
+        if (sig == null || !sig.contains("<")) {
             return new ArrayList<>();
         }
         int startIdx = sig.indexOf("<") + 1;

--- a/compiler/src/test/java/io/neow3j/compiler/ContractEventsTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/ContractEventsTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import static java.util.Arrays.asList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
@@ -101,6 +102,7 @@ public class ContractEventsTest {
         CompilationUnit res = new Compiler().compile(ContractEventsTestContract.class.getName());
 
         List<ContractEvent> manifestEvents = res.getManifest().getAbi().getEvents();
+
         assertThat(manifestEvents.get(0).getName(), is("event1"));
         ContractParameter arg1 = new ContractParameter("arg1", ContractParameterType.STRING);
         ContractParameter arg2 = new ContractParameter("arg2", ContractParameterType.INTEGER);
@@ -113,6 +115,9 @@ public class ContractEventsTest {
         ContractParameter arg4 = new ContractParameter("arg4", ContractParameterType.STRING);
         ContractParameter arg5 = new ContractParameter("arg5", ContractParameterType.ANY);
         assertThat(manifestEvents.get(1).getParameters(), contains(arg1, arg2, arg3, arg4, arg5));
+
+        assertThat(manifestEvents.get(2).getName(), is("EventWithoutParameters"));
+        assertThat(manifestEvents.get(2).getParameters(), is(empty()));
     }
 
     @Test
@@ -142,12 +147,16 @@ public class ContractEventsTest {
 
     public static class ContractEventsTestContract {
 
+        @DisplayName("EventWithoutParameters")
+        private static io.neow3j.devpack.events.Event event0;
+
         private static Event2Args<String, Integer> event1;
 
         @DisplayName("displayName")
         private static Event5Args<String, Integer, Boolean, String, Object> event2;
 
         public static void main() {
+            event0.fire();
             event1.fire("notification", 0);
             event2.fire("notification", 0, false, "notification", "notification");
         }

--- a/devpack/src/main/java/io/neow3j/devpack/events/Event0Arg.java
+++ b/devpack/src/main/java/io/neow3j/devpack/events/Event0Arg.java
@@ -1,5 +1,0 @@
-package io.neow3j.devpack.events;
-
-public class Event0Arg extends Event {
-
-}


### PR DESCRIPTION
Compilation for `Event` and `Event0Arg` failed.
I removed the latter because it was not intuitive to me when writing a contract.