### PR TITLE
Add `Neow3j.init()` to fetch node-specific version info

### DIFF
--- a/core/src/main/java/io/neow3j/protocol/Neow3j.java
+++ b/core/src/main/java/io/neow3j/protocol/Neow3j.java
@@ -2,6 +2,7 @@ package io.neow3j.protocol;
 
 import io.neow3j.protocol.core.JsonRpc2_0Neow3j;
 import io.neow3j.protocol.core.Neo;
+import io.neow3j.protocol.core.response.NeoGetVersion;
 import io.neow3j.protocol.rx.Neow3jRx;
 import io.neow3j.types.Hash160;
 
@@ -10,6 +11,8 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+
+import static io.neow3j.protocol.core.JsonRpc2_0Neow3j.initializedJsonRpc2_0Neow3j;
 
 /**
  * JSON-RPC Request object building factory.
@@ -29,7 +32,7 @@ public abstract class Neow3j implements Neo, Neow3jRx {
      * @return the new Neow3j instance.
      */
     public static Neow3j build(Neow3jService neow3jService) {
-        return new JsonRpc2_0Neow3j(neow3jService, new Neow3jConfig());
+        return build(neow3jService, new Neow3jConfig());
     }
 
     /**
@@ -41,6 +44,29 @@ public abstract class Neow3j implements Neo, Neow3jRx {
      */
     public static Neow3j build(Neow3jService neow3jService, Neow3jConfig config) {
         return new JsonRpc2_0Neow3j(neow3jService, config);
+    }
+
+    /**
+     * Constructs a new Neow3j instance using the given configuration.
+     * <p>
+     * Fetches version specific information from the node to be used in this instance's configuration. This will
+     * overwrite variables in the config for the variables contained in {@link Neow3jConfig.ConfigValue}. Note, that
+     * it only overwrites default values. If a variable (e.g., msPerBlock) has been manually set in the config
+     * parameter (i.e., with {@link Neow3jConfig#setBlockInterval(int)}), this variable will NOT be overwritten by
+     * the node value. That means: {@code user-set value >> node-provided value >> default values} | where {@code a
+     * >> b} means that a will be used if a is present.
+     *
+     * @param neow3jService a neow3j service instance, i.e., HTTP or IPC.
+     * @param config        the configuration to use.
+     * @return the new Neow3j instance.
+     * @throws IOException if something goes wrong when communicating with the Neo node.
+     */
+    public static Neow3j init(Neow3jService neow3jService, Neow3jConfig config) throws IOException {
+        return initializedJsonRpc2_0Neow3j(neow3jService, config);
+    }
+
+    protected void setNodeVersionInfo(NeoGetVersion.NeoVersion.Protocol protocol) {
+         config.setNodeVersionInfo(protocol);
     }
 
     /**
@@ -156,9 +182,7 @@ public abstract class Neow3j implements Neo, Neow3jRx {
 
     /**
      * Gets the maximum time in milliseconds that can pass form the construction of a transaction until it gets
-     * included in a block. A transaction becomes invalid after this time increment is surpassed. @return the
-     * <p>
-     * Defaults to {@link Neow3jConfig#MAX_VALID_UNTIL_BLOCK_INCREMENT_BASE} divided by the configured block interval.
+     * included in a block. A transaction becomes invalid after this time increment is surpassed.
      *
      * @return the maximum valid until block time increment.
      */

--- a/core/src/main/java/io/neow3j/protocol/core/JsonRpc2_0Neow3j.java
+++ b/core/src/main/java/io/neow3j/protocol/core/JsonRpc2_0Neow3j.java
@@ -94,6 +94,15 @@ public class JsonRpc2_0Neow3j extends Neow3j {
         this.neow3jRx = new JsonRpc2_0Rx(this, getScheduledExecutorService());
     }
 
+    public static JsonRpc2_0Neow3j initializedJsonRpc2_0Neow3j(Neow3jService neow3jService, Neow3jConfig config)
+            throws IOException {
+
+        JsonRpc2_0Neow3j jsonRpc20Neow3j = new JsonRpc2_0Neow3j(neow3jService, config);
+        NeoGetVersion.NeoVersion.Protocol protocol = jsonRpc20Neow3j.getVersion().send().getVersion().getProtocol();
+        jsonRpc20Neow3j.setNodeVersionInfo(protocol);
+        return jsonRpc20Neow3j;
+    }
+
     // region Blockchain Methods
 
     /**


### PR DESCRIPTION
Closes (#1081)

`Neow3j.build()` might be used in several places within neow3j where a node need not be present. Thus, I dislike the idea of adding an integrated RPC call in the `build()` function.

Instead, we could add another static creator function for a Neow3j object. One, that allows to fetch node-specific version info directly at object creation time. `Neow3j.init()` will do the same as `Neow3j.build()` plus additionally, it executes a `getVersion` RPC to get the node-specific protocol values and sets those required by neow3j in the Neow3j object's config. The values that can be fetched from the node and are useful for the Neow3j instance are collected in the enum `Neow3jConfig.ConfigValue`. For these values applies (a >> b meaning a preferred over b):

user-set value >> node-specific value >> default value