### PR TITLE
Improve GitHub workflow dispatch inputs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,10 +3,12 @@ name: Release SDK, devpack, Gradle plugin
 on:
   workflow_dispatch:
     inputs:
-      snapshot:
-        description: 'Publish snapshot?'
-        required: false
-        default: 'false'
+      release-type:
+        description: 'Release Type'
+        type: choice
+        options:
+          - Snapshot
+          - Official
 
 jobs:
   build:
@@ -21,8 +23,8 @@ jobs:
           cache: 'gradle'
       - name: Unit Tests
         run: ./gradlew --info clean test
-      - name: Release
-        if: github.event.inputs.snapshot != 'true'
+      - name: Release Official Version
+        if: inputs.release-type == 'Official'
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY_ARMORED }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_KEY_PASSWORD }}
@@ -33,14 +35,11 @@ jobs:
         run: | # If the neofs module is to be published in the future, remove the -x :neofs:publishToSonatype
           ./gradlew --info -x test -x :gradle-plugin:publishToSonatype -x :neofs:publishToSonatype publishToSonatype closeAndReleaseSonatypeStagingRepository
           ./gradlew :gradle-plugin:publishPlugin -Pgradle.publish.key=$GRADLE_PUBLISH_KEY -Pgradle.publish.secret=$GRADLE_PUBLISH_SECRET
-      - name: Release Snapshot
-        if: github.event.inputs.snapshot == 'true'
+      - name: Release Snapshot Version
+        if: inputs.release-type == 'Snapshot'
         env:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.GPG_KEY_ARMORED }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.GPG_KEY_PASSWORD }}
           ORG_GRADLE_PROJECT_sonatypeUsername: ${{ secrets.SONATYPE_USERNAME }}
           ORG_GRADLE_PROJECT_sonatypePassword: ${{ secrets.SONATYPE_PASSWORD }}
-        run: | # If you want to release a snapshot of gradle-plugin, remove the -x :gradle-plugin:publishToSonatype
-          ./gradlew --info -x test publishToSonatype -Psnapshot 
-
-
+        run: ./gradlew --info -x test publishToSonatype -Psnapshot


### PR DESCRIPTION
With these changes, the workflow dispatch input window will now look like the following:

<img width="319" alt="image" src="https://github.com/neow3j/neow3j/assets/53603111/70650f17-181c-4547-a1e3-5055d259c787">

<img width="323" alt="image" src="https://github.com/neow3j/neow3j/assets/53603111/e727b21e-6051-4185-97a4-6785337baccb">

@csmuller, I didn't get the reason for the comment on the snapshot run command on line 43 `# If you want to release a snapshot of gradle-plugin, remove the -x :gradle-plugin:publishToSonatype` since there is no `-x :gradle-plugin:publishToSonatype` there. I don't understand it in that context. Can you tell me what it's about?

Afaik, the snapshot release also publishes the gradle-plugin now (please correct me if I'm wrong). Do you think we should have an option of releasing a snapshot without the gradle-plugin? If not, I'll leave it like it is.