### PR TITLE
Fix ContractParameter equals method

### DIFF
--- a/core/src/main/java/io/neow3j/types/ContractParameter.java
+++ b/core/src/main/java/io/neow3j/types/ContractParameter.java
@@ -428,8 +428,9 @@ public class ContractParameter {
      */
     public static ContractParameter publicKey(byte[] publicKey) {
         if (publicKey.length != NeoConstants.PUBLIC_KEY_SIZE_COMPRESSED) {
-            throw new IllegalArgumentException("Public key argument must be " + NeoConstants.PUBLIC_KEY_SIZE_COMPRESSED +
-                    " bytes but was " + publicKey.length + " bytes.");
+            throw new IllegalArgumentException(
+                    "Public key argument must be " + NeoConstants.PUBLIC_KEY_SIZE_COMPRESSED +
+                            " bytes but was " + publicKey.length + " bytes.");
         }
         return new ContractParameter(PUBLIC_KEY, publicKey);
     }
@@ -459,7 +460,7 @@ public class ContractParameter {
             if (type.equals(BYTE_ARRAY) || type.equals(SIGNATURE) || type.equals(PUBLIC_KEY)) {
                 return Arrays.equals((byte[]) value, (byte[]) that.value);
             } else if (type.equals(HASH160) || type.equals(HASH256)) {
-                return getValue().toString().equals(that.getValue().toString());
+                return Objects.equals(getValue(), that.getValue());
             } else if (type.equals(ARRAY)) {
                 ContractParameter[] thatValue = (ContractParameter[]) that.getValue();
                 ContractParameter[] oValue = (ContractParameter[]) ((ContractParameter) o).getValue();

--- a/core/src/main/java/io/neow3j/types/ContractParameter.java
+++ b/core/src/main/java/io/neow3j/types/ContractParameter.java
@@ -456,12 +456,10 @@ public class ContractParameter {
         }
         ContractParameter that = (ContractParameter) o;
         if (type == that.type && Objects.equals(name, that.name)) {
-            if (type.equals(BYTE_ARRAY) ||
-                    type.equals(SIGNATURE) ||
-                    type.equals(PUBLIC_KEY) ||
-                    type.equals(HASH160) ||
-                    type.equals(HASH256)) {
+            if (type.equals(BYTE_ARRAY) || type.equals(SIGNATURE) || type.equals(PUBLIC_KEY)) {
                 return Arrays.equals((byte[]) value, (byte[]) that.value);
+            } else if (type.equals(HASH160) || type.equals(HASH256)) {
+                return getValue().toString().equals(that.getValue().toString());
             } else if (type.equals(ARRAY)) {
                 ContractParameter[] thatValue = (ContractParameter[]) that.getValue();
                 ContractParameter[] oValue = (ContractParameter[]) ((ContractParameter) o).getValue();

--- a/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
+++ b/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
@@ -661,10 +661,6 @@ public class ContractParameterTest {
     }
 
     @Test
-    public void testEqualsHash160Parameter() {
-    }
-
-    @Test
     public void testHashCode() {
         int result = contractParameter.hashCode();
         assertNotEquals(0, result);

--- a/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
+++ b/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
@@ -629,6 +629,18 @@ public class ContractParameterTest {
         ContractParameter param2 = hash160(Hash160.ZERO);
         assertEquals(param1, param2);
 
+        param1 = new ContractParameter(null);
+        param2 = hash160(Hash160.ZERO);
+        assertNotEquals(param1, param2);
+
+        param1 = new ContractParameter(ContractParameterType.HASH160, null);
+        param2 = hash160(Hash160.ZERO);
+        assertNotEquals(param1, param2);
+
+        param1 = new ContractParameter(ContractParameterType.HASH160, null);
+        param2 = new ContractParameter(ContractParameterType.HASH160, null);
+        assertEquals(param1, param2);
+
         param1 = hash256(Hash256.ZERO);
         param2 = hash256(Hash256.ZERO);
         assertEquals(param1, param2);

--- a/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
+++ b/core/src/test/java/io/neow3j/contract/ContractParameterTest.java
@@ -621,9 +621,35 @@ public class ContractParameterTest {
     @Test
     public void testEquals() {
         assertNotEquals("o", contractParameter);
-        assertThat(contractParameter.equals(string("value")), is(true));
+        assertEquals(contractParameter, string("value"));
         assertNotEquals(contractParameter, string("test"));
         assertNotEquals(contractParameter, integer(1));
+
+        ContractParameter param1 = hash160(Hash160.ZERO);
+        ContractParameter param2 = hash160(Hash160.ZERO);
+        assertEquals(param1, param2);
+
+        param1 = hash256(Hash256.ZERO);
+        param2 = hash256(Hash256.ZERO);
+        assertEquals(param1, param2);
+
+        param1 = hash256(Hash256.ZERO);
+        param2 = hash160(Hash160.ZERO);
+        assertNotEquals(param1, param2);
+
+        param1 = signature(
+                "01020304010203040102030401020304010203040102030401020304010203040102030401020304010203040102030401020304010203040102030401020304");
+        param2 = signature(
+                "01020304010203040102030401020304010203040102030401020304010203040102030401020304010203040102030401020304010203040102030401020304");
+        assertEquals(param1, param2);
+
+        param1 = publicKey("010203040102030401020304010203040102030401020304010203040102030401");
+        param2 = publicKey("010203040102030401020304010203040102030401020304010203040102030401");
+        assertEquals(param1, param2);
+    }
+
+    @Test
+    public void testEqualsHash160Parameter() {
     }
 
     @Test


### PR DESCRIPTION
I had to fix this now, because it after all got more problematic for the GrantShares code.

Closes #887 