### PR TITLE
Revert "Make the "core" dependency in devpack transitive"

### DIFF
--- a/devpack/build.gradle
+++ b/devpack/build.gradle
@@ -1,7 +1,7 @@
 description 'neow3j: Java Development Package for Neo Smart Contracts'
 
 dependencies {
-    api project(':core')
+    implementation project(':core')
 }
 
 compileJava {


### PR DESCRIPTION
Reverts neow3j/neow3j#1047

As we discussed in the daily, we should revert and then open an issue to properly implement a way to avoid developers to be confused with type of the core & SDK & devpack.