### PR TITLE
Update test-tools for neo-express 3.7.6 changes

### DIFF
--- a/int-tests/src/test-integration/java/io/neow3j/protocol/Neow3jReadOnlyIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/protocol/Neow3jReadOnlyIntegrationTest.java
@@ -733,7 +733,7 @@ public class Neow3jReadOnlyIntegrationTest {
         assertThat(protocol.getInitialGasDistribution(),
                 is(BigInteger.valueOf(5_200_000_000_000_000L)));
 
-        assertThat(protocol.getHardforks(), hasSize(3));
+        assertThat(protocol.getHardforks(), hasSize(4));
         NeoGetVersion.NeoVersion.Protocol.Hardforks aspidochelone = protocol.getHardforks().get(0);
         assertThat(aspidochelone.getName(), is("Aspidochelone"));
         assertThat(aspidochelone.getBlockHeight(), is(BigInteger.ZERO));
@@ -743,6 +743,9 @@ public class Neow3jReadOnlyIntegrationTest {
         NeoGetVersion.NeoVersion.Protocol.Hardforks cockatrice = protocol.getHardforks().get(2);
         assertThat(cockatrice.getName(), is("Cockatrice"));
         assertThat(cockatrice.getBlockHeight(), is(BigInteger.ZERO));
+        NeoGetVersion.NeoVersion.Protocol.Hardforks domovoi = protocol.getHardforks().get(3);
+        assertThat(domovoi.getName(), is("Domovoi"));
+        assertThat(domovoi.getBlockHeight(), is(BigInteger.ZERO));
     }
 
     // SmartContract Methods
@@ -901,7 +904,7 @@ public class Neow3jReadOnlyIntegrationTest {
                 .getPlugins();
 
         assertNotNull(plugins);
-        assertThat(plugins, hasSize(11));
+        assertThat(plugins, hasSize(10));
     }
 
     @Test

--- a/test-tools/src/main/java/io/neow3j/test/TestBlockchain.java
+++ b/test-tools/src/main/java/io/neow3j/test/TestBlockchain.java
@@ -101,13 +101,23 @@ public interface TestBlockchain {
     String fastForward(int seconds, int n) throws Exception;
 
     /**
-     * Executes the given command.
+     * Executes the given command in the test container.
      *
      * @param commandParts the command separated into its parts.
      * @return the message emitted on executing the command or null if no message is emitted.
      * @throws Exception if an error occurred when trying to execute the command on the blockchain.
      */
     String execCommand(String... commandParts) throws Exception;
+
+    /**
+     * Executes a {@code neoxp} command with the given command parts using the test container's default neo-express
+     * file path as input to the command.
+     *
+     * @param commandParts the neoxp command parts.
+     * @return the message emitted on executing the command or null if no message is emitted.
+     * @throws Exception if an error occurred when trying to execute the command on the blockchain.
+     */
+    String execNeoxpCommandWithDefaultConfig(String... commandParts) throws Exception;
 
     /**
      * Starts the blockchain, i.e., the process that includes the blockchain.

--- a/test-tools/src/main/resources/test.properties
+++ b/test-tools/src/main/resources/test.properties
@@ -34,5 +34,5 @@ oracleContractHash=fe924b7cfe89ddd271abaf7210a80a7e11178758
 nameServiceHash=7a8fcf0392cd625647907afa8e45cc66872b596b
 
 # Test container
-neo3PrivateNetContainerImg=ghcr.io/axlabs/neo3-privatenet-docker/neo-cli-with-plugins:neo-node-3.7.4
-neoExpressDockerImage=ghcr.io/neow3j/neow3j-test-docker:neoxp-3.6.94
+neo3PrivateNetContainerImg=ghcr.io/axlabs/neo3-privatenet-docker/neo-cli-with-plugins:neo-node-3.7.5
+neoExpressDockerImage=ghcr.io/neow3j/neow3j-test-docker:neoxp-3.7.6

--- a/test-tools/src/test/java/io/neow3j/test/NeoExpressTestContainerTest.java
+++ b/test-tools/src/test/java/io/neow3j/test/NeoExpressTestContainerTest.java
@@ -1,0 +1,67 @@
+package io.neow3j.test;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+public class NeoExpressTestContainerTest {
+
+    @Test
+    public void testAddDefaultConfigInput() {
+        ArrayList<String> commands = new ArrayList<>();
+        commands.add("neoxp");
+        commands.add("oracle");
+        commands.add("enable");
+        commands.add("genesis");
+
+        NeoExpressTestContainer.addDefaultConfigInput(commands);
+
+        assertThat(commands, hasSize(6));
+        assertThat(commands.get(4), is("--input"));
+        assertThat(commands.get(5), is(NeoExpressTestContainer.NEOXP_CONFIG_DEST));
+    }
+
+    @Test
+    public void testAddDefaultConfigInput_withExistingInputFlag() {
+        ArrayList<String> commands = new ArrayList<>();
+        commands.add("neoxp");
+        commands.add("oracle");
+        commands.add("enable");
+        commands.add("--input");
+        commands.add(NeoExpressTestContainer.NEOXP_CONFIG_DEST);
+        commands.add("genesis");
+
+        NeoExpressTestContainer.addDefaultConfigInput(commands);
+
+        assertThat(commands, hasSize(6));
+        assertThat(commands.get(0), is("neoxp"));
+        assertThat(commands.get(1), is("oracle"));
+        assertThat(commands.get(2), is("enable"));
+        assertThat(commands.get(3), is("--input"));
+        assertThat(commands.get(4), is(NeoExpressTestContainer.NEOXP_CONFIG_DEST));
+        assertThat(commands.get(5), is("genesis"));
+    }
+
+    @Test
+    public void testAddNeoxpCommand() {
+        ArrayList<String> commands = new ArrayList<>();
+        commands.add("create");
+
+        NeoExpressTestContainer.addNeoxpCommand(commands);
+
+        assertThat(commands, hasSize(2));
+        assertThat(commands.get(0), is("neoxp"));
+        assertThat(commands.get(1), is("create"));
+
+        NeoExpressTestContainer.addNeoxpCommand(commands);
+
+        assertThat(commands, hasSize(2));
+        assertThat(commands.get(0), is("neoxp"));
+        assertThat(commands.get(1), is("create"));
+    }
+
+}


### PR DESCRIPTION
Neo express has changed how the `neo-express` file is read by default. Before v3.7.x, if no specific file was provided, the `default.neo-express` was expected in the working directory. With the release of 3.7.x, the default file is now expected in the absolute path `/root/.neo-express/default.neo-express`.

In the `neow3j-test-docker`, the `neo-express` file that is used to start a N3 blockchain is located in the absolute path `/neoxp/default.neo-express`. Thus, I adapted the `NeoExpressTestContainer` to use the `--input` flag when sending `neoxp` commands that require to be executed based on this running chain.

The behaviour of the existing methods does not change. There's no breaking change.

There is a new method `execNeoxpCommandWithDefaultConfig(String... commandParts)` which let's you send neoxp commands without the need to add the `neoxp` command as first command part, nor specify the default `neo-express` file in every call. The method is quite forgiving as it does not break if `neoxp` or the `--input` flag are used in the command parts. The input will be replaced with the default location, and the rest is ignored.