### PR TITLE
Make the "core" dependency in devpack transitive

### DIFF
--- a/devpack/build.gradle
+++ b/devpack/build.gradle
@@ -1,7 +1,7 @@
 description 'neow3j: Java Development Package for Neo Smart Contracts'
 
 dependencies {
-    implementation project(':core')
+    api project(':core')
 }
 
 compileJava {


### PR DESCRIPTION
Without having access to the _core_ module, developers using the devpack get warnings about undiscoverable enum values from OpCode and InteropService which are used in the devpack. Making the _core_ dependency transitive fixes the issue.

Here's how it looked like:
![Screenshot 2024-04-16 at 09 55 36](https://github.com/neow3j/neow3j/assets/37138571/57e0cdf9-175d-421f-ad40-4d69ad3b3e54)
