### PR TITLE
Make the output of `compileJava` an input of `neow3jCompile` to have a consistent caching behavior

### DIFF
--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
@@ -6,6 +6,7 @@ import org.gradle.api.provider.Property;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputDirectory;
+import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
@@ -13,6 +14,9 @@ abstract public class Neow3jCompileTask extends DefaultTask {
     static final String CLASSNAME_NAME = "className";
     private static final String DEBUG_NAME = "debug";
     private static final String OUTPUT_DIR_NAME = "outputDir";
+
+    @InputDirectory
+    public abstract DirectoryProperty getBuildDirectory();
 
     @Input
     @Option(option = CLASSNAME_NAME, description = "Sets the smart contract class name (fully qualified name) to be " +

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
@@ -18,7 +18,7 @@ abstract public class Neow3jCompileTask extends DefaultTask {
 
     @Input
     @Option(option = CACHEABLE_NAME, description = "Sets wheter the neow3j compiler should cache the compilation output.")
-    public abstract Property<Boolean> getCacheFlag();
+    public abstract Property<Boolean> getCacheable();
 
     @Input
     @Option(option = CLASSNAME_NAME, description = "Sets the smart contract class name (fully qualified name) to be " +

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
@@ -10,15 +10,9 @@ import org.gradle.api.tasks.TaskAction;
 import org.gradle.api.tasks.options.Option;
 
 abstract public class Neow3jCompileTask extends DefaultTask {
-
-    static final String CACHEABLE_NAME = "cacheable";
     static final String CLASSNAME_NAME = "className";
     private static final String DEBUG_NAME = "debug";
     private static final String OUTPUT_DIR_NAME = "outputDir";
-
-    @Input
-    @Option(option = CACHEABLE_NAME, description = "Sets wheter the neow3j compiler should cache the compilation output.")
-    public abstract Property<Boolean> getCacheable();
 
     @Input
     @Option(option = CLASSNAME_NAME, description = "Sets the smart contract class name (fully qualified name) to be " +

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
@@ -11,13 +11,13 @@ import org.gradle.api.tasks.options.Option;
 
 abstract public class Neow3jCompileTask extends DefaultTask {
 
-    static final String CACHE_FLAG = "cacheFlag";
+    static final String CACHEABLE_NAME = "cacheable";
     static final String CLASSNAME_NAME = "className";
     private static final String DEBUG_NAME = "debug";
     private static final String OUTPUT_DIR_NAME = "outputDir";
 
     @Input
-    @Option(option = CACHE_FLAG, description = "Sets the cache flag for compiling")
+    @Option(option = CACHEABLE_NAME, description = "Sets wheter the neow3j compiler should cache the compilation output.")
     public abstract Property<Boolean> getCacheFlag();
 
     @Input

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jCompileTask.java
@@ -11,9 +11,14 @@ import org.gradle.api.tasks.options.Option;
 
 abstract public class Neow3jCompileTask extends DefaultTask {
 
+    static final String CACHE_FLAG = "cacheFlag";
     static final String CLASSNAME_NAME = "className";
     private static final String DEBUG_NAME = "debug";
     private static final String OUTPUT_DIR_NAME = "outputDir";
+
+    @Input
+    @Option(option = CACHE_FLAG, description = "Sets the cache flag for compiling")
+    public abstract Property<Boolean> getCacheFlag();
 
     @Input
     @Option(option = CLASSNAME_NAME, description = "Sets the smart contract class name (fully qualified name) to be " +

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPlugin.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPlugin.java
@@ -3,6 +3,7 @@ package io.neow3j.devpack.gradle;
 import org.gradle.api.Plugin;
 import org.gradle.api.Project;
 import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.util.GradleVersion;
@@ -37,6 +38,8 @@ public class Neow3jPlugin implements Plugin<Project> {
             task.getDebug().set(extension.getDebug());
             task.getOutputDir().set(extension.getOutputDir());
             task.getProject().getPluginManager().apply(JavaLibraryPlugin.class);
+            JavaCompile compileJava = (JavaCompile) project.getTasks().getByName(JavaPlugin.COMPILE_JAVA_TASK_NAME);
+            task.getBuildDirectory().set(compileJava.getDestinationDir());
             task.dependsOn(JavaPlugin.COMPILE_JAVA_TASK_NAME);
         });
     }

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPlugin.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPlugin.java
@@ -31,11 +31,8 @@ public class Neow3jPlugin implements Plugin<Project> {
         // Set default values that will be overwritten by the values set in dev's build.gradle.
         extension.getDebug().set(true);
         extension.getOutputDir().set(new File(buildDir.getAsFile().get(), DEFAULT_OUTPUT_DIR));
-        extension.getCacheable().set(false);
 
         project.getTasks().create(TASK_NAME, Neow3jCompileTask.class, task -> {
-            task.getCacheable().set(extension.getCacheable());
-            task.getOutputs().cacheIf(value -> extension.getCacheable().get());
             task.getClassName().set(extension.getClassName());
             task.getDebug().set(extension.getDebug());
             task.getOutputDir().set(extension.getOutputDir());

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPlugin.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPlugin.java
@@ -6,8 +6,6 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.util.GradleVersion;
-import org.gradle.api.specs.Spec;
-import org.gradle.api.specs.Specs;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -33,11 +31,11 @@ public class Neow3jPlugin implements Plugin<Project> {
         // Set default values that will be overwritten by the values set in dev's build.gradle.
         extension.getDebug().set(true);
         extension.getOutputDir().set(new File(buildDir.getAsFile().get(), DEFAULT_OUTPUT_DIR));
-
-        Spec<boolean>cacheFlagSpec = value -> value;
+        extension.getCacheable().set(false);
 
         project.getTasks().create(TASK_NAME, Neow3jCompileTask.class, task -> {
-            task.getOutputs().cacheIf(cacheFlagSpec -> getCacheFlag());
+            task.getCacheable().set(extension.getCacheable());
+            task.getOutputs().cacheIf(value -> extension.getCacheable().get());
             task.getClassName().set(extension.getClassName());
             task.getDebug().set(extension.getDebug());
             task.getOutputDir().set(extension.getOutputDir());

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPlugin.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPlugin.java
@@ -6,6 +6,8 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.plugins.JavaLibraryPlugin;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.util.GradleVersion;
+import org.gradle.api.specs.Spec;
+import org.gradle.api.specs.Specs;
 import org.jetbrains.annotations.NotNull;
 
 import java.io.File;
@@ -32,7 +34,10 @@ public class Neow3jPlugin implements Plugin<Project> {
         extension.getDebug().set(true);
         extension.getOutputDir().set(new File(buildDir.getAsFile().get(), DEFAULT_OUTPUT_DIR));
 
+        Spec<boolean>cacheFlagSpec = value -> value;
+
         project.getTasks().create(TASK_NAME, Neow3jCompileTask.class, task -> {
+            task.getOutputs().cacheIf(cacheFlagSpec -> getCacheFlag());
             task.getClassName().set(extension.getClassName());
             task.getDebug().set(extension.getDebug());
             task.getOutputDir().set(extension.getOutputDir());

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginExtension.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginExtension.java
@@ -4,8 +4,6 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 
 abstract public class Neow3jPluginExtension {
-    
-    public abstract Property<Boolean> getCacheable();
 
     public abstract Property<String> getClassName();
 

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginExtension.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginExtension.java
@@ -4,6 +4,8 @@ import org.gradle.api.file.DirectoryProperty;
 import org.gradle.api.provider.Property;
 
 abstract public class Neow3jPluginExtension {
+    
+    public abstract Property<Boolean> getCacheFlag();
 
     public abstract Property<String> getClassName();
 

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginExtension.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginExtension.java
@@ -5,7 +5,7 @@ import org.gradle.api.provider.Property;
 
 abstract public class Neow3jPluginExtension {
     
-    public abstract Property<Boolean> getCacheFlag();
+    public abstract Property<Boolean> getCacheable();
 
     public abstract Property<String> getClassName();
 

--- a/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginExtension.java
+++ b/gradle-plugin/src/main/java/io/neow3j/devpack/gradle/Neow3jPluginExtension.java
@@ -5,6 +5,8 @@ import org.gradle.api.provider.Property;
 
 abstract public class Neow3jPluginExtension {
 
+    public abstract DirectoryProperty getBuildDirectory();
+
     public abstract Property<String> getClassName();
 
     public abstract Property<Boolean> getDebug();

--- a/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/GradleProjectTestCase.java
+++ b/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/GradleProjectTestCase.java
@@ -99,6 +99,12 @@ public class GradleProjectTestCase {
         appendFile(destination, content);
     }
 
+    protected GradleProjectTestCase replaceMethodName(String oldMethodName, String newMethodName)
+            throws IOException {
+        TestCaseUtils.replaceMethodName(this.smartContractSourceFile.getAbsolutePath(), oldMethodName, newMethodName);
+        return this;
+    }
+
     public GradleProjectTestCase withContractSourceFileName(String contractSourceFileName)
             throws IOException {
         this.contractSourceFileName = contractSourceFileName;

--- a/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/Neow3jCompilePluginIntegrationTest.java
+++ b/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/Neow3jCompilePluginIntegrationTest.java
@@ -261,8 +261,7 @@ public class Neow3jCompilePluginIntegrationTest {
 
         // check whether the compilation miserably failed :-)
         assertEquals(FAILED, buildResult.task(":" + TASK_NAME).getOutcome());
-        assertTrue(testCase.getBuildNeow3jOutputDir().exists());
-        assertEquals(0, requireNonNull(testCase.getBuildNeow3jOutputDir().listFiles()).length);
+        assertFalse(testCase.getBuildNeow3jOutputDir().exists());
     }
 
     @Test

--- a/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/Neow3jCompilePluginIntegrationTest.java
+++ b/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/Neow3jCompilePluginIntegrationTest.java
@@ -54,6 +54,7 @@ public class Neow3jCompilePluginIntegrationTest {
         testCase.runBuild();
         buildResult = testCase.getGradleBuildResult();
         assertNotEquals(FROM_CACHE, buildResult.task(":" + TASK_NAME).getOutcome());
+        assertNotEquals(UP_TO_DATE, buildResult.task(":" + TASK_NAME).getOutcome());
         assertEquals(SUCCESS, buildResult.task(":" + TASK_NAME).getOutcome());
     }
 
@@ -80,6 +81,7 @@ public class Neow3jCompilePluginIntegrationTest {
         testCase.runBuild();
         buildResult = testCase.getGradleBuildResult();
         assertNotEquals(FROM_CACHE, buildResult.task(":" + TASK_NAME).getOutcome());
+        assertNotEquals(SUCCESS, buildResult.task(":" + TASK_NAME).getOutcome());
         assertEquals(UP_TO_DATE, buildResult.task(":" + TASK_NAME).getOutcome());
     }
 

--- a/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/Neow3jCompilePluginIntegrationTest.java
+++ b/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/Neow3jCompilePluginIntegrationTest.java
@@ -13,6 +13,8 @@ import static io.neow3j.devpack.gradle.Neow3jPlugin.TASK_NAME;
 import static java.util.Objects.requireNonNull;
 import static org.gradle.testkit.runner.TaskOutcome.FAILED;
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS;
+import static org.gradle.testkit.runner.TaskOutcome.FROM_CACHE;
+import static org.gradle.testkit.runner.TaskOutcome.UP_TO_DATE;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
@@ -28,7 +30,7 @@ public class Neow3jCompilePluginIntegrationTest {
     public Path projectRootDir;
 
     @Test
-    public void testTaskCompilationCache() {
+    public void testTaskCompilationCache() throws IOException {
         String buildFileContent = "" +
               "sourceCompatibility = JavaVersion.VERSION_1_8" + "\n" +
               "targetCompatibility = JavaVersion.VERSION_1_8" + "\n" +
@@ -50,16 +52,10 @@ public class Neow3jCompilePluginIntegrationTest {
         assertEquals(SUCCESS, firstBuildResult.task(":" + TASK_NAME).getOutcome());
 
         // run for the second time to assert cache was not used
-        GradleProjectTestCase testCacheNotUsed = new GradleProjectTestCase(this.projectRootDir)
-              .withDefaultDependencies()
-              .appendToBuildFile(buildFileContent)
-              .withContractName("ContractTest")
-              .withContractSourceFileName("ContractTest.java")
-              .runBuild();
-
-        BuildResult buildResult = testCacheNotUsed.getGradleBuildResult();
+        testCase.runBuild();
+        BuildResult buildResult = testCase.getGradleBuildResult();
         assertNotEquals(FROM_CACHE, buildResult.task(":" + TASK_NAME).getOutcome());
-        assertEquals(SUCCESS, buildResult.task(":" + TASK_NAME).getOutcome());
+        assertEquals(UP_TO_DATE, buildResult.task(":" + TASK_NAME).getOutcome());
     }
 
     @Test

--- a/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/TestCaseUtils.java
+++ b/gradle-plugin/src/test-integration/java/io/neow3j/devpack/gradle/TestCaseUtils.java
@@ -7,6 +7,9 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.charset.StandardCharsets;
 import java.util.stream.Collectors;
 
@@ -51,4 +54,16 @@ public class TestCaseUtils {
         return in.lines().collect(Collectors.joining());
     }
 
+    protected static void replaceMethodName(String filePath, String oldMethodName, String newMethodName) throws IOException {
+        Path path = Paths.get(filePath);
+
+        // Read the file content into a String
+        String content = new String(Files.readAllBytes(path), StandardCharsets.UTF_8);
+
+        // Replace the method name
+        content = content.replaceAll("\\b" + oldMethodName + "\\b", newMethodName);
+
+        // Write the modified content back to the file
+        Files.write(path, content.getBytes(StandardCharsets.UTF_8));
+    }
 }


### PR DESCRIPTION
#1016 

So @gsmachado I've followed your instructions, and I think this is the right way. I'm sure i dont understand 100% how it all happens, but Im getting along. Now I need to test this changes (specially the syntax around Spec), but I'm not quite sure how, running `./gradlew tests` or `./gradlew integrationTests` is failing, is there any setup needed? If so, where can I find it?