### PR TITLE
Fix from serializable method in Transaction DTO

### DIFF
--- a/core/src/main/java/io/neow3j/protocol/core/response/NeoApplicationLog.java
+++ b/core/src/main/java/io/neow3j/protocol/core/response/NeoApplicationLog.java
@@ -133,6 +133,7 @@ public class NeoApplicationLog {
             return stack;
         }
 
+        @JsonIgnore
         public StackItem getFirstStackItem() {
             if (stack.size() == 0) {
                 throw new IndexOutOfBoundsException("The stack is empty. This means that no items were left on the " +
@@ -156,6 +157,7 @@ public class NeoApplicationLog {
             return notifications;
         }
 
+        @JsonIgnore
         public Notification getFirstNotification() {
             if (notifications.size() == 0) {
                 throw new IndexOutOfBoundsException("This execution did not send any notifications.");

--- a/core/src/main/java/io/neow3j/protocol/core/response/OracleResponse.java
+++ b/core/src/main/java/io/neow3j/protocol/core/response/OracleResponse.java
@@ -2,12 +2,13 @@ package io.neow3j.protocol.core.response;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.math.BigInteger;
 import java.util.Objects;
 
 public class OracleResponse {
 
     @JsonProperty(value = "id", required = true)
-    private Integer id;
+    private BigInteger id;
 
     @JsonProperty(value = "code")
     private OracleResponseCode responseCode;
@@ -18,7 +19,14 @@ public class OracleResponse {
     public OracleResponse() {
     }
 
-    public OracleResponse(Integer id, OracleResponseCode responseCode, String result) {
+    /**
+     * Constructs a new OracleResponse object.
+     *
+     * @param id           the request id.
+     * @param responseCode the response code.
+     * @param result       the result.
+     */
+    public OracleResponse(BigInteger id, OracleResponseCode responseCode, String result) {
         this.id = id;
         this.responseCode = responseCode;
         this.result = result;
@@ -30,7 +38,7 @@ public class OracleResponse {
      *
      * @return the response id.
      */
-    public int getId() {
+    public BigInteger getId() {
         return id;
     }
 

--- a/core/src/main/java/io/neow3j/protocol/core/response/OracleResponseAttribute.java
+++ b/core/src/main/java/io/neow3j/protocol/core/response/OracleResponseAttribute.java
@@ -22,12 +22,22 @@ public class OracleResponseAttribute extends TransactionAttribute {
     }
 
     /**
-     * Gets the oracle response.
-     *
      * @return the oracle response.
      */
     public OracleResponse getOracleResponse() {
         return oracleResponse;
+    }
+
+    /**
+     * Transforms a {@link io.neow3j.transaction.OracleResponseAttribute} object to an instance of this type (its DTO
+     * representation type).
+     *
+     * @param attr the OracleResponse transaction attribute.
+     * @return the DTO form of the attribute.
+     */
+    public static TransactionAttribute fromSerializable(io.neow3j.transaction.OracleResponseAttribute attr) {
+        OracleResponse oracleResponse = new OracleResponse(attr.getId(), attr.getCode(), new String(attr.getResult()));
+        return new OracleResponseAttribute(oracleResponse);
     }
 
     @Override

--- a/core/src/main/java/io/neow3j/protocol/core/response/Transaction.java
+++ b/core/src/main/java/io/neow3j/protocol/core/response/Transaction.java
@@ -131,7 +131,7 @@ public class Transaction {
         validUntilBlock = tx.getValidUntilBlock();
         signers = tx.getSigners().stream().map(TransactionSigner::new).collect(Collectors.toList());
         attributes = tx.getAttributes().stream()
-                .map(a -> TransactionAttribute.fromType(a.getType()))
+                .map(TransactionAttribute::fromSerializable)
                 .collect(Collectors.toList());
         script = Base64.encode(tx.getScript());
         witnesses = tx.getWitnesses().stream().map(NeoWitness::new).collect(Collectors.toList());

--- a/core/src/main/java/io/neow3j/protocol/core/response/Transaction.java
+++ b/core/src/main/java/io/neow3j/protocol/core/response/Transaction.java
@@ -1,5 +1,6 @@
 package io.neow3j.protocol.core.response;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -173,6 +174,7 @@ public class Transaction {
         return signers;
     }
 
+    @JsonIgnore
     public TransactionSigner getFirstSigner() {
         if (signers.size() == 0) {
             throw new IndexOutOfBoundsException("This transaction does not have any signers. It might be malformed, " +
@@ -192,6 +194,7 @@ public class Transaction {
         return attributes;
     }
 
+    @JsonIgnore
     public TransactionAttribute getFirstAttribute() {
         if (attributes.size() == 0) {
             throw new IndexOutOfBoundsException("This transaction does not have any attributes.");

--- a/core/src/main/java/io/neow3j/protocol/core/response/TransactionAttribute.java
+++ b/core/src/main/java/io/neow3j/protocol/core/response/TransactionAttribute.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import io.neow3j.transaction.TransactionAttributeType;
 
+import static io.neow3j.transaction.TransactionAttributeType.ORACLE_RESPONSE;
 import static java.lang.String.format;
 
 @JsonTypeInfo(use = Id.NAME, property = "type", include = As.EXISTING_PROPERTY)
@@ -44,19 +45,42 @@ public abstract class TransactionAttribute {
                 TransactionAttributeType.HIGH_PRIORITY.jsonValue(), type.jsonValue()));
     }
 
+    /**
+     * Casts this transaction attribute to a {@link OracleResponseAttribute} if possible, and returns it.
+     *
+     * @return this transaction attribute as a {@link OracleResponseAttribute}.
+     * @throws IllegalStateException if this transaction attribute is not an instance of
+     *                               {@link OracleResponseAttribute}.
+     */
+    @JsonIgnore
+    public OracleResponseAttribute asOracleResponse() {
+        if (this instanceof OracleResponseAttribute) {
+            return (OracleResponseAttribute) this;
+        }
+        throw new IllegalStateException(format("This transaction attribute is not of type %s but of %s.",
+                ORACLE_RESPONSE.jsonValue(), type.jsonValue()));
+    }
+
     public TransactionAttributeType getType() {
         return type;
     }
 
-    public static TransactionAttribute fromType(TransactionAttributeType type) {
-        switch (type) {
+    /**
+     * Transforms a {@link io.neow3j.transaction.TransactionAttribute} object to a concrete instance of this type (its
+     * DTO representation type).
+     *
+     * @param attr the transaction attribute.
+     * @return the DTO form of the attribute.
+     */
+    public static TransactionAttribute fromSerializable(io.neow3j.transaction.TransactionAttribute attr) {
+        switch (attr.getType()) {
             case HIGH_PRIORITY:
                 return new HighPriorityAttribute();
             case ORACLE_RESPONSE:
-                return new OracleResponseAttribute();
+                return OracleResponseAttribute.fromSerializable((io.neow3j.transaction.OracleResponseAttribute) attr);
             default:
                 throw new IllegalArgumentException(
-                        "No concrete class found for transaction attribute type " + type.jsonValue());
+                        "No concrete class found for transaction attribute type " + attr.getType().jsonValue());
         }
     }
 

--- a/core/src/main/java/io/neow3j/transaction/OracleResponseAttribute.java
+++ b/core/src/main/java/io/neow3j/transaction/OracleResponseAttribute.java
@@ -8,6 +8,8 @@ import io.neow3j.utils.BigIntegers;
 
 import java.io.IOException;
 import java.math.BigInteger;
+import java.util.Arrays;
+import java.util.Objects;
 
 /**
  * A high priority attribute can be used by committee members to prioritize a transaction.
@@ -38,6 +40,13 @@ public class OracleResponseAttribute extends TransactionAttribute {
 
     public OracleResponseAttribute() {
         super(TransactionAttributeType.ORACLE_RESPONSE);
+    }
+
+    public OracleResponseAttribute(BigInteger id, OracleResponseCode code, byte[] result) {
+        this();
+        this.id = id;
+        this.code = code;
+        this.result = result;
     }
 
     /**
@@ -81,6 +90,21 @@ public class OracleResponseAttribute extends TransactionAttribute {
         writer.write(BigIntegers.toLittleEndianByteArray(id));
         writer.writeByte(code.byteValue());
         writer.writeVarBytes(result);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof OracleResponseAttribute)) {
+            return false;
+        }
+        OracleResponseAttribute that = (OracleResponseAttribute) o;
+        return Objects.equals(getType(), that.getType()) &&
+                Objects.equals(getId(), that.getId()) &&
+                Objects.equals(getCode(), that.getCode()) &&
+                Arrays.equals(getResult(), that.getResult());
     }
 
 }

--- a/core/src/test/java/io/neow3j/protocol/core/RequestTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/RequestTest.java
@@ -1243,7 +1243,7 @@ public class RequestTest extends RequestTester {
     @Test
     public void testExpressCreateOracleResponseTx() throws Exception {
         neow3jExpress.expressCreateOracleResponseTx(
-                new OracleResponse(3, OracleResponseCode.SUCCESS, "bmVvdzNq")).send();
+                new OracleResponse(BigInteger.valueOf(3), OracleResponseCode.SUCCESS, "bmVvdzNq")).send();
 
         verifyResult("{\n" +
                 " \"jsonrpc\": \"2.0\",\n" +

--- a/core/src/test/java/io/neow3j/protocol/core/ResponseTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/ResponseTest.java
@@ -1341,11 +1341,11 @@ public class ResponseTest extends ResponseTester {
         thrown = assertThrows(IndexOutOfBoundsException.class, () -> transaction.getAttribute(2));
         assertThat(thrown.getMessage(), containsString("only has 2 attributes"));
         assertThat(attributes.get(1).getType(), is(TransactionAttributeType.ORACLE_RESPONSE));
-        OracleResponseAttribute oracleResponseAttribute = (OracleResponseAttribute) attributes.get(1);
+        OracleResponseAttribute oracleResponseAttribute = attributes.get(1).asOracleResponse();
         OracleResponse oracleResp = oracleResponseAttribute.getOracleResponse();
         assertThat(oracleResp.getResponseCode(), is(OracleResponseCode.SUCCESS));
         assertThat(oracleResp.getResult(), is("EQwhA/HsPB4oPogN5unEifDyfBkAfFM4WqpMDJF8MgB57a3yEQtBMHOzuw=="));
-        assertThat(oracleResp.getId(), is(0));
+        assertThat(oracleResp.getId(), is(BigInteger.ZERO));
 
         assertThat(transaction.getScript(),
                 is("AGQMFObBATZUrxE9ipaL3KUsmUioK5U9DBQP7O1Ep0MA2doEn6k2cKQxFxiP9hPADAh0cmFuc2ZlcgwUiXcg2M129PAKv6N8Dt2InCCP3ptBYn1bUjg="));

--- a/core/src/test/java/io/neow3j/protocol/core/response/TransactionAttributeTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/response/TransactionAttributeTest.java
@@ -1,0 +1,55 @@
+package io.neow3j.protocol.core.response;
+
+import io.neow3j.crypto.Base64;
+import io.neow3j.transaction.TransactionAttributeType;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigInteger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class TransactionAttributeTest {
+
+    @Test
+    public void testAsHighPriority_wrongType() {
+        TransactionAttribute oracleResponseAttribute = new OracleResponseAttribute(new OracleResponse(BigInteger.TEN,
+                OracleResponseCode.SUCCESS, Base64.encode(new byte[]{0x00, 0x01})));
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                oracleResponseAttribute::asHighPriority);
+        assertThat(thrown.getMessage(),
+                containsString("attribute is not of type " + TransactionAttributeType.HIGH_PRIORITY.jsonValue()));
+    }
+
+    @Test
+    public void testAsOracleResponse_wrongType() {
+        TransactionAttribute notValidBeforeAttribute = new HighPriorityAttribute();
+        IllegalStateException thrown = assertThrows(IllegalStateException.class,
+                notValidBeforeAttribute::asOracleResponse);
+        assertThat(thrown.getMessage(),
+                containsString("attribute is not of type " + TransactionAttributeType.ORACLE_RESPONSE.jsonValue()));
+    }
+
+    @Test
+    public void testHighPriority_transformFromSerializable() {
+        TransactionAttribute actual = TransactionAttribute.fromSerializable(new io.neow3j.transaction.HighPriorityAttribute());
+        assertEquals(actual, new HighPriorityAttribute());
+    }
+
+    @Test
+    public void testOracleResponse_transformFromSerializable() {
+        TransactionAttribute actual = TransactionAttribute.fromSerializable(
+                new io.neow3j.transaction.OracleResponseAttribute(
+                        BigInteger.TEN, OracleResponseCode.TIMEOUT, "hello".getBytes()
+                )
+        );
+
+        OracleResponseAttribute expected = new OracleResponseAttribute(
+                new OracleResponse(BigInteger.TEN, OracleResponseCode.TIMEOUT, "hello")
+        );
+        assertEquals(actual, expected);
+    }
+
+}

--- a/core/src/test/java/io/neow3j/transaction/TransactionBuilderTest.java
+++ b/core/src/test/java/io/neow3j/transaction/TransactionBuilderTest.java
@@ -983,8 +983,7 @@ public class TransactionBuilderTest {
         tx.send();
         NeoApplicationLog applicationLog = tx.getApplicationLog();
         assertThat(applicationLog.getTransactionId(),
-                is(new Hash256(
-                        "0xeb52f99ae5cf923d8905bdd91c4160e2207d20c0cb42f8062f31c6743770e4d1")));
+                is(new Hash256("0xeb52f99ae5cf923d8905bdd91c4160e2207d20c0cb42f8062f31c6743770e4d1")));
     }
 
     @Test

--- a/core/src/test/java/io/neow3j/transaction/TransactionTest.java
+++ b/core/src/test/java/io/neow3j/transaction/TransactionTest.java
@@ -606,15 +606,15 @@ public class TransactionTest {
                 signers,
                 BigInteger.TEN.pow(8).longValue(),
                 1L,
-                asList(new NotValidBeforeAttribute(BigInteger.TEN)),
+                asList(new HighPriorityAttribute()),
                 new byte[]{(byte) OpCode.PUSH1.getCode()},
                 witnesses);
 
         String json = tx.toJson();
         assertThat(json, is(
                 "{\"vmstate\":null," +
-                        "\"hash\":\"21ab105180a72e4c03ae6afa5ee9dab499933428d617a58185b9c2264cf6a16e\"," +
-                        "\"size\":81," +
+                        "\"hash\":\"40124209fe280d5bbe24a6ae54399b8a36baf2fba30de78b9017e6956cf69c05\"," +
+                        "\"size\":77," +
                         "\"version\":0," +
                         "\"nonce\":16909060," +
                         "\"sender\":\"0f46dc4287b70117ce8354924b5cb3a47215ad93\"," +
@@ -627,7 +627,7 @@ public class TransactionTest {
                         "{\"account\":\"d6c712eb53b1a130f59fd4e5864bdac27458a509\",\"scopes\":\"CalledByEntry\"," +
                         "\"allowedcontracts\":[],\"allowedgroups\":[],\"rules\":[]}]," +
                         "\"attributes\":" +
-                        "[{\"type\":\"NotValidBefore\",\"height\":10}]," +
+                        "[{\"type\":\"HighPriority\"}]," +
                         "\"script\":\"EQ==\"," +
                         "\"witnesses\":[{\"invocation\":\"AA==\",\"verification\":\"AA==\"}]," +
                         "\"blockhash\":null," +

--- a/core/src/test/java/io/neow3j/transaction/TransactionTest.java
+++ b/core/src/test/java/io/neow3j/transaction/TransactionTest.java
@@ -1,5 +1,6 @@
 package io.neow3j.transaction;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.neow3j.constants.NeoConstants;
 import io.neow3j.crypto.Base64;
 import io.neow3j.crypto.ECKeyPair;
@@ -587,6 +588,53 @@ public class TransactionTest {
         UnsupportedOperationException thrown =
                 assertThrows(UnsupportedOperationException.class, tx::toContractParametersContext);
         assertThat(thrown.getMessage(), is("Cannot handle contract signers"));
+    }
+
+    @Test
+    public void testToJson() throws JsonProcessingException {
+        List<Signer> signers = new ArrayList<>();
+        signers.add(AccountSigner.global(account1));
+        signers.add(AccountSigner.calledByEntry(account2));
+
+        List<Witness> witnesses = new ArrayList<>();
+        witnesses.add(new Witness(new byte[]{0x00}, new byte[]{0x00}));
+
+        Transaction tx = new Transaction(neow,
+                (byte) 0,
+                0x01020304L,
+                0x01020304L,
+                signers,
+                BigInteger.TEN.pow(8).longValue(),
+                1L,
+                asList(new NotValidBeforeAttribute(BigInteger.TEN)),
+                new byte[]{(byte) OpCode.PUSH1.getCode()},
+                witnesses);
+
+        String json = tx.toJson();
+        assertThat(json, is(
+                "{\"vmstate\":null," +
+                        "\"hash\":\"21ab105180a72e4c03ae6afa5ee9dab499933428d617a58185b9c2264cf6a16e\"," +
+                        "\"size\":81," +
+                        "\"version\":0," +
+                        "\"nonce\":16909060," +
+                        "\"sender\":\"0f46dc4287b70117ce8354924b5cb3a47215ad93\"," +
+                        "\"sysfee\":\"100000000\"," +
+                        "\"netfee\":\"1\"," +
+                        "\"validuntilblock\":16909060," +
+                        "\"signers\":[" +
+                        "{\"account\":\"0f46dc4287b70117ce8354924b5cb3a47215ad93\",\"scopes\":\"Global\"," +
+                        "\"allowedcontracts\":[],\"allowedgroups\":[],\"rules\":[]}," +
+                        "{\"account\":\"d6c712eb53b1a130f59fd4e5864bdac27458a509\",\"scopes\":\"CalledByEntry\"," +
+                        "\"allowedcontracts\":[],\"allowedgroups\":[],\"rules\":[]}]," +
+                        "\"attributes\":" +
+                        "[{\"type\":\"NotValidBefore\",\"height\":10}]," +
+                        "\"script\":\"EQ==\"," +
+                        "\"witnesses\":[{\"invocation\":\"AA==\",\"verification\":\"AA==\"}]," +
+                        "\"blockhash\":null," +
+                        "\"confirmations\":0," +
+                        "\"blocktime\":0" +
+                        "}"
+        ));
     }
 
 }

--- a/int-tests/src/test-integration/java/io/neow3j/protocol/Neow3jExpressIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/protocol/Neow3jExpressIntegrationTest.java
@@ -165,7 +165,7 @@ public class Neow3jExpressIntegrationTest {
         String responseResult = "bmVvdzNq";
         String oracleResponseTx = getNeow3jExpress()
                 .expressCreateOracleResponseTx(
-                        new OracleResponse(0, OracleResponseCode.SUCCESS, responseResult))
+                        new OracleResponse(BigInteger.ZERO, OracleResponseCode.SUCCESS, responseResult))
                 .send()
                 .getOracleResponseTx();
 


### PR DESCRIPTION
Fixes #973 

## 🚨 Breaking Change 🚨 
### 1
Removed `io.neow3j.protocol.core.response.TransactionAttribute.fromType(TransactionAttributeType)`
It's replaced by the new `fromSerializable()` method
`io.neow3j.protocol.core.response.TransactionAttribute.fromSerializable(TransactionAttribute)`


### 2
`io.neow3j.protocol.core.responseOracleResponse(Integer, OracleResponseCode, String)`
👇🏼 
`io.neow3j.protocol.core.responseOracleResponse(BigInteger, OracleResponseCode, String)`