### PR TITLE
Support `Hash160` and `Hash256` keys in storage delete methods

### DIFF
--- a/devpack/src/main/java/io/neow3j/devpack/Storage.java
+++ b/devpack/src/main/java/io/neow3j/devpack/Storage.java
@@ -1577,6 +1577,24 @@ public class Storage {
      * @param key     the key to delete.
      */
     @Instruction(interopService = SYSTEM_STORAGE_DELETE)
+    public static native void delete(StorageContext context, Hash160 key);
+
+    /**
+     * Deletes the value corresponding to the given key from the storage.
+     *
+     * @param context the storage context to delete from.
+     * @param key     the key to delete.
+     */
+    @Instruction(interopService = SYSTEM_STORAGE_DELETE)
+    public static native void delete(StorageContext context, Hash256 key);
+
+    /**
+     * Deletes the value corresponding to the given key from the storage.
+     *
+     * @param context the storage context to delete from.
+     * @param key     the key to delete.
+     */
+    @Instruction(interopService = SYSTEM_STORAGE_DELETE)
     public static native void delete(StorageContext context, ECPoint key);
 
     // endregion delete

--- a/devpack/src/main/java/io/neow3j/devpack/StorageMap.java
+++ b/devpack/src/main/java/io/neow3j/devpack/StorageMap.java
@@ -2562,6 +2562,38 @@ public class StorageMap {
     @Instruction(opcode = OpCode.PUSH0)
     @Instruction(opcode = OpCode.PICKITEM)
     @Instruction(interopService = InteropService.SYSTEM_STORAGE_DELETE)
+    public native void delete(Hash160 key);
+
+    /**
+     * Deletes the entry with a key equal to {@code prefix + key} from the underlying storage context.
+     *
+     * @param key The key to delete.
+     */
+    @Instruction(opcode = OpCode.OVER)
+    @Instruction(opcode = OpCode.PUSH1)
+    @Instruction(opcode = OpCode.PICKITEM)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.CAT)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.PUSH0)
+    @Instruction(opcode = OpCode.PICKITEM)
+    @Instruction(interopService = InteropService.SYSTEM_STORAGE_DELETE)
+    public native void delete(Hash256 key);
+
+    /**
+     * Deletes the entry with a key equal to {@code prefix + key} from the underlying storage context.
+     *
+     * @param key The key to delete.
+     */
+    @Instruction(opcode = OpCode.OVER)
+    @Instruction(opcode = OpCode.PUSH1)
+    @Instruction(opcode = OpCode.PICKITEM)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.CAT)
+    @Instruction(opcode = OpCode.SWAP)
+    @Instruction(opcode = OpCode.PUSH0)
+    @Instruction(opcode = OpCode.PICKITEM)
+    @Instruction(interopService = InteropService.SYSTEM_STORAGE_DELETE)
     public native void delete(ECPoint key);
 
     // endregion delete

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/StorageIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/StorageIntegrationTest.java
@@ -1418,6 +1418,35 @@ public class StorageIntegrationTest {
         assertThat(res.getStack().get(0).getValue(), is(nullValue()));
     }
 
+
+    @Test
+    public void deleteByHash160Key() throws Throwable {
+        ct.invokeFunctionAndAwaitExecution(STORE_DATA, byteArray(reverseHexString(KEY_HASH160_HEX)),
+                byteArrayFromString("delete by hash160"));
+
+        InvocationResult res = ct.callInvokeFunction("getByHash160Key", hash160(KEY_HASH160))
+                .getInvocationResult();
+        assertThat(res.getFirstStackItem().getType(), is(StackItemType.BYTE_STRING));
+        assertThat(res.getFirstStackItem().getString(), is("delete by hash160"));
+
+        res = ct.callInvokeFunction(testName, hash160(KEY_HASH160)).getInvocationResult();
+        assertNull(res.getFirstStackItem().getValue());
+    }
+
+    @Test
+    public void deleteByHash256Key() throws Throwable {
+        ct.invokeFunctionAndAwaitExecution(STORE_DATA, byteArray(reverseHexString(KEY_HASH256_HEX)),
+                byteArrayFromString("delete by hash256"));
+
+        InvocationResult res = ct.callInvokeFunction("getByHash256Key", hash256(KEY_HASH256))
+                .getInvocationResult();
+        assertThat(res.getFirstStackItem().getType(), is(StackItemType.BYTE_STRING));
+        assertThat(res.getFirstStackItem().getString(), is("delete by hash256"));
+
+        res = ct.callInvokeFunction(testName, hash256(KEY_HASH256)).getInvocationResult();
+        assertNull(res.getFirstStackItem().getValue());
+    }
+
     @Test
     public void deleteByECPointKey() throws Throwable {
         ct.invokeFunctionAndAwaitExecution(STORE_DATA, byteArray(KEY_ECPOINT_HEX),
@@ -2261,6 +2290,16 @@ public class StorageIntegrationTest {
         }
 
         public static ByteString deleteByIntegerKey(int key) {
+            Storage.delete(ctx, key);
+            return Storage.get(ctx, key);
+        }
+
+        public static ByteString deleteByHash160Key(io.neow3j.devpack.Hash160 key) {
+            Storage.delete(ctx, key);
+            return Storage.get(ctx, key);
+        }
+
+        public static ByteString deleteByHash256Key(io.neow3j.devpack.Hash256 key) {
             Storage.delete(ctx, key);
             return Storage.get(ctx, key);
         }

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/StorageMapIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/StorageMapIntegrationTest.java
@@ -1404,6 +1404,38 @@ public class StorageMapIntegrationTest {
     }
 
     @Test
+    public void deleteByHash160() throws Throwable {
+        ct.invokeFunctionAndAwaitExecution(STORE_DATA, byteArray(reverseHexString(KEY_HASH160_HEX)),
+                byteArrayFromString("del by hash160"));
+
+        InvocationResult res = ct.callInvokeFunction("getByHash160Key", hash160(KEY_HASH160)).getInvocationResult();
+
+        assertThat(res.getFirstStackItem().getType(), is(StackItemType.BYTE_STRING));
+        assertThat(res.getFirstStackItem().getString(), is("del by hash160"));
+
+        res = ct.callInvokeFunction(testName, hash160(KEY_HASH160)).getInvocationResult();
+        assertNull(res.getFirstStackItem().getValue());
+
+        ct.invokeFunctionAndAwaitExecution(REMOVE_DATA, byteArray(reverseHexString(KEY_HASH160_HEX)));
+    }
+
+    @Test
+    public void deleteByHash256() throws Throwable {
+        ct.invokeFunctionAndAwaitExecution(STORE_DATA, byteArray(reverseHexString(KEY_HASH256_HEX)),
+                byteArrayFromString("del by hash256"));
+
+        InvocationResult res = ct.callInvokeFunction("getByHash256Key", hash256(KEY_HASH256)).getInvocationResult();
+
+        assertThat(res.getFirstStackItem().getType(), is(StackItemType.BYTE_STRING));
+        assertThat(res.getFirstStackItem().getString(), is("del by hash256"));
+
+        res = ct.callInvokeFunction(testName, hash256(KEY_HASH256)).getInvocationResult();
+        assertNull(res.getFirstStackItem().getValue());
+
+        ct.invokeFunctionAndAwaitExecution(REMOVE_DATA, byteArray(reverseHexString(KEY_HASH256_HEX)));
+    }
+
+    @Test
     public void deleteByECPoint() throws Throwable {
         ct.invokeFunctionAndAwaitExecution(STORE_DATA, byteArray(KEY_ECPOINT_HEX), byteArrayFromString("del by point"));
 
@@ -2110,25 +2142,25 @@ public class StorageMapIntegrationTest {
             return Storage.get(ctx, prefix.concat(key.toByteArray()));
         }
 
-        public static ByteString putECPointKeyIntegerValue(io.neow3j.devpack.ECPoint key, int value) {
+        public static ByteString putECPointKeyIntegerValue(ECPoint key, int value) {
             assert ECPoint.isValid(key);
             map.put(key, value);
             return Storage.get(ctx, prefix.concat(key.toByteArray()));
         }
 
-        public static ByteString putECPointKeyBooleanValue(io.neow3j.devpack.ECPoint key, boolean value) {
+        public static ByteString putECPointKeyBooleanValue(ECPoint key, boolean value) {
             assert ECPoint.isValid(key);
             map.put(key, value);
             return Storage.get(ctx, prefix.concat(key.toByteArray()));
         }
 
-        public static ByteString putECPointKeyStringValue(io.neow3j.devpack.ECPoint key, String value) {
+        public static ByteString putECPointKeyStringValue(ECPoint key, String value) {
             assert ECPoint.isValid(key);
             map.put(key, value);
             return Storage.get(ctx, prefix.concat(key.toByteArray()));
         }
 
-        public static ByteString putECPointKeyHash160Value(io.neow3j.devpack.ECPoint key, io.neow3j.devpack.Hash160 value) {
+        public static ByteString putECPointKeyHash160Value(ECPoint key, io.neow3j.devpack.Hash160 value) {
             assert ECPoint.isValid(key);
             map.put(key, value);
             return Storage.get(ctx, prefix.concat(key.toByteArray()));
@@ -2168,6 +2200,16 @@ public class StorageMapIntegrationTest {
         public static ByteString deleteByInteger(int key) {
             map.delete(key);
             return Storage.get(ctx, prefix.concat(key));
+        }
+
+        public static ByteString deleteByHash160(io.neow3j.devpack.Hash160 key) {
+            map.delete(key);
+            return Storage.get(ctx, prefix.concat(key.toByteString()));
+        }
+
+        public static ByteString deleteByHash256(io.neow3j.devpack.Hash256 key) {
+            map.delete(key);
+            return Storage.get(ctx, prefix.concat(key.toByteString()));
         }
 
         public static ByteString deleteByECPoint(ECPoint key) {


### PR DESCRIPTION
Closes #985 