### PR TITLE
Replace neow3j config constructor with static default function

### DIFF
--- a/contract/src/test/java/io/neow3j/contract/ContractManagementTest.java
+++ b/contract/src/test/java/io/neow3j/contract/ContractManagementTest.java
@@ -3,7 +3,6 @@ package io.neow3j.contract;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.neow3j.protocol.Neow3j;
-import io.neow3j.protocol.Neow3jConfig;
 import io.neow3j.protocol.core.response.ContractManifest;
 import io.neow3j.protocol.core.response.ContractState;
 import io.neow3j.protocol.exceptions.RpcResponseErrorException;
@@ -30,6 +29,7 @@ import java.util.List;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static io.neow3j.constants.NeoConstants.MAX_MANIFEST_SIZE;
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static io.neow3j.protocol.ObjectMapperFactory.getObjectMapper;
 import static io.neow3j.test.WireMockTestHelper.setUpWireMockForCall;
 import static io.neow3j.test.WireMockTestHelper.setUpWireMockForInvokeFunction;
@@ -72,7 +72,7 @@ public class ContractManagementTest {
         // Configuring WireMock to use default host and the dynamic port set in WireMockRule.
         int port = wireMockExtension.getPort();
         WireMock.configureFor(port);
-        neow3j = Neow3j.build(new HttpService("http://127.0.0.1:" + port), new Neow3jConfig().setNetworkMagic(769));
+        neow3j = Neow3j.build(new HttpService("http://127.0.0.1:" + port), defaultNeow3jConfig().setNetworkMagic(769));
         account1 = Account.fromWIF("L1WMhxazScMhUrdv34JqQb1HFSQmWeN2Kpc1R9JGKwL7CDNP21uR");
     }
 

--- a/contract/src/test/java/io/neow3j/contract/PolicyContractTest.java
+++ b/contract/src/test/java/io/neow3j/contract/PolicyContractTest.java
@@ -3,7 +3,6 @@ package io.neow3j.contract;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.neow3j.protocol.Neow3j;
-import io.neow3j.protocol.Neow3jConfig;
 import io.neow3j.protocol.http.HttpService;
 import io.neow3j.script.ScriptBuilder;
 import io.neow3j.transaction.Transaction;
@@ -19,6 +18,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static io.neow3j.types.ContractParameter.hash160;
 import static io.neow3j.types.ContractParameter.integer;
 import static io.neow3j.test.WireMockTestHelper.setUpWireMockForCall;
@@ -52,7 +52,7 @@ public class PolicyContractTest {
         int port = wireMockExtension.getPort();
         WireMock.configureFor(port);
         Neow3j neow3j = Neow3j.build(new HttpService("http://127.0.0.1:" + port),
-                new Neow3jConfig().setNetworkMagic(769));
+                defaultNeow3jConfig().setNetworkMagic(769));
         policyContract = new PolicyContract(neow3j);
         account1 = Account.fromWIF("L1WMhxazScMhUrdv34JqQb1HFSQmWeN2Kpc1R9JGKwL7CDNP21uR");
         recipient = new Hash160("969a77db482f74ce27105f760efa139223431394");

--- a/contract/src/test/java/io/neow3j/contract/SmartContractTest.java
+++ b/contract/src/test/java/io/neow3j/contract/SmartContractTest.java
@@ -4,7 +4,6 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import io.neow3j.contract.exceptions.UnexpectedReturnTypeException;
 import io.neow3j.protocol.Neow3j;
-import io.neow3j.protocol.Neow3jConfig;
 import io.neow3j.protocol.core.response.ContractManifest;
 import io.neow3j.protocol.core.response.NeoInvokeFunction;
 import io.neow3j.protocol.core.stackitem.StackItem;
@@ -27,6 +26,7 @@ import java.util.List;
 import java.util.function.Function;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static io.neow3j.test.WireMockTestHelper.setUpWireMockForCall;
 import static io.neow3j.test.WireMockTestHelper.setUpWireMockForInvokeFunction;
 import static io.neow3j.types.ContractParameter.hash160;
@@ -71,7 +71,7 @@ public class SmartContractTest {
         // Configuring WireMock to use default host and the dynamic port set in WireMockRule.
         int port = wireMockExtension.getPort();
         WireMock.configureFor(port);
-        neow = Neow3j.build(new HttpService("http://127.0.0.1:" + port), new Neow3jConfig().setNetworkMagic(769));
+        neow = Neow3j.build(new HttpService("http://127.0.0.1:" + port), defaultNeow3jConfig().setNetworkMagic(769));
         account1 = Account.fromWIF("L1WMhxazScMhUrdv34JqQb1HFSQmWeN2Kpc1R9JGKwL7CDNP21uR");
         recipient = new Hash160("969a77db482f74ce27105f760efa139223431394");
         someContract = new SmartContract(SOME_SCRIPT_HASH, neow);

--- a/core/src/main/java/io/neow3j/protocol/Neow3j.java
+++ b/core/src/main/java/io/neow3j/protocol/Neow3j.java
@@ -12,6 +12,7 @@ import java.nio.ByteOrder;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static io.neow3j.protocol.core.JsonRpc2_0Neow3j.initializedJsonRpc2_0Neow3j;
 
 /**
@@ -32,7 +33,7 @@ public abstract class Neow3j implements Neo, Neow3jRx {
      * @return the new Neow3j instance.
      */
     public static Neow3j build(Neow3jService neow3jService) {
-        return build(neow3jService, new Neow3jConfig());
+        return build(neow3jService, defaultNeow3jConfig());
     }
 
     /**

--- a/core/src/main/java/io/neow3j/protocol/Neow3jConfig.java
+++ b/core/src/main/java/io/neow3j/protocol/Neow3jConfig.java
@@ -96,25 +96,13 @@ public class Neow3jConfig {
     }
 
     /**
-     * Constructs a configuration instance with default values.
+     * @return constructs a configuration instance with default values.
      */
-    public Neow3jConfig() {
+    public static Neow3jConfig defaultNeow3jConfig() {
+        return new Neow3jConfig();
     }
 
-    public Neow3jConfig(long networkMagic, int blockInterval, int pollingInterval, long maxValidUntilBlockIncrement,
-            ScheduledExecutorService scheduledExecutorService) {
-        this(networkMagic, blockInterval, pollingInterval, maxValidUntilBlockIncrement, scheduledExecutorService,
-                MAINNET_NNS_CONTRACT_HASH);
-    }
-
-    public Neow3jConfig(long networkMagic, int blockInterval, int pollingInterval, long maxValidUntilBlockIncrement,
-            ScheduledExecutorService scheduledExecutorService, Hash160 neoNameServiceScriptHash) {
-        this.networkMagic = networkMagic;
-        this.blockInterval = blockInterval;
-        this.maxValidUntilBlockIncrement = maxValidUntilBlockIncrement;
-        this.pollingInterval = pollingInterval;
-        this.scheduledExecutorService = scheduledExecutorService;
-        this.nnsResolver = neoNameServiceScriptHash;
+    private Neow3jConfig() {
     }
 
     /**

--- a/core/src/main/java/io/neow3j/protocol/Neow3jExpress.java
+++ b/core/src/main/java/io/neow3j/protocol/Neow3jExpress.java
@@ -14,6 +14,7 @@ import io.neow3j.protocol.core.response.NeoExpressShutdown;
 import io.neow3j.protocol.core.response.OracleResponse;
 import io.neow3j.types.Hash160;
 
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static java.util.Arrays.asList;
 import static java.util.Collections.emptyList;
 
@@ -33,7 +34,7 @@ public class Neow3jExpress extends JsonRpc2_0Neow3j implements NeoExpress {
      * @return the new Neow3jExpress instance
      */
     public static Neow3jExpress build(Neow3jService neow3jService) {
-        return new Neow3jExpress(neow3jService, new Neow3jConfig()) {
+        return new Neow3jExpress(neow3jService, defaultNeow3jConfig()) {
         };
     }
 

--- a/core/src/test/java/io/neow3j/protocol/core/JsonRpc2_0Neow3jTest.java
+++ b/core/src/test/java/io/neow3j/protocol/core/JsonRpc2_0Neow3jTest.java
@@ -1,13 +1,13 @@
 package io.neow3j.protocol.core;
 
 import io.neow3j.protocol.Neow3j;
-import io.neow3j.protocol.Neow3jConfig;
 import io.neow3j.protocol.Neow3jService;
 import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.util.concurrent.ScheduledExecutorService;
 
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThrows;
@@ -21,7 +21,7 @@ public class JsonRpc2_0Neow3jTest {
             = mock(ScheduledExecutorService.class);
     private Neow3jService service = mock(Neow3jService.class);
 
-    private Neow3j neow3j = Neow3j.build(service, new Neow3jConfig()
+    private Neow3j neow3j = Neow3j.build(service, defaultNeow3jConfig()
             .setPollingInterval(10)
             .setScheduledExecutorService(scheduledExecutorService));
 

--- a/core/src/test/java/io/neow3j/protocol/rx/JsonRpc2_0RxTest.java
+++ b/core/src/test/java/io/neow3j/protocol/rx/JsonRpc2_0RxTest.java
@@ -1,5 +1,6 @@
 package io.neow3j.protocol.rx;
 
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.Is.is;
@@ -11,7 +12,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import io.neow3j.protocol.Neow3j;
-import io.neow3j.protocol.Neow3jConfig;
 import io.neow3j.protocol.Neow3jService;
 import io.neow3j.protocol.core.Request;
 import io.neow3j.protocol.core.response.NeoBlock;
@@ -43,7 +43,7 @@ public class JsonRpc2_0RxTest {
     @BeforeAll
     public void setUp() {
         neow3jService = mock(Neow3jService.class);
-        neow3j = Neow3j.build(neow3jService, new Neow3jConfig()
+        neow3j = Neow3j.build(neow3jService, defaultNeow3jConfig()
                 .setPollingInterval(1000)
                 .setScheduledExecutorService(Executors.newSingleThreadScheduledExecutor()));
     }

--- a/core/src/test/java/io/neow3j/transaction/TransactionBuilderTest.java
+++ b/core/src/test/java/io/neow3j/transaction/TransactionBuilderTest.java
@@ -7,7 +7,6 @@ import io.neow3j.crypto.Base64;
 import io.neow3j.crypto.ECKeyPair;
 import io.neow3j.crypto.ECKeyPair.ECPublicKey;
 import io.neow3j.protocol.Neow3j;
-import io.neow3j.protocol.Neow3jConfig;
 import io.neow3j.protocol.core.response.InvocationResult;
 import io.neow3j.protocol.core.response.NeoApplicationLog;
 import io.neow3j.protocol.core.response.NeoBlock;
@@ -43,6 +42,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Collectors;
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static io.neow3j.test.TestProperties.neoTokenHash;
 import static io.neow3j.test.WireMockTestHelper.setUpWireMockForBalanceOf;
 import static io.neow3j.test.WireMockTestHelper.setUpWireMockForCall;
@@ -104,7 +104,7 @@ public class TransactionBuilderTest {
         // Configuring WireMock to use default host and the dynamic port set in WireMockRule.
         int port = wireMockExtension.getPort();
         WireMock.configureFor(port);
-        neow = Neow3j.build(new HttpService("http://127.0.0.1:" + port), new Neow3jConfig().setNetworkMagic(769));
+        neow = Neow3j.build(new HttpService("http://127.0.0.1:" + port), defaultNeow3jConfig().setNetworkMagic(769));
         account1 = new Account(ECKeyPair.create(hexStringToByteArray(
                 "e6e919577dd7b8e97805151c05ae07ff4f752654d6d8797597aca989c02c4cb3")));
         account2 = new Account(ECKeyPair.create(hexStringToByteArray(

--- a/core/src/test/java/io/neow3j/transaction/TransactionTest.java
+++ b/core/src/test/java/io/neow3j/transaction/TransactionTest.java
@@ -6,7 +6,6 @@ import io.neow3j.crypto.Base64;
 import io.neow3j.crypto.ECKeyPair;
 import io.neow3j.crypto.Sign;
 import io.neow3j.protocol.Neow3j;
-import io.neow3j.protocol.Neow3jConfig;
 import io.neow3j.protocol.core.response.NeoBlockCount;
 import io.neow3j.protocol.core.response.NeoSendRawTransaction;
 import io.neow3j.protocol.http.HttpService;
@@ -33,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 
 import static io.neow3j.crypto.Hash.sha256;
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static io.neow3j.utils.ArrayUtils.concatenate;
 import static io.neow3j.utils.Numeric.hexStringToByteArray;
 import static java.util.Arrays.asList;
@@ -330,7 +330,7 @@ public class TransactionTest {
     @Test
     public void getTxId() {
         Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"),
-                new Neow3jConfig().setNetworkMagic(5195086));
+                defaultNeow3jConfig().setNetworkMagic(5195086));
 
         List<Signer> signers = new ArrayList<>();
         signers.add(AccountSigner.calledByEntry(account3));
@@ -354,7 +354,7 @@ public class TransactionTest {
     @Test
     public void toArrayWithoutWitness() {
         Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"),
-                new Neow3jConfig().setNetworkMagic(5195086));
+                defaultNeow3jConfig().setNetworkMagic(5195086));
 
         List<Signer> signers = new ArrayList<>();
         signers.add(AccountSigner.calledByEntry(account3));
@@ -378,7 +378,7 @@ public class TransactionTest {
     @Test
     public void getHashData() throws IOException {
         Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"),
-                new Neow3jConfig().setNetworkMagic(769));
+                defaultNeow3jConfig().setNetworkMagic(769));
 
         List<Signer> signers = new ArrayList<>();
         signers.add(AccountSigner.none(Account.fromScriptHash(account1)));
@@ -451,7 +451,8 @@ public class TransactionTest {
 
     @Test
     public void testAddMultiSigWitnessWithPubKeySigMap() throws IOException {
-        Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"), new Neow3jConfig().setNetworkMagic(768));
+        Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"),
+                defaultNeow3jConfig().setNetworkMagic(768));
 
         Account multiSigAccount = Account.createMultiSigAccount(asList(
                         a4.getECKeyPair().getPublicKey(),
@@ -489,7 +490,7 @@ public class TransactionTest {
 
     @Test
     public void testAddMultiSigWitnessWithAccounts() throws IOException {
-        Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"), new Neow3jConfig().setNetworkMagic(768));
+        Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"), defaultNeow3jConfig().setNetworkMagic(768));
 
         Account multiSigAccount = Account.createMultiSigAccount(asList(
                         a4.getECKeyPair().getPublicKey(),
@@ -527,7 +528,7 @@ public class TransactionTest {
     public void toContractParameterContextJson() throws IOException, InvalidAlgorithmParameterException,
             NoSuchAlgorithmException, NoSuchProviderException {
 
-        Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"), new Neow3jConfig().setNetworkMagic(769));
+        Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"), defaultNeow3jConfig().setNetworkMagic(769));
 
         ECKeyPair.ECPublicKey pubKey = ECKeyPair.createEcKeyPair().getPublicKey();
         Account multiSigAccount = Account.createMultiSigAccount(asList(pubKey, pubKey, pubKey), 2);
@@ -590,7 +591,7 @@ public class TransactionTest {
 
     @Test
     public void toContractParameterContextJson_unsupportedContractSigners() throws IOException {
-        Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"), new Neow3jConfig().setNetworkMagic(769));
+        Neow3j neow = Neow3j.build(new HttpService("http://localhost:40332"), defaultNeow3jConfig().setNetworkMagic(769));
 
         Account singleSigAccount1 = Account.create();
         Hash160 dummyHash = new Hash160("f32bf2a3e36a9fd3411337ffcd48eed7bec727ce");

--- a/int-tests/src/test-integration/java/io/neow3j/compiler/LedgerContractIntegrationTest.java
+++ b/int-tests/src/test-integration/java/io/neow3j/compiler/LedgerContractIntegrationTest.java
@@ -36,6 +36,7 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.List;
 
+import static io.neow3j.protocol.Neow3jConfig.defaultNeow3jConfig;
 import static io.neow3j.test.TestProperties.ledgerContractHash;
 import static io.neow3j.types.ContractParameter.hash256;
 import static io.neow3j.types.ContractParameter.integer;
@@ -108,7 +109,7 @@ public class LedgerContractIntegrationTest {
         assertThat(tx.get(4).getInteger().intValue(), greaterThanOrEqualTo(1)); // system fee
         assertThat(tx.get(5).getInteger().intValue(), greaterThanOrEqualTo(1)); // network fee
         assertThat(tx.get(6).getInteger().longValue(),
-                greaterThanOrEqualTo(new Neow3jConfig().getMaxValidUntilBlockIncrement()));
+                greaterThanOrEqualTo(defaultNeow3jConfig().getMaxValidUntilBlockIncrement()));
         assertThat(tx.get(7).getHexString().length(), greaterThanOrEqualTo(1)); // script
     }
 
@@ -123,7 +124,7 @@ public class LedgerContractIntegrationTest {
         assertThat(tx.get(4).getInteger().intValue(), greaterThanOrEqualTo(1)); // system fee
         assertThat(tx.get(5).getInteger().intValue(), greaterThanOrEqualTo(1)); // network fee
         assertThat(tx.get(6).getInteger().longValue(),
-                greaterThanOrEqualTo(new Neow3jConfig().getMaxValidUntilBlockIncrement()));
+                greaterThanOrEqualTo(defaultNeow3jConfig().getMaxValidUntilBlockIncrement()));
         assertThat(tx.get(7).getHexString().length(), greaterThanOrEqualTo(1)); // script
     }
 
@@ -275,7 +276,7 @@ public class LedgerContractIntegrationTest {
         assertThat(tx.get(4).getInteger().intValue(), greaterThanOrEqualTo(1)); // system fee
         assertThat(tx.get(5).getInteger().intValue(), greaterThanOrEqualTo(1)); // network fee
         assertThat(tx.get(6).getInteger().longValue(),
-                greaterThanOrEqualTo(new Neow3jConfig().getMaxValidUntilBlockIncrement()));
+                greaterThanOrEqualTo(defaultNeow3jConfig().getMaxValidUntilBlockIncrement()));
         assertThat(tx.get(7).getHexString().length(), greaterThanOrEqualTo(1)); // script
     }
 


### PR DESCRIPTION
This would be a breaking change. It's still a draft and I'm open for suggestions and feedback.

Since `Neow3jConfig` has setters for all the variables, I think these bulky constructors with that many parameters are completely redundant and we can do better here. I've removed the constructors and added a static function that returns the default config. Then, if a user would like to configure some variable manually, they can just use the appropriate setter for it. Imo, this makes it look cleaner, it's more concise and gets rid of these ugly beasts of constructors.