### PR TITLE
Allow combined permissions if wildcard permission has specified methods

### DIFF
--- a/compiler/src/main/java/io/neow3j/compiler/ManifestBuilder.java
+++ b/compiler/src/main/java/io/neow3j/compiler/ManifestBuilder.java
@@ -116,12 +116,16 @@ public class ManifestBuilder {
                 .map(ManifestBuilder::getContractPermission)
                 .collect(Collectors.toList());
 
-        // If there is one permission with the wildcard character '*', it must be the only one.
-        boolean wildcardPermission = permissions.stream()
-                .anyMatch(p -> p.getContract().equals("*"));
-        if (wildcardPermission && permissions.size() > 1) {
-            throw new CompilerException("A contract permission with the wildcard character '*' can only be used " +
-                    "exclusively and not in combination with other permissions.");
+        // If there is one permission that has both a wildcard for contracts and a wildcard for methods, it should be
+        // the only permission of this contract as any other permission would be redundant. While it's technically
+        // allowed, neow3j will throw an exception to make sure the developer is aware and not left with a false
+        // promise.
+        boolean completeWildcardPermission = permissions.stream()
+                .anyMatch(p -> p.getContract().equals("*") &&
+                        p.getMethods().size() == 1 && p.getMethods().get(0).equals("*"));
+        if (completeWildcardPermission && permissions.size() > 1) {
+            throw new CompilerException("A contract permission with the wildcard character '*' for contracts and " +
+                    "methods should only be used exclusively and not in combination with other permissions.");
         }
         return permissions;
     }

--- a/compiler/src/test/java/io/neow3j/compiler/PermissionManifestTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/PermissionManifestTest.java
@@ -162,8 +162,25 @@ public class PermissionManifestTest {
         CompilerException thrown = assertThrows(CompilerException.class, () -> new Compiler().compile(
                 PermissionManifestTestContractWithRedundantPermissions.class.getName()));
         assertThat(thrown.getMessage(),
-                containsString("A contract permission with the wildcard character '*' can only be used " +
-                        "exclusively and not in combination with other permissions."));
+                containsString("A contract permission with the wildcard character '*' for contracts and methods " +
+                        "should only be used exclusively and not in combination with other permissions."));
+    }
+
+    @Test
+    public void testWildcardContractsWithMethodsCombination() throws IOException {
+        CompilationUnit compUnit = new Compiler().compile(
+                PermissionManifestTestContractWithWildcardContractsWithSpecifiedMethodsAndOtherPermissions.class.getName());
+        List<ContractPermission> permissions = compUnit.getManifest().getPermissions();
+        assertThat(permissions, hasSize(3));
+        assertThat(new Hash160(permissions.get(0).getContract()), is(NativeContract.LedgerContract.getContractHash()));
+        assertThat(permissions.get(0).getMethods(), hasSize(1));
+        assertThat(permissions.get(0).getMethods().get(0), is("*"));
+        assertThat(permissions.get(1).getContract(), is(CONTRACT_HASH_1));
+        assertThat(permissions.get(1).getMethods(), hasSize(1));
+        assertThat(permissions.get(1).getMethods().get(0), is("*"));
+        assertThat(permissions.get(2).getContract(), is("*"));
+        assertThat(permissions.get(2).getMethods(), hasSize(1));
+        assertThat(permissions.get(2).getMethods().get(0), is("onNEP17Payment"));
     }
 
     @Test
@@ -276,8 +293,18 @@ public class PermissionManifestTest {
 
     @Permission(nativeContract = NativeContract.LedgerContract)
     @Permission(contract = CONTRACT_HASH_1)
-    @Permission(contract = "*")
+    @Permission(contract = "*", methods = {"*"})
     static class PermissionManifestTestContractWithRedundantPermissions {
+
+        public static void main() {
+        }
+
+    }
+
+    @Permission(nativeContract = NativeContract.LedgerContract)
+    @Permission(contract = CONTRACT_HASH_1)
+    @Permission(contract = "*", methods = "onNEP17Payment")
+    static class PermissionManifestTestContractWithWildcardContractsWithSpecifiedMethodsAndOtherPermissions {
 
         public static void main() {
         }


### PR DESCRIPTION
Fixes #1082 

This is a non-breaking change as it expands what is allowed.