### PR TITLE
Update NFT integration tests

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,10 +10,6 @@ at [neow3j.io](https://neow3j.io) is up-to-date.
    and replace it with the new version number. There should be two affected files, i.e., `README.md`,
    and `DEVELOPMENT.md`.
 3. Verify that the release version is also set correctly in the files `build.gradle` and `Compiler.java`.
-    - In case that the version number in `build.gradle` and `Compiler.java` need updating, the tests
-      `NNSIntegrationTest`, `NFTIntegrationTest`, `DivisibleNFTIntegrationTest`, and
-      `NonDivisibleNFTIntegrationTest` will fail because of the version change in the compiler.
-        - If this is the case, change the contract hashes in these tests accordingly to make them pass again.
 4. Create a Pull Request from `release` to `main` -- this is called a "Release Pull Request".
     - Set the name as "Release x.x.x".
     - Set the correct milestone, project and a reviewer.
@@ -53,7 +49,8 @@ Where:
    ./core/build/libs/core-3.8.0-all.jar) of all the artifacts that need to be released for that module.
 5. Go to [https://oss.sonatype.org/](https://oss.sonatype.org/), log in and go to the *Staging Upload* section.
 6. Choose *Artifact Bundle* as the *Upload Mode* and upload the bundle jars (i.e., the files ending with `-all.jar`) for
-   each module except the `gradle-plugin` module. A confirmation for a successful upload should be displayed in the GUI.
+   each module except for the `gradle-plugin` and `int-tests` modules. A confirmation for a successful upload should be 
+   displayed in the GUI.
 7. All uploaded bundles should show up in the *Staging Repositories* section as separate repositories. Once they reach
    the Status **closed** the **Release** button becomes available. Select all repositories and click **Release**.
 8. Search for `io.neow3j` in the *Artifact Search* section to make sure that the process worked.
@@ -61,9 +58,7 @@ Where:
    Repository.
 
 ## Finish Source Code Release Process
-1. Go to the `main` branch and bump the version in the `build.gradle` and `Compiler.java` file on the `main` branch. 
-   Thus, also update the NFT integration tests accordingly to make them pass again, (i.e., `NNSIntegrationTest`, 
-   `NFTIntegrationTest`, `DivisibleNFTIntegrationTest`, and `NonDivisibleNFTIntegrationTest`).
+1. Go to the `main` branch and bump the version in the `build.gradle` and `Compiler.java` file on the `main` branch.
 
 ## Update `neow3j-examples` Repositories and Run Smoke Tests
 

--- a/devpack/src/main/java/io/neow3j/devpack/contracts/ContractInterface.java
+++ b/devpack/src/main/java/io/neow3j/devpack/contracts/ContractInterface.java
@@ -10,7 +10,7 @@ import io.neow3j.devpack.Hash160;
  * When this class is extended, the constructor of the extending class must take exactly one parameter of type
  * {@link Hash160} or a constant {@link String} and pass it to the {@code super()} call without any additional logic.
  */
-public abstract class ContractInterface {
+public class ContractInterface {
 
     /**
      * Initializes an interface to a smart contract.

--- a/devpack/src/main/java/io/neow3j/devpack/contracts/NonFungibleToken.java
+++ b/devpack/src/main/java/io/neow3j/devpack/contracts/NonFungibleToken.java
@@ -11,7 +11,7 @@ import io.neow3j.devpack.Map;
  * When this class is extended, the constructor of the extending class must take exactly one parameter of type
  * {@link Hash160} or a constant {@link String} and pass it to the {@code super()} call without any additional logic.
  */
-public abstract class NonFungibleToken extends Token {
+public class NonFungibleToken extends Token {
 
     /**
      * Initializes an interface to a non-fungible token.

--- a/devpack/src/main/java/io/neow3j/devpack/contracts/Token.java
+++ b/devpack/src/main/java/io/neow3j/devpack/contracts/Token.java
@@ -8,7 +8,7 @@ import io.neow3j.devpack.Hash160;
  * When this class is extended, the constructor of the extending class must take exactly one parameter of type
  * {@link Hash160} or a constant {@link String} and pass it to the {@code super()} call without any additional logic.
  */
-public abstract class Token extends ContractInterface {
+public class Token extends ContractInterface {
 
     /**
      * Initializes an interface to a token contract.

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/ContractInterfaceIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/ContractInterfaceIntegrationTest.java
@@ -23,8 +23,6 @@ import org.junit.rules.TestName;
 import java.io.IOException;
 import java.math.BigInteger;
 
-import static io.neow3j.devpack.Helper.reverse;
-import static io.neow3j.devpack.StringLiteralHelper.hexToBytes;
 import static io.neow3j.test.TestProperties.gasTokenHash;
 import static io.neow3j.test.TestProperties.neoTokenHash;
 import static io.neow3j.test.TestProperties.stdLibHash;
@@ -204,7 +202,7 @@ public class ContractInterfaceIntegrationTest {
         public static String callSymbolOfFungibleToken() {
             CustomFungibleToken customFungibleToken =
                     new CustomFungibleToken("ef4073a0f2b305a38ec4050e4d3d28bc40ea63f5");
-            return customFungibleToken.symbol();// 0x457fa4900813d577495b5c980849337cb048f041
+            return customFungibleToken.symbol();
         }
 
         public static String callSymbolOfFungibleTokenWithStaticHash() {
@@ -223,8 +221,7 @@ public class ContractInterfaceIntegrationTest {
         }
 
         public static boolean transferFungibleTokenWithStaticHashToClaimGas(Hash160 gasClaimer) {
-            CustomFungibleToken customFungibleToken = new CustomFungibleToken(
-                    new Hash160(reverse(hexToBytes(cst).toByteArray())));
+            CustomFungibleToken customFungibleToken = new CustomFungibleToken(cst);
             int amount = 0;
             return customFungibleToken.transfer(gasClaimer, gasClaimer, amount, null);
         }
@@ -250,9 +247,7 @@ public class ContractInterfaceIntegrationTest {
         }
 
         public static Hash160 getHash() {
-            return new CustomContract(
-                    new Hash160(reverse(hexToBytes("acce6fd80d44e1796aa0c2c625e9e4e0ce39efc0").toByteArray())))
-                    .getHash();
+            return new CustomContract("acce6fd80d44e1796aa0c2c625e9e4e0ce39efc0").getHash();
         }
 
         public static Hash160 getHashFromContractInterfaceInInitsslot() {
@@ -260,12 +255,12 @@ public class ContractInterfaceIntegrationTest {
         }
 
         public static Hash160 getHashFromContractInterfaceWithHashFromInitsslotValue() {
-            return new CustomContract(new Hash160(reverse(hexToBytes(cst).toByteArray()))).getHash();
+            return new CustomContract(cst).getHash();
         }
     }
 
     static class CustomContract extends ContractInterface {
-        public CustomContract(Hash160 contractHash) {
+        public CustomContract(String contractHash) {
             super(contractHash);
         }
     }

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/ContractTestRule.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/ContractTestRule.java
@@ -42,6 +42,7 @@ import static io.neow3j.test.TestProperties.client1AccountWIF;
 import static io.neow3j.test.TestProperties.client2AccountWIF;
 import static io.neow3j.test.TestProperties.defaultAccountWIF;
 import static io.neow3j.transaction.Witness.createMultiSigWitness;
+import static io.neow3j.types.ContractParameter.hash160;
 import static io.neow3j.utils.ArrayUtils.reverseArray;
 import static io.neow3j.utils.Await.waitUntilBlockCountIsGreaterThanZero;
 import static io.neow3j.utils.Await.waitUntilContractIsDeployed;
@@ -69,6 +70,7 @@ public class ContractTestRule implements TestRule {
     private boolean signAsCommittee = false;
     private boolean signWithDefaultAccount = false;
 
+    private static final String SET_HASH = "setHash";
     private static final int DEFAULT_ITERATOR_COUNT = 100;
 
     public ContractTestRule(String fullyQualifiedName) {
@@ -449,6 +451,10 @@ public class ContractTestRule implements TestRule {
 
     public ContainerState getNeoTestContainer() {
         return neoTestContainer;
+    }
+
+    public void setHash(Hash160 scriptHash) throws Throwable {
+        invokeFunctionAndAwaitExecution(SET_HASH, hash160(scriptHash));
     }
 
 }

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/DivisibleNFTIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/DivisibleNFTIntegrationTest.java
@@ -39,11 +39,12 @@ public class DivisibleNFTIntegrationTest {
     public TestName testName = new TestName();
 
     @ClassRule
-    public static ContractTestRule ct = new ContractTestRule(DivisibleNFTTestContract.class.getName());
+    public static ContractTestRule ct = new ContractTestRule(TestContract.class.getName());
 
     @BeforeClass
     public static void setUp() throws Throwable {
         SmartContract sc = ct.deployContract(ConcreteDivisibleNFT.class.getName());
+        ct.setHash(sc.getScriptHash());
     }
 
     @Test
@@ -69,21 +70,26 @@ public class DivisibleNFTIntegrationTest {
     }
 
     @Permission(contract = "*")
-    static class DivisibleNFTTestContract {
-
-        static DivisibleNonFungibleToken customDivisibleNFT =
-                new DivisibleNonFungibleToken("31383c172f155a235a89cb68530037ef90047891");
+    static class TestContract {
 
         public static boolean testTransfer(Hash160 from, Hash160 to, int amount, ByteString tokenId, Object data) {
-            return customDivisibleNFT.transfer(from, to, amount, tokenId, data);
+            return new DivisibleNonFungibleToken(getHash()).transfer(from, to, amount, tokenId, data);
         }
 
         public static Iterator<Hash160> testOwnerOf(ByteString tokenId) {
-            return customDivisibleNFT.ownerOf(tokenId);
+            return new DivisibleNonFungibleToken(getHash()).ownerOf(tokenId);
         }
 
         public static int testBalanceOf(Hash160 account, ByteString tokenId) {
-            return customDivisibleNFT.balanceOf(account, tokenId);
+            return new DivisibleNonFungibleToken(getHash()).balanceOf(account, tokenId);
+        }
+
+        public static void setHash(Hash160 contractHash) {
+            Storage.put(Storage.getStorageContext(), 0xff, contractHash);
+        }
+
+        private static Hash160 getHash() {
+            return Storage.getHash160(Storage.getReadOnlyContext(), 0xff);
         }
 
     }

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/FungibleTokenTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/FungibleTokenTest.java
@@ -14,8 +14,6 @@ import org.junit.rules.TestName;
 
 import java.io.IOException;
 
-import static io.neow3j.devpack.Helper.reverse;
-import static io.neow3j.devpack.StringLiteralHelper.hexToBytes;
 import static io.neow3j.test.TestProperties.neoTokenHash;
 import static io.neow3j.types.ContractParameter.hash160;
 import static io.neow3j.types.ContractParameter.integer;
@@ -81,8 +79,7 @@ public class FungibleTokenTest {
     @Permission(nativeContract = NativeContract.NeoToken, methods = "*")
     static class FungibleTokenTestContract {
 
-        static FungibleToken token = new FungibleToken(
-                new Hash160(reverse(hexToBytes("ef4073a0f2b305a38ec4050e4d3d28bc40ea63f5").toByteArray())));
+        static FungibleToken token = new FungibleToken("ef4073a0f2b305a38ec4050e4d3d28bc40ea63f5");
 
         public static String callSymbolMethodOfFungibleToken() {
             return token.symbol();

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/NFTIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/NFTIntegrationTest.java
@@ -11,7 +11,6 @@ import io.neow3j.devpack.StorageContext;
 import io.neow3j.devpack.StorageMap;
 import io.neow3j.devpack.annotations.Permission;
 import io.neow3j.devpack.constants.FindOptions;
-import io.neow3j.devpack.contracts.DivisibleNonFungibleToken;
 import io.neow3j.devpack.contracts.NonFungibleToken;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.stackitem.ByteStringStackItem;
@@ -49,6 +48,7 @@ public class NFTIntegrationTest {
     @BeforeClass
     public static void setUp() throws Throwable {
         SmartContract sc = ct.deployContract(ConcreteNonFungibleToken.class.getName());
+        ct.setHash(sc.getScriptHash());
     }
 
     @Test
@@ -113,38 +113,44 @@ public class NFTIntegrationTest {
     @Permission(contract = "*")
     static class NonFungibleTokenTestContract {
 
-        static NonFungibleToken nft = new DivisibleNonFungibleToken("8e830f69ace5e1d84a83e4dc5866b2ad6ca81167");
-
         public static String testSymbol() {
-            return nft.symbol();
+            return new NonFungibleToken(getHash()).symbol();
         }
 
         public static int testDecimals() {
-            return nft.decimals();
+            return new NonFungibleToken(getHash()).decimals();
         }
 
         public static int testTotalSupply() {
-            return nft.totalSupply();
+            return new NonFungibleToken(getHash()).totalSupply();
         }
 
         public static int testBalanceOf(Hash160 account) {
-            return nft.balanceOf(account);
+            return new NonFungibleToken(getHash()).balanceOf(account);
         }
 
         public static Iterator<ByteString> testTokensOf(Hash160 account) {
-            return nft.tokensOf(account);
+            return new NonFungibleToken(getHash()).tokensOf(account);
         }
 
         public static boolean testTransfer(Hash160 to, ByteString tokenId, Object data) {
-            return nft.transfer(to, tokenId, data);
+            return new NonFungibleToken(getHash()).transfer(to, tokenId, data);
         }
 
         public static Iterator<ByteString> testTokens() {
-            return nft.tokens();
+            return new NonFungibleToken(getHash()).tokens();
         }
 
         public static Map<String, String> testProperties(ByteString tokenId) {
-            return nft.properties(tokenId);
+            return new NonFungibleToken(getHash()).properties(tokenId);
+        }
+
+        public static void setHash(Hash160 contractHash) {
+            Storage.put(Storage.getStorageContext(), 0xff, contractHash);
+        }
+
+        private static Hash160 getHash() {
+            return Storage.getHash160(Storage.getReadOnlyContext(), 0xff);
         }
     }
 

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/NNSIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/NNSIntegrationTest.java
@@ -3,6 +3,7 @@ package io.neow3j.compiler;
 import io.neow3j.contract.SmartContract;
 import io.neow3j.devpack.Hash160;
 import io.neow3j.devpack.List;
+import io.neow3j.devpack.Storage;
 import io.neow3j.devpack.annotations.Permission;
 import io.neow3j.devpack.contracts.NeoNameService;
 import io.neow3j.protocol.core.RecordType;
@@ -34,11 +35,12 @@ public class NNSIntegrationTest {
     public TestName testName = new TestName();
 
     @ClassRule
-    public static ContractTestRule ct = new ContractTestRule(NNSTestContract.class.getName());
+    public static ContractTestRule ct = new ContractTestRule(TestContract.class.getName());
 
     @BeforeClass
     public static void setUp() throws Throwable {
         SmartContract sc = ct.deployContract(ConcreteNeoNameService.class.getName());
+        ct.setHash(sc.getScriptHash());
     }
 
     @Test
@@ -122,52 +124,58 @@ public class NNSIntegrationTest {
     }
 
     @Permission(contract = "*")
-    static class NNSTestContract {
-
-        static NeoNameService nameService = new NeoNameService("c58e21daa5f94352ab6f1b749bdbd3089bfed653");
+    static class TestContract {
 
         public static void testAddRoot(String root) {
-            nameService.addRoot(root);
+            new NeoNameService(getHash()).addRoot(root);
         }
 
         public static void testSetPrice(List<Integer> priceList) {
-            nameService.setPrice(priceList);
+            new NeoNameService(getHash()).setPrice(priceList);
         }
 
         public static int testGetPrice(int length) {
-            return nameService.getPrice(length);
+            return new NeoNameService(getHash()).getPrice(length);
         }
 
         public static boolean testIsAvailable(String name) {
-            return nameService.isAvailable(name);
+            return new NeoNameService(getHash()).isAvailable(name);
         }
 
         public static boolean testRegister(String name, Hash160 owner) {
-            return nameService.register(name, owner);
+            return new NeoNameService(getHash()).register(name, owner);
         }
 
         public static int testRenew(String name) {
-            return nameService.renew(name);
+            return new NeoNameService(getHash()).renew(name);
         }
 
         public static void testSetAdmin(String name, Hash160 admin) {
-            nameService.setAdmin(name, admin);
+            new NeoNameService(getHash()).setAdmin(name, admin);
         }
 
         public static void testSetRecord(String name, int type, String data) {
-            nameService.setRecord(name, type, data);
+            new NeoNameService(getHash()).setRecord(name, type, data);
         }
 
         public static String testGetRecord(String name, int type) {
-            return nameService.getRecord(name, type);
+            return new NeoNameService(getHash()).getRecord(name, type);
         }
 
         public static void testDeleteRecord(String name, int type) {
-            nameService.deleteRecord(name, type);
+            new NeoNameService(getHash()).deleteRecord(name, type);
         }
 
         public static String testResolve(String name, int type) {
-            return nameService.resolve(name, type);
+            return new NeoNameService(getHash()).resolve(name, type);
+        }
+
+        public static void setHash(Hash160 contractHash) {
+            Storage.put(Storage.getStorageContext(), 0xff, contractHash);
+        }
+
+        private static Hash160 getHash() {
+            return Storage.getHash160(Storage.getReadOnlyContext(), 0xff);
         }
 
     }

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/NonDivisibleNFTIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/NonDivisibleNFTIntegrationTest.java
@@ -3,6 +3,7 @@ package io.neow3j.compiler;
 import io.neow3j.contract.SmartContract;
 import io.neow3j.devpack.ByteString;
 import io.neow3j.devpack.Hash160;
+import io.neow3j.devpack.Storage;
 import io.neow3j.devpack.annotations.Permission;
 import io.neow3j.devpack.contracts.NonDivisibleNonFungibleToken;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
@@ -29,7 +30,7 @@ public class NonDivisibleNFTIntegrationTest {
     @BeforeClass
     public static void setUp() throws Throwable {
         SmartContract sc = ct.deployContract(ConcreteNonDivisibleNFT.class.getName());
-        System.out.println(sc.getScriptHash());
+        ct.setHash(sc.getScriptHash());
     }
 
     @Test
@@ -43,11 +44,16 @@ public class NonDivisibleNFTIntegrationTest {
     @Permission(contract = "*")
     static class NonDivisibleNFTTestContract {
 
-        static NonDivisibleNonFungibleToken nft =
-                new NonDivisibleNonFungibleToken("68663f14cf7298b9a274034475a789c6830943fa");
-
         public static Hash160 testOwnerOf(ByteString tokenId) {
-            return nft.ownerOf(tokenId);
+            return new NonDivisibleNonFungibleToken(getHash()).ownerOf(tokenId);
+        }
+
+        public static void setHash(Hash160 contractHash) {
+            Storage.put(Storage.getStorageContext(), 0xff, contractHash);
+        }
+
+        private static Hash160 getHash() {
+            return Storage.getHash160(Storage.getReadOnlyContext(), 0xff);
         }
 
     }


### PR DESCRIPTION
With the recent changes, the NFT integration tests no longer need to statically set the deployed contract hash. With the changes in this PR, the contract hashes are now set dynamically and after a version bump, these tests no longer need separate updating.

Accordingly, I have updated the `RELEASE.md` which no longer needs this step.

Finally, I've removed the `abstract` modifier in the classes `ContractInterface`, `NonFungibleToken`, and `Token`. That way methods held by these classes can also be used without using/creating a specific subtype of them (e.g., `NonDivisibleNonFungibleToken` if it doesn't matter whether the called NFT is divisible or not...).