### PR TITLE
Inject neow3j version to compiler at build time

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,7 +15,6 @@ at [neow3j.io](https://neow3j.io) is up-to-date.
 1. Create a branch `release` from `main`.
 2. Make sure the release version number is set in the following files:
    - `build.gradle`, in the `version` property
-   - `Compiler.java`, in the `COMPILER_NAME` constant
    - `README.md`, in the sections that explain how to import neow3j
 3. Commit and push the `release` branch, and open a pull request to `main`.
 4. Once the pull request has been merged, tag the `main` branch at the **top** commit. Tag format, e.g., `3.14.0`. 

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ ext {
 }
 
 group 'io.neow3j'
-version '3.24.1'
+version '3.24.2'
 if (project.hasProperty('snapshot')) {
     version = version + '-SNAPSHOT'
 }

--- a/compiler/build.gradle
+++ b/compiler/build.gradle
@@ -1,5 +1,29 @@
 description 'neow3j: JVM Compiler to NeoVM'
 
+// Inject the Gradle project version into the compiler at build time.
+//
+// The compiler version is written into the NEF file and must exactly reflect the version that produced it (including
+// "-SNAPSHOT" when applicable).
+//
+// This uses resource filtering on compiler.properties instead of hardcoding the version in Java to avoid manual
+// updates and to keep a single source of truth (project.version).
+//
+// IMPORTANT:
+// - The placeholder in compiler.properties MUST match the key used here.
+// - If this expansion is removed or renamed, the compiler will fail at runtime when loading its version (by design,
+//   to prevent invalid NEFs).
+// - Do NOT add a compiler.properties file under test resources, as test resources shadow main resources and will
+//   break version injection.
+tasks.named("processResources") {
+    // Inject the project version into the resource filtering inputs so Gradle re-runs this task when version changes.
+    inputs.property("compilerVersion", project.version.toString())
+
+    // Expand placeholders like ${compilerVersion} in this specific file at build time.
+    filesMatching("io/neow3j/compiler/compiler.properties") {
+        expand(compilerVersion: project.version.toString())
+    }
+}
+
 dependencies {
     api "org.ow2.asm:asm-tree:$asmVersion"
 

--- a/compiler/src/main/resources/io/neow3j/compiler/compiler.properties
+++ b/compiler/src/main/resources/io/neow3j/compiler/compiler.properties
@@ -1,0 +1,1 @@
+compiler.version=${compilerVersion}

--- a/compiler/src/test/java/io/neow3j/compiler/CompilerVersionTest.java
+++ b/compiler/src/test/java/io/neow3j/compiler/CompilerVersionTest.java
@@ -1,0 +1,16 @@
+package io.neow3j.compiler;
+
+import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.text.MatchesPattern.matchesPattern;
+
+public class CompilerVersionTest {
+
+    @Test
+    public void compilerPropertiesIsExpanded() {
+        String version = new Compiler().loadCompilerVersion();
+        assertThat(version, matchesPattern("^[0-9]+\\.[0-9]+\\.[0-9]+(-SNAPSHOT)?$"));
+    }
+
+}


### PR DESCRIPTION
Fixes #1149 

I've released a snapshot that includes this change (including the neo3.9 changes). You can test it with the examples repo using the snapshot version `3.24.1-SNAPSHOT`. Compiling a contract with this snapshot will provide a NEF that has the compiler as `neow3j-3.24.1-SNAPSHOT`.